### PR TITLE
fix: resolve issue where sandbox pods would not come up for github login users w/ missing configmap-devcontainer.yaml

### DIFF
--- a/repo-agent/k8s/configmap-devcontainer.yaml
+++ b/repo-agent/k8s/configmap-devcontainer.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: devcontainer-json
+  namespace: repo-agent-system
 data:
   devcontainer.json: |
     {


### PR DESCRIPTION
Fixes issue where devc-* pods were stuck initializing as configmap wasn't properly created in GitHub namespaces (worked for default).  The issue was related to accidentally removing the `namespace: repo-agent-system` from the repo-agent/k8s/configmap-devcontainer.yaml.  This meant the copy failed.  Default was not affected as removing the namespace applied it to the default ns.  This change fixes the sandboxes in all places now

Before:
```go
aprindle@aprindle-ssd-v2 ~/gemini-gemini-for-kubernetes-development/repo-agent  [fix-mt-issues]kubectl describe po -n aaron-prindle devc-gemini-for-kubernetes-development-pr-129]

Events:
  Type     Reason       Age                   From               Message
  ----     ------       ----                  ----               -------
  Normal   Scheduled    5m45s                 default-scheduler  Successfully assigned aaron-prindle/devc-gemini-for-kubernetes-development-pr-129 to repo-agent-control-plane
  Warning  FailedMount  95s (x10 over 5m45s)  kubelet            MountVolume.SetUp failed for volume "devcontainer-config" : configmap "devcontainer-json" not found
===

Can you help root cause and fix this bug in the code?  First output a plan and then output the list of files that need to be touched and a summary of what changes need to be made. Then we can implement those changes in a followup
```

After:
```
aprindle@aprindle-ssd-v2 ~ kubectl get po --all-namespaces
NAMESPACE              NAME                                                              READY   STATUS    RESTARTS        AGE
aaron-prindle          devc-kube-api-linter-issue-192-triage                             2/2     Running   0               20s
aaron-prindle          devc-kube-api-linter-pr-193                                       2/2     Running   0               21s
agent-sandbox-system   agent-sandbox-controller-0                                        1/1     Running   0               3m42s
default                devc-gemini-for-kubernetes-development-issue-128-triage           2/2     Running   0               2m32s
default                devc-gemini-for-kubernetes-development-pr-129                     2/2     Running   0               2m32s

```