### PR TITLE
Filter out stderr from agent output.

### DIFF
--- a/repo-agent/pkg/llm/exec.go
+++ b/repo-agent/pkg/llm/exec.go
@@ -14,7 +14,11 @@
 
 package llm
 
-import "os/exec"
+import (
+	"bytes"
+	"os"
+	"os/exec"
+)
 
 type CommandExecutor interface {
 	Run(command string, args ...string) ([]byte, error)
@@ -26,5 +30,14 @@ type RealCommandExecutor struct{}
 
 func (e *RealCommandExecutor) Run(command string, args ...string) ([]byte, error) {
 	cmd := exec.Command(command, args...)
-	return cmd.CombinedOutput()
+	// Dont return combined output. Return only stdout and log stderr separately.
+	// Create a buffer to capture stdout
+	var stdout bytes.Buffer
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = &stdout
+	err := cmd.Run()
+	if err != nil {
+		return nil, err
+	}
+	return stdout.Bytes(), nil
 }


### PR DESCRIPTION
Most recent gemini throws a warning line in stderr when running in yolo mode