### PR TITLE
feat(repo-agent): support for explicit list of issues in issuehandlers

### DIFF
--- a/repo-agent/k8s/crds/review.gemini.google.com_repowatches.yaml
+++ b/repo-agent/k8s/crds/review.gemini.google.com_repowatches.yaml
@@ -40,6 +40,10 @@ spec:
                         prompt:
                           type: string
                       type: object
+                    issues:
+                      items:
+                        type: integer
+                      type: array
                     labels:
                       items:
                         type: string

--- a/repo-agent/repowatch/api/v1alpha1/repowatch_types.go
+++ b/repo-agent/repowatch/api/v1alpha1/repowatch_types.go
@@ -49,6 +49,10 @@ type IssueHandlerSpec struct {
 	// +kubebuilder:validation:Optional
 	Labels []string `json:"labels"`
 
+	// Issues to filter issues for this handler
+	// +kubebuilder:validation:Optional
+	Issues []int `json:"issues"`
+
 	// Gemini configuration for the bug fix sandboxes.
 	Gemini GeminiConfig `json:"gemini,omitempty"`
 

--- a/repo-agent/repowatch/api/v1alpha1/zz_generated.deepcopy.go
+++ b/repo-agent/repowatch/api/v1alpha1/zz_generated.deepcopy.go
@@ -32,6 +32,11 @@ func (in *IssueHandlerSpec) DeepCopyInto(out *IssueHandlerSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Issues != nil {
+		in, out := &in.Issues, &out.Issues
+		*out = make([]int, len(*in))
+		copy(*out, *in)
+	}
 	out.Gemini = in.Gemini
 }
 

--- a/repo-agent/repowatch/controllers/repowatch_controller.go
+++ b/repo-agent/repowatch/controllers/repowatch_controller.go
@@ -216,6 +216,20 @@ func (r *RepoWatchReconciler) reconcileIssuesForHandler(ctx context.Context, use
 		repoIssues = append(repoIssues, issue)
 	}
 
+	// If the handler has a list of issues, filter the issues
+	if len(handler.Issues) > 0 {
+		var filteredIssues []*github.Issue
+		for _, issue := range repoIssues {
+			for _, issueNumber := range handler.Issues {
+				if *issue.Number == issueNumber {
+					filteredIssues = append(filteredIssues, issue)
+					break
+				}
+			}
+		}
+		repoIssues = filteredIssues
+	}
+
 	// Log repoIssues and sandboxList for debug purposes
 	issuesStr := []string{}
 	for _, issue := range repoIssues {


### PR DESCRIPTION
Adds a new  field to the  in the
CRD. This field allows specifying a list of issue numbers to be processed by the issue handler. If the list is not empty, only the issues in the list will be processed.

Fixes #28