### PR TITLE
Added missing diff url from test resource

### DIFF
--- a/repo-agent/repowatch/controllers/repowatch_controller_test.go
+++ b/repo-agent/repowatch/controllers/repowatch_controller_test.go
@@ -77,7 +77,7 @@ func TestRepoWatchReconciler_Reconcile(t *testing.T) {
 			responses: map[string]*http.Response{
 				"https://api.github.com/repos/test/repo/pulls?state=open": {
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`[{"number": 1, "head": {"repo": {"clone_url": "https://github.com/test/repo", "html_url": "https://github.com/test/repo"}, "ref": "main"}, "html_url": "https://github.com/test/repo/pull/1", "title": "Test PR"}]`)),
+					Body:       ioutil.NopCloser(strings.NewReader(`[{"number": 1, "head": {"repo": {"clone_url": "https://github.com/test/repo", "html_url": "https://github.com/test/repo"}, "ref": "main"}, "html_url": "https://github.com/test/repo/pull/1", "title": "Test PR", "diff_url": "https://github.com/test/repo/pull/1.diff"}]`)),
 				},
 				"https://api.github.com/user": {
 					StatusCode: http.StatusOK,
@@ -329,6 +329,7 @@ func TestReconcileReviewSandboxes(t *testing.T) {
 		},
 		HTMLURL: github.String("https://github.com/test/repo/pull/1"),
 		Title:   github.String("Test PR"),
+		DiffURL: github.String("https://github.com/test/repo/pull/1.diff"),
 	}
 
 	// Sandbox for a PR that is now closed


### PR DESCRIPTION
* Adds missing `diffURL` and `DiffURL` fields in test resources to fix unit tests.

```
$ go test -cover -v ./repowatch/controllers/...
=== RUN   TestRepoWatchReconciler_Reconcile
--- PASS: TestRepoWatchReconciler_Reconcile (0.08s)
=== RUN   TestRepoWatchReconciler_ReconcileIssues
--- PASS: TestRepoWatchReconciler_ReconcileIssues (0.02s)
=== RUN   TestReconcileReviewSandboxes
=== RUN   TestReconcileReviewSandboxes/deletes_sandbox_for_closed_PR_and_creates_new_for_open_PR
=== RUN   TestReconcileReviewSandboxes/does_not_create_new_sandbox_if_max_active_sandboxes_reached
=== RUN   TestReconcileReviewSandboxes/does_not_create_new_sandbox_if_it_already_exists
--- PASS: TestReconcileReviewSandboxes (0.01s)
    --- PASS: TestReconcileReviewSandboxes/deletes_sandbox_for_closed_PR_and_creates_new_for_open_PR (0.00s)
    --- PASS: TestReconcileReviewSandboxes/does_not_create_new_sandbox_if_max_active_sandboxes_reached (0.00s)
    --- PASS: TestReconcileReviewSandboxes/does_not_create_new_sandbox_if_it_already_exists (0.00s)
=== RUN   TestReconcileIssueHandlerSandboxes
=== RUN   TestReconcileIssueHandlerSandboxes/deletes_sandbox_for_closed_issue_and_creates_new_for_open_issue
=== RUN   TestReconcileIssueHandlerSandboxes/does_not_create_new_sandbox_if_max_active_sandboxes_reached
=== RUN   TestReconcileIssueHandlerSandboxes/does_not_create_new_sandbox_if_it_already_exists
--- PASS: TestReconcileIssueHandlerSandboxes (0.02s)
    --- PASS: TestReconcileIssueHandlerSandboxes/deletes_sandbox_for_closed_issue_and_creates_new_for_open_issue (0.01s)
    --- PASS: TestReconcileIssueHandlerSandboxes/does_not_create_new_sandbox_if_max_active_sandboxes_reached (0.00s)
    --- PASS: TestReconcileIssueHandlerSandboxes/does_not_create_new_sandbox_if_it_already_exists (0.00s)
=== RUN   TestRepoWatchReconciler_Reconcile_NotFound
--- PASS: TestRepoWatchReconciler_Reconcile_NotFound (0.00s)
=== RUN   TestRepoWatchReconciler_Reconcile_GitHubSecretNotFound
--- PASS: TestRepoWatchReconciler_Reconcile_GitHubSecretNotFound (0.01s)
=== RUN   TestRepoWatchReconciler_Reconcile_InvalidRepoURL
--- PASS: TestRepoWatchReconciler_Reconcile_InvalidRepoURL (0.01s)
=== RUN   TestNewGithubClient
=== RUN   TestNewGithubClient/valid_secret
=== RUN   TestNewGithubClient/secret_not_found
=== RUN   TestNewGithubClient/pat_not_found_in_secret
=== RUN   TestNewGithubClient/name_and_email_are_optional
--- PASS: TestNewGithubClient (0.01s)
    --- PASS: TestNewGithubClient/valid_secret (0.00s)
    --- PASS: TestNewGithubClient/secret_not_found (0.00s)
    --- PASS: TestNewGithubClient/pat_not_found_in_secret (0.00s)
    --- PASS: TestNewGithubClient/name_and_email_are_optional (0.00s)
PASS
coverage: 75.5% of statements
ok  	github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/repowatch/controllers	0.214s	coverage: 75.5% of statements
```