### PR TITLE
Make the review comments movable

### DIFF
--- a/repo-agent/review-ui/ui/src/App.js
+++ b/repo-agent/review-ui/ui/src/App.js
@@ -232,6 +232,12 @@ function App() {
         newDraft.review = { ...newDraft.review, body: value };
       } else if (field === 'comment.body' && index !== null) {
         newDraft.review.comments[index] = { ...newDraft.review.comments[index], body: value };
+      } else if (field === 'comment.path' && index !== null) {
+        newDraft.review.comments[index] = { ...newDraft.review.comments[index], path: value };
+      } else if (field === 'comment.line' && index !== null) {
+        newDraft.review.comments[index] = { ...newDraft.review.comments[index], line: value };
+      } else if (field === 'comment.side' && index !== null) {
+        newDraft.review.comments[index] = { ...newDraft.review.comments[index], side: value };
       }
       return { ...prevDrafts, [id]: newDraft };
     });
@@ -431,6 +437,29 @@ function App() {
       .catch(err => console.error("Failed to delete issue:", err));
   };
 
+  const handleMoveCommentAndSave = (id, index, newPath, newLine, newSide) => {
+    setDrafts(prevDrafts => {
+      const newDrafts = JSON.parse(JSON.stringify(prevDrafts));
+      const draftToUpdate = newDrafts[id];
+      if (draftToUpdate && draftToUpdate.review && draftToUpdate.review.comments && draftToUpdate.review.comments[index]) {
+        const commentToUpdate = draftToUpdate.review.comments[index];
+        commentToUpdate.path = newPath;
+        commentToUpdate.line = newLine;
+        commentToUpdate.side = newSide;
+
+        const draftYaml = yaml.dump(draftToUpdate);
+        fetch(`/api/repo/${activeRepo.namespace}/${activeRepo.name}/prs/${id}/draft`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ draft: draftYaml })
+        }).catch(err => console.error("Failed to save draft:", err));
+      } else {
+        console.error("Could not find comment to update in handleMoveCommentAndSave");
+      }
+      return newDrafts;
+    });
+  };
+
   const getSandboxStatusClass = (item) => {
     if (!item.sandbox) {
       return 'grey';
@@ -477,6 +506,7 @@ function App() {
           getSandboxStatusClass={getSandboxStatusClass}
           toggleCollapse={toggleCollapse}
           namespace={namespace}
+          handleMoveCommentAndSave={handleMoveCommentAndSave}
         />
       ));
     } else {

--- a/repo-agent/review-ui/ui/src/PrReviewCard.js
+++ b/repo-agent/review-ui/ui/src/PrReviewCard.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import yaml from 'js-yaml';
 import { parseDiff, Diff, getChangeKey } from 'react-diff-view';
 import 'react-diff-view/style/index.css';
@@ -22,12 +22,14 @@ function PrReviewCard({
   toggleCollapse,
   getSandboxStatusClass,
   namespace,
+  handleMoveCommentAndSave,
 }) {
   const [diff, setDiff] = useState(null);
   const [diffError, setDiffError] = useState(null);
   const [fileCollapsed, setFileCollapsed] = useState({});
   const [reviewFlairText, setReviewFlairText] = useState('');
   const [curlCommand, setCurlCommand] = useState(null);
+  const lastDragTargetRef = useRef(null);
 
   const getReviewFlairColor = (flairText) => {
     switch (flairText) {
@@ -162,7 +164,16 @@ function PrReviewCard({
             widgets[changeKey] = (
               <div className="diff-widget">
                 {keyComments.map(comment => (
-                  <div key={comment.index}>
+                  <div
+                    key={comment.index}
+                    draggable={!pr.review}
+                    onDragStart={e => {
+                      if (pr.review) return;
+                      e.dataTransfer.setData('application/json', JSON.stringify({ prId: pr.id, commentIndex: comment.index }));
+                      e.stopPropagation();
+                    }}
+                    style={{ cursor: pr.review ? 'default' : 'move' }}
+                  >
                     {pr.review ? (
                       <pre className="review-pre">{comment.body}</pre>
                     ) : (
@@ -193,6 +204,94 @@ function PrReviewCard({
             }));
           };
 
+          const handleDragOverFile = e => {
+            e.preventDefault();
+            let target = e.target;
+            while (target && !target.classList.contains('diff-line')) {
+              target = target.parentElement;
+            }
+
+            if (lastDragTargetRef.current !== target) {
+              if (lastDragTargetRef.current) {
+                lastDragTargetRef.current.style.backgroundColor = '';
+              }
+              if (target) {
+                target.style.backgroundColor = 'rgba(0, 100, 255, 0.1)';
+              }
+              lastDragTargetRef.current = target;
+            }
+          };
+
+          const handleDragLeaveFile = e => {
+            if (lastDragTargetRef.current && !e.currentTarget.contains(e.relatedTarget)) {
+              lastDragTargetRef.current.style.backgroundColor = '';
+              lastDragTargetRef.current = null;
+            }
+          };
+
+          const handleDrop = (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            console.log('Drop event triggered');
+
+            if (lastDragTargetRef.current) {
+              lastDragTargetRef.current.style.backgroundColor = '';
+              lastDragTargetRef.current = null;
+            }
+
+            const commentDataText = e.dataTransfer.getData('application/json');
+            if (!commentDataText) {
+                console.error('No comment data in dataTransfer.');
+                return;
+            }
+            console.log('Comment data text:', commentDataText);
+            const commentData = JSON.parse(commentDataText);
+            const { prId, commentIndex } = commentData;
+            console.log('Parsed comment data:', { prId, commentIndex });
+
+
+            let target = e.target;
+            while (target && !target.classList.contains('diff-line')) {
+                target = target.parentElement;
+            }
+
+            if (!target) {
+                console.error('Could not find diff-line target.');
+                return;
+            }
+            console.log('Drop target:', target);
+
+            const gutters = target.querySelectorAll('.diff-gutter');
+            const oldLineGutter = gutters[0];
+            const newLineGutter = gutters[1];
+
+            const rect = target.getBoundingClientRect();
+            const isRightSide = e.clientX > rect.left + rect.width / 2;
+            const side = isRightSide ? 'RIGHT' : 'LEFT';
+            console.log('Calculated side:', side);
+
+            let line;
+            if (side === 'RIGHT') {
+                const newLineNumber = parseInt(newLineGutter?.textContent, 10);
+                if (!isNaN(newLineNumber)) {
+                    line = newLineNumber;
+                }
+            } else { // LEFT
+                const oldLineNumber = parseInt(oldLineGutter?.textContent, 10);
+                if (!isNaN(oldLineNumber)) {
+                    line = oldLineNumber;
+                }
+            }
+            console.log('Calculated line:', line);
+
+            if (line && side) {
+                console.log('Calling handleMoveCommentAndSave with:', { prId, commentIndex, path, line, side });
+                handleMoveCommentAndSave(prId, commentIndex, path, line, side);
+            } else {
+                console.error('Could not determine line and/or side for drop.');
+            }
+          };
+
           return (
             <div key={fileId} className="diff-file">
               <div className="diff-file-header" onClick={toggleFileCollapse} style={{ cursor: 'pointer', display: 'flex', alignItems: 'center' }}>
@@ -207,12 +306,21 @@ function PrReviewCard({
                 </span>
               </div>
               {!isFileCollapsed && (
-                <>
+                <div onDragOver={handleDragOverFile} onDrop={handleDrop} onDragLeave={handleDragLeaveFile}>
                   {unplacedComments.length > 0 && (
                     <div className="diff-widget" style={{padding: '10px', borderBottom: '1px solid #ddd'}}>
                       <h6>Comments on lines not shown in diff or file-level comments</h6>
                       {unplacedComments.map(comment => (
-                        <div key={comment.index} style={{ borderTop: '1px solid #eee', paddingTop: '5px', marginTop: '5px' }}>
+                        <div
+                          key={comment.index}
+                          style={{ borderTop: '1px solid #eee', paddingTop: '5px', marginTop: '5px', cursor: pr.review ? 'default' : 'move' }}
+                          draggable={!pr.review}
+                          onDragStart={e => {
+                              if (pr.review) return;
+                              e.dataTransfer.setData('application/json', JSON.stringify({ prId: pr.id, commentIndex: comment.index }));
+                              e.stopPropagation();
+                          }}
+                        >
                           {pr.review ? (
                             <>
                               {comment.line && <p style={{fontSize: 'small', color: '#555', marginBottom: '5px'}}>Line: {comment.line} ({comment.side || 'RIGHT'})</p>}
@@ -236,7 +344,7 @@ function PrReviewCard({
                     </div>
                   )}
                   <Diff viewType="split" diffType={type} hunks={hunks} widgets={widgets} />
-                </>
+                </div>
               )}
             </div>
           );


### PR DESCRIPTION
Currently gemini-cli generates comments by a offset. We are looking to fix it #85 .
However we think even under best case scenarios we may want to reanchor comments to diff line. 

This allows that. 

[move-comments.webm](https://github.com/user-attachments/assets/89c92062-9c51-438c-a688-895196e26663)
