### PR TITLE
feat(repo-agent): support layer caching for dev-container builds

### DIFF
--- a/repo-agent/issue-sandbox/issue-sandbox-rgd.yaml
+++ b/repo-agent/issue-sandbox/issue-sandbox-rgd.yaml
@@ -118,6 +118,11 @@ spec:
                       value: ${string(schema.spec.destination.pushEnabled)}
                     - name: ENVBUILDER_GIT_URL
                       value: ${schema.spec.source.cloneURL}
+                    # https://github.com/coder/terraform-provider-envbuilder/issues/68#issuecomment-2557247792
+                    #- name: ENVBUILDER_GET_CACHED_IMAGE
+                    #  value: "1"
+                    - name: ENVBUILDER_CACHE_REPO
+                      value: registry.repo-agent-system.svc.cluster.local:5000/envbuilder-cache
                     - name: ENVBUILDER_DEVCONTAINER_DIR
                       value: /
                     #- name: ENVBUILDER_DOCKERFILE_PATH

--- a/repo-agent/k8s/issue-sandbox-rgd.yaml
+++ b/repo-agent/k8s/issue-sandbox-rgd.yaml
@@ -118,6 +118,11 @@ spec:
                       value: ${string(schema.spec.destination.pushEnabled)}
                     - name: ENVBUILDER_GIT_URL
                       value: ${schema.spec.source.cloneURL}
+                    # https://github.com/coder/terraform-provider-envbuilder/issues/68#issuecomment-2557247792
+                    #- name: ENVBUILDER_GET_CACHED_IMAGE
+                    #  value: "1"
+                    - name: ENVBUILDER_CACHE_REPO
+                      value: registry.repo-agent-system.svc.cluster.local:5000/envbuilder-cache
                     - name: ENVBUILDER_DEVCONTAINER_DIR
                       value: /
                     #- name: ENVBUILDER_DOCKERFILE_PATH

--- a/repo-agent/k8s/registry.yaml
+++ b/repo-agent/k8s/registry.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry
+  namespace: repo-agent-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: registry
+  template:
+    metadata:
+      labels:
+        app: registry
+    spec:
+      containers:
+      - name: registry
+        image: registry:2
+        ports:
+        - containerPort: 5000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry
+  namespace: repo-agent-system
+spec:
+  selector:
+    app: registry
+  ports:
+  - protocol: TCP
+    port: 5000
+    targetPort: 5000

--- a/repo-agent/k8s/review-sandbox-rgd.yaml
+++ b/repo-agent/k8s/review-sandbox-rgd.yaml
@@ -88,6 +88,11 @@ spec:
                       value: ${schema.spec.gemini.prompt}
                     - name: ENVBUILDER_GIT_URL
                       value: ${schema.spec.source.cloneURL}
+                    # https://github.com/coder/terraform-provider-envbuilder/issues/68#issuecomment-2557247792
+                    #- name: ENVBUILDER_GET_CACHED_IMAGE
+                    #  value: "1"
+                    - name: ENVBUILDER_CACHE_REPO
+                      value: registry.repo-agent-system.svc.cluster.local:5000/envbuilder-cache
                     - name: ENVBUILDER_DEVCONTAINER_DIR
                       value: /
                     #- name: ENVBUILDER_DOCKERFILE_PATH

--- a/repo-agent/review-sandbox/review-sandbox-rgd.yaml
+++ b/repo-agent/review-sandbox/review-sandbox-rgd.yaml
@@ -88,6 +88,11 @@ spec:
                       value: ${schema.spec.gemini.prompt}
                     - name: ENVBUILDER_GIT_URL
                       value: ${schema.spec.source.cloneURL}
+                    # https://github.com/coder/terraform-provider-envbuilder/issues/68#issuecomment-2557247792
+                    #- name: ENVBUILDER_GET_CACHED_IMAGE
+                    #  value: "1"
+                    - name: ENVBUILDER_CACHE_REPO
+                      value: registry.repo-agent-system.svc.cluster.local:5000/envbuilder-cache
                     - name: ENVBUILDER_DEVCONTAINER_DIR
                       value: /
                     #- name: ENVBUILDER_DOCKERFILE_PATH


### PR DESCRIPTION
This change introduces layer caching for dev-container builds to reduce agent latency. It adds a container registry to the cluster and configures the issue and review sandboxes to use it for caching.

- Adds a container registry deployment and service.
- Updates the issue and review sandbox definitions to use the environment variable.

Fixes #38


**Before caching**
2m59.420172141s

```
...
latest" _CONTAINER_USER="root" _REMOTE_USER="root" ./install.sh
#2: Cmd: /bin/sh
#2: Args: [-c VERSION="latest" _CONTAINER_USER="root" _REMOTE_USER="root" ./install.sh]
#2: Util.Lookup returned: &{Uid:0 Gid:0 Username:root Name:root HomeDir:/root}
#2: Performing slow lookup of group ids for root
#2: Running: [/bin/sh -c VERSION="latest" _CONTAINER_USER="root" _REMOTE_USER="root" ./install.sh]

added 584 packages in 24s

148 packages are looking for funding
  run `npm fund` for details
#2: Taking snapshot of files...
#2: Pushing layer registry.repo-agent-system.svc.cluster.local:ac3aaa23b23c9f1d59d10e519b9aa03a64f2b64280f75a7415504234db6619f1 to cache now
#2: Pushing image to registry.repo-agent-system.svc.cluster.local:ac3aaa23b23c9f1d59d10e519b9aa03a64f2b64280f75a7415504234db6619f1
#2: USER root
#2: Cmd: USER
#2: No files changed in this command, skipping snapshotting.
#2: Error uploading layer to cache: failed to push to destination registry.repo-agent-system.svc.cluster.local:f4553ff460f7c52880f731205efc40e923e249aec696d6a1c0e575fba605faab: HEAD https://index.docker.io/v2/library/registry.repo-agent-system.svc.cluster.local/manifests/f4553ff460f7c52880f731205efc40e923e249aec696d6a1c0e575fba605faab: unexpected status code 401 Unauthorized (HEAD responses have no body, use GET for details)
#2: 🏗️ Built image! [2m59.420172141s]
#2: 👀 Found devcontainer.json label metadata in image...
....

```

**After caching**
48.04386774s

```
...
#2: Checking for cached layer registry.repo-agent-system.svc.cluster.local:5000/envbuilder-cache:f4553ff460f7c52880f731205efc40e923e249aec696d6a1c0e575fba605faab...
#2: Using caching version of cmd: RUN ABSPROXYBASEPATH="" APPGROUP="Web Editors" APPNAME="" APPOPENIN="slim-window" APPSHARE="owner" AUTH="password" CERT="" CERTHOST="" CERTKEY="" DISABLEFILEDOWNLOADS="false" DISABLEFILEUPLOADS="false" DISABLEGETTINGSTARTEDOVERRIDE="false" DISABLEPROXY="false" DISABLETELEMETRY="false" DISABLEUPDATECHECK="false" DISABLEWORKSPACETRUST="false" ENABLEPROPOSEDAPI="" EXTENSIONS="" GITHUBAUTHTOKENFILE="" HASHEDPASSWORDFILE="" HOST="0.0.0.0" LOCALE="" LOGFILE="/tmp/code-server.log" PASSWORDFILE="" PORT="13337" PROXYDOMAIN="" SOCKET="" SOCKETMODE="" TRUSTEDORIGINS="" VERBOSE="false" VERSION="" WELCOMETEXT="" WORKSPACE="" _CONTAINER_USER="root" _REMOTE_USER="root" ./install.sh
#2: Checking for cached layer registry.repo-agent-system.svc.cluster.local:5000/envbuilder-cache:7c702bc5daf170f64f3096b3cd102564f2e95bbb56b306463b0efc2069582f34...
#2: Using caching version of cmd: RUN GOLANGCILINTVERSION="latest" VERSION="latest" _CONTAINER_USER="root" _REMOTE_USER="root" ./install.sh
#2: Checking for cached layer registry.repo-agent-system.svc.cluster.local:5000/envbuilder-cache:4a0e92f907a75dae23e6731589c4286b47c4ba58d8187ba5b3d915d6d7ffdd07...
#2: Using caching version of cmd: RUN INSTALLYARNUSINGAPT="true" NODEGYPDEPENDENCIES="true" NVMINSTALLPATH="/usr/local/share/nvm" NVMVERSION="latest" PNPMVERSION="latest" VERSION="lts" _CONTAINER_USER="root" _REMOTE_USER="root" ./install.sh
#2: Checking for cached layer registry.repo-agent-system.svc.cluster.local:5000/envbuilder-cache:ac3aaa23b23c9f1d59d10e519b9aa03a64f2b64280f75a7415504234db6619f1...
#2: Using caching version of cmd: RUN VERSION="latest" _CONTAINER_USER="root" _REMOTE_USER="root" ./install.sh
...
#2: Extraction complete
#2: USER root
#2: Cmd: USER
#2: No files changed in this command, skipping snapshotting.
#2: WORKDIR /.envbuilder/features/code-server-10bf317d
#2: Cmd: workdir
#2: Changed working directory to /.envbuilder/features/code-server-10bf317d
#2: No files changed in this command, skipping snapshotting.
#2: RUN ABSPROXYBASEPATH="" APPGROUP="Web Editors" APPNAME="" APPOPENIN="slim-window" APPSHARE="owner" AUTH="password" CERT="" CERTHOST="" CERTKEY="" DISABLEFILEDOWNLOADS="false" DISABLEFILEUPLOADS="false" DISABLEGETTINGSTARTEDOVERRIDE="false" DISABLEPROXY="false" DISABLETELEMETRY="false" DISABLEUPDATECHECK="false" DISABLEWORKSPACETRUST="false" ENABLEPROPOSEDAPI="" EXTENSIONS="" GITHUBAUTHTOKENFILE="" HASHEDPASSWORDFILE="" HOST="0.0.0.0" LOCALE="" LOGFILE="/tmp/code-server.log" PASSWORDFILE="" PORT="13337" PROXYDOMAIN="" SOCKET="" SOCKETMODE="" TRUSTEDORIGINS="" VERBOSE="false" VERSION="" WELCOMETEXT="" WORKSPACE="" _CONTAINER_USER="root" _REMOTE_USER="root" ./install.sh
#2: Found cached layer, extracting to filesystem
#2: WORKDIR /.envbuilder/features/go-10774d69
#2: Cmd: workdir
#2: Changed working directory to /.envbuilder/features/go-10774d69
#2: No files changed in this command, skipping snapshotting.
#2: ENV GOPATH=/go
....
#2: Cmd: USER
#2: No files changed in this command, skipping snapshotting.
#2: 🏗️ Built image! [48.04386774s]
#2: 👀 Found devcontainer.json label metadata in image...
....
```