### PR TITLE
fix: resolve 404 issues accessing devcontainer by updating ui-httproute.yaml to allow for accepting connections from any namespace

### DIFF
--- a/repo-agent/issue-sandbox/issue-sandbox-rgd.yaml
+++ b/repo-agent/issue-sandbox/issue-sandbox-rgd.yaml
@@ -211,6 +211,7 @@ spec:
         spec:
           parentRefs:
             - name: ${schema.spec.gateway.ref} # Reference to the Gateway created outside of this RGD
+              namespace: repo-agent-system
           rules:
             - backendRefs:
                 - name: ${service.metadata.name}

--- a/repo-agent/k8s/issue-sandbox-rgd.yaml
+++ b/repo-agent/k8s/issue-sandbox-rgd.yaml
@@ -211,6 +211,7 @@ spec:
         spec:
           parentRefs:
             - name: ${schema.spec.gateway.ref} # Reference to the Gateway created outside of this RGD
+              namespace: repo-agent-system
           rules:
             - backendRefs:
                 - name: ${service.metadata.name}

--- a/repo-agent/k8s/review-sandbox-rgd.yaml
+++ b/repo-agent/k8s/review-sandbox-rgd.yaml
@@ -187,6 +187,7 @@ spec:
         spec:
           parentRefs:
             - name: ${schema.spec.gateway.ref} # Reference to the Gateway created outside of this RGD
+              namespace: repo-agent-system
           rules:
             - backendRefs:
                 - name: ${service.metadata.name}

--- a/repo-agent/k8s/ui-httproute.yaml
+++ b/repo-agent/k8s/ui-httproute.yaml
@@ -17,6 +17,9 @@ spec:
     - name: http
       protocol: HTTP
       port: 13380
+      allowedRoutes:
+        namespaces:
+          from: All
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/repo-agent/review-sandbox/review-sandbox-rgd.yaml
+++ b/repo-agent/review-sandbox/review-sandbox-rgd.yaml
@@ -187,6 +187,7 @@ spec:
         spec:
           parentRefs:
             - name: ${schema.spec.gateway.ref} # Reference to the Gateway created outside of this RGD
+              namespace: repo-agent-system
           rules:
             - backendRefs:
                 - name: ${service.metadata.name}


### PR DESCRIPTION
PR fixes 404 issues accessing devcontainer by updating ui-httproute.yaml to allow for accepting connections from any namespace

Before:
<404 white page>

After:
<img width="2167" height="1212" alt="image" src="https://github.com/user-attachments/assets/ba0915e9-9e76-4672-8c5f-409536005080" />
^ means the 404 is gone and the pod is still booting up.  Will update with actual  VS Code in ~10 mins