### PR TITLE
Use the newly published gemini-cli devcontainer-feature

### DIFF
--- a/repo-agent/examples/kcc-configmap-devcontainer.yaml
+++ b/repo-agent/examples/kcc-configmap-devcontainer.yaml
@@ -10,17 +10,13 @@ data:
     	"name": "Go and Node.js Dev Container",
     	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
     	"features": {
-    		"ghcr.io/devcontainers/features/go:1": {
-    			"version": "latest"
-    		},
-    		"ghcr.io/devcontainers/features/node:1": {
-    			"version": "lts"
-    		},
-            "ghcr.io/coder/devcontainer-features/code-server:1": {
-                "port": 13337,
-                "host": "0.0.0.0"
-            },
-    	},
-    	"postCreateCommand": "npm install -g @google/gemini-cli",
-        "appPort": ["13337:13337"]
+        "ghcr.io/devcontainers/features/go:1": { "version": "latest" },
+        "ghcr.io/devcontainers/features/node:1": { "version": "lts" },
+        "ghcr.io/gke-labs/gemini-for-kubernetes-development/gemini-cli:latest": {},
+        "ghcr.io/coder/devcontainer-features/code-server:1": {
+          "port": 13337,
+          "host": "0.0.0.0"
+        },
+      },
+      "appPort": ["13337:13337"]
     }

--- a/repo-agent/examples/kro-configmap-devcontainer.yaml
+++ b/repo-agent/examples/kro-configmap-devcontainer.yaml
@@ -10,17 +10,13 @@ data:
     	"name": "Go and Node.js Dev Container",
     	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
     	"features": {
-    		"ghcr.io/devcontainers/features/go:1": {
-    			"version": "1.24"
-    		},
-    		"ghcr.io/devcontainers/features/node:1": {
-    			"version": "lts"
-    		},
+        "ghcr.io/devcontainers/features/go:1": { "version": "latest" },
+        "ghcr.io/devcontainers/features/node:1": { "version": "lts" },
+        "ghcr.io/gke-labs/gemini-for-kubernetes-development/gemini-cli:latest": {},
         "ghcr.io/coder/devcontainer-features/code-server:1": {
           "port": 13337,
           "host": "0.0.0.0"
         },
-    	},
-    	"postCreateCommand": "npm install -g @google/gemini-cli",
+      },
       "appPort": ["13337:13337"]
     }

--- a/repo-agent/k8s/configmap-devcontainer.yaml
+++ b/repo-agent/k8s/configmap-devcontainer.yaml
@@ -7,20 +7,16 @@ metadata:
 data:
   devcontainer.json: |
     {
-    	"name": "Go and Node.js Dev Container",
-    	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
-    	"features": {
-    		"ghcr.io/devcontainers/features/go:1": {
-    			"version": "latest"
-    		},
-    		"ghcr.io/devcontainers/features/node:1": {
-    			"version": "lts"
-    		},
-            "ghcr.io/coder/devcontainer-features/code-server:1": {
-                "port": 13337,
-                "host": "0.0.0.0"
-            },
-    	},
-    	"postCreateCommand": "npm install -g @google/gemini-cli",
-        "appPort": ["13337:13337"]
+      name": "Go and Node.js Dev Container",
+      "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+      "features": {
+        "ghcr.io/devcontainers/features/go:1": { "version": "latest" },
+        "ghcr.io/devcontainers/features/node:1": { "version": "lts" },
+        "ghcr.io/gke-labs/gemini-for-kubernetes-development/gemini-cli:latest": {},
+        "ghcr.io/coder/devcontainer-features/code-server:1": {
+          "port": 13337,
+          "host": "0.0.0.0"
+        },
+      },
+      "appPort": ["13337:13337"]
     }


### PR DESCRIPTION
We recently published the gemini-cli devcontainer feature in gkelabs.
Use that instead of postinstall script.

https://github.com/gke-labs/gemini-for-kubernetes-development/pkgs/container/gemini-for-kubernetes-development%2Fgemini-cli