### PR TITLE
fix: resolve issue where UI would break with white page if no entries were found for either review, triage or bugfix

### DIFF
--- a/repo-agent/review-ui/review-api/main.go
+++ b/repo-agent/review-ui/review-api/main.go
@@ -225,7 +225,7 @@ func populateMockData() {
 func getRepos(c *gin.Context) {
 	fetchAndPopulateRepos(c.Request.Context())
 
-	var repos []Repo
+	repos := []Repo{}
 	iter := rdb.Scan(c.Request.Context(), 0, "repo:*", 0).Iterator()
 	for iter.Next(c.Request.Context()) {
 		key := iter.Val()
@@ -322,7 +322,7 @@ func getPRs(c *gin.Context) {
 	repo := c.Param("repo")
 	fetchAndPopulatePRs(c.Request.Context(), repo)
 	// SCAN Redis for PRs for repo
-	var prs []PR
+	prs := []PR{}
 	repoPRKeyPrefix := fmt.Sprintf("pr:repo:%s:pr:", repo)
 	iter := rdb.Scan(c.Request.Context(), 0, repoPRKeyPrefix+"*", 0).Iterator()
 	for iter.Next(c.Request.Context()) {
@@ -695,7 +695,7 @@ func getIssues(c *gin.Context) {
 	handler := c.Param("handler")
 	fetchAndPopulateIssues(c.Request.Context(), repo, handler)
 
-	var issues []Issue
+	issues := []Issue{}
 	issueKeyPrefix := fmt.Sprintf("issue:repo:%s:handler:%s:issue:*", repo, handler)
 	iter := rdb.Scan(c.Request.Context(), 0, issueKeyPrefix, 0).Iterator()
 	for iter.Next(c.Request.Context()) {

--- a/repo-agent/review-ui/ui/src/App.js
+++ b/repo-agent/review-ui/ui/src/App.js
@@ -13,9 +13,10 @@ function App() {
     fetch('/api/repos')
       .then(res => res.json())
       .then(data => {
-        setRepos(data);
-        if (data.length > 0) {
-          const firstRepo = data[0];
+        const safeData = data || [];
+        setRepos(safeData);
+        if (safeData.length > 0) {
+          const firstRepo = safeData[0];
           setActiveRepo(firstRepo.name);
           if (firstRepo.review) {
             setActiveSubTab({ repo: firstRepo.name, name: 'review' });
@@ -34,9 +35,10 @@ function App() {
         fetch(`/api/repo/${activeRepo}/prs`)
           .then(res => res.json())
           .then(data => {
-            setPrs(data);
+            const safeData = data || [];
+            setPrs(safeData);
             const initialDrafts = {};
-            data.forEach(pr => {
+            safeData.forEach(pr => {
               initialDrafts[pr.id] = pr.draft || '';
             });
             setDrafts(initialDrafts);
@@ -47,9 +49,10 @@ function App() {
         fetch(`/api/repo/${activeRepo}/issues/${activeSubTab.name}`)
           .then(res => res.json())
           .then(data => {
-            setIssues(data);
+            const safeData = data || [];
+            setIssues(safeData);
             const initialDrafts = {};
-            data.forEach(issue => {
+            safeData.forEach(issue => {
               initialDrafts[issue.id] = issue.draft || '';
             });
             setDrafts(initialDrafts);


### PR DESCRIPTION
PR fixes issue where if GitHub hook didn't find entries for either review, triage, or bugfix - clicking that would make the UI break with a white page (vs showing 0 entires in the normal UI)

Image: 
<img width="2165" height="1225" alt="Screenshot 2025-10-29 8 00 48 PM" src="https://github.com/user-attachments/assets/159e33da-72f0-42f0-9948-1dc31effc776" />

Console logs:
(index):1 Unchecked runtime.lastError: Could not establish connection. Receiving end does not exist.
App.js:57 Failed to fetch issues for agent-sandbox handler triage: TypeError: Cannot read properties of null (reading 'forEach')
    at App.js:52:18
(anonymous) @ App.js:57
react-dom.production.min.js:188 TypeError: Cannot read properties of null (reading 'map')
    at f (App.js:216:21)
    at vo (react-dom.production.min.js:160:137)
    at _u (react-dom.production.min.js:196:258)
    at xi (react-dom.production.min.js:291:88)
    at bs (react-dom.production.min.js:279:389)
    at gs (react-dom.production.min.js:279:320)
    at vs (react-dom.production.min.js:279:180)
    at as (react-dom.production.min.js:270:88)
    at ls (react-dom.production.min.js:267:429)
    at S (scheduler.production.min.js:13:203)
fu @ react-dom.production.min.js:188
react-dom.production.min.js:282 Uncaught TypeError: Cannot read properties of null (reading 'map')
    at f (App.js:216:21)
    at vo (react-dom.production.min.js:160:137)
    at _u (react-dom.production.min.js:196:258)
    at xi (react-dom.production.min.js:291:88)
    at bs (react-dom.production.min.js:279:389)
    at gs (react-dom.production.min.js:279:320)
    at vs (react-dom.production.min.js:279:180)
    at as (react-dom.production.min.js:270:88)
    at ls (react-dom.production.min.js:267:429)
    at S (scheduler.production.min.js:13:203)
