### PR TITLE
feat: add export curl command button for PR reviews

### DIFF
--- a/repo-agent/review-ui/ui/src/PrReviewCard.js
+++ b/repo-agent/review-ui/ui/src/PrReviewCard.js
@@ -18,6 +18,7 @@ function PrReviewCard({
   handleYamlDraftChange,
   handleYamlDraftBlur,
   handleSubmit,
+  handleExportCurl,
   toggleCollapse,
   getSandboxStatusClass,
 }) {
@@ -25,6 +26,7 @@ function PrReviewCard({
   const [diffError, setDiffError] = useState(null);
   const [fileCollapsed, setFileCollapsed] = useState({});
   const [reviewFlairText, setReviewFlairText] = useState('');
+  const [curlCommand, setCurlCommand] = useState(null);
 
   const getReviewFlairColor = (flairText) => {
     switch (flairText) {
@@ -343,8 +345,27 @@ function PrReviewCard({
             <button className="btn btn-submit" onClick={() => handleSubmit(pr.id)} disabled={!!pr.review}>
               {pr.review ? 'Draft Created' : 'Create Draft Review'}
             </button>
+            <button className="btn btn-submit" style={{marginLeft: '10px', backgroundColor: '#6c757d'}} onClick={() => handleExportCurl(pr.id, setCurlCommand)} disabled={!!pr.review}>
+              Export Curl Command
+            </button>
           <button className="btn btn-delete" onClick={(e) => { e.stopPropagation(); handleDelete(pr.id); }}>&#x2715;</button>
           </div>
+          {curlCommand && (
+            <div className="curl-command-display" style={{marginTop: '10px'}}>
+              <h4>Curl Command</h4>
+              <textarea
+                className="review-textarea"
+                style={{height: '150px', fontFamily: 'monospace', width: '100%'}}
+                value={curlCommand}
+                readOnly
+              />
+              <button className="btn" style={{marginTop: '5px'}} onClick={() => {
+                navigator.clipboard.writeText(curlCommand);
+                alert("Copied to clipboard!");
+              }}>Copy to Clipboard</button>
+              <button className="btn" style={{marginTop: '5px', marginLeft: '10px'}} onClick={() => setCurlCommand(null)}>Close</button>
+            </div>
+          )}
         </>
       )}
     </div>


### PR DESCRIPTION
fixes #113 

This PR adds an "Export Curl Command" button to allow for a usage pattern where users give read-only tokens but can then copy the full curl command that repo-agent would essentially run and run it locally with their own write access PAT.  That way they don't have to trust our MT setup, etc for trust.  Goal is to make security conscious users able to get most functionality possible as well as de-risk potential issue where users don't want to use repo-agent as it requires write-access PAT

Gist showing the exported command working:
https://gist.github.com/aaron-prindle/14d41d56d342bb35600acfc734c04198

<img width="2127" height="1129" alt="Screenshot 2025-11-12 4 03 16 PM" src="https://github.com/user-attachments/assets/bf244d71-472a-44ad-99b0-89c8dda9eabf" />

<img width="1989" height="692" alt="image" src="https://github.com/user-attachments/assets/4d10c8d6-60bd-4b4a-8de0-5ebd2f5c146b" />


