### PR TITLE
fix: remove trailing comma from githubSecretName types

### DIFF
--- a/repo-agent/repowatch/api/v1alpha1/repowatch_types.go
+++ b/repo-agent/repowatch/api/v1alpha1/repowatch_types.go
@@ -112,7 +112,7 @@ type RepoWatchSpec struct {
 
 	// Secret containing the GitHub Personal Access Token (PAT) for accessing the repo.
 	// +kubebuilder:validation:Required
-	GithubSecretName string `json:"githubSecretName,"`
+	GithubSecretName string `json:"githubSecretName"`
 
 	// How often to check for new PRs (in seconds).
 	// +kubebuilder:validation:Minimum=30


### PR DESCRIPTION
PR removes trailing comma from githubSecretName types