### PR TITLE
fix: resolve issue where sandboxes were not per-tenant and the links collided, should be namespaced in url

### DIFF
--- a/repo-agent/issue-sandbox/issue-sandbox-rgd.yaml
+++ b/repo-agent/issue-sandbox/issue-sandbox-rgd.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: kro.run/v1alpha1
 kind: ResourceGraphDefinition
 metadata:
@@ -224,7 +223,7 @@ spec:
               matches:
                 - path:
                     type: PathPrefix
-                    value: /sandbox/${schema.metadata.name} # Route path based on the name provided by user
+                    value: /sandbox/${schema.metadata.namespace}/${schema.metadata.name} # Route path based on the name provided by user
               filters:
                 - type: URLRewrite
                   urlRewrite:

--- a/repo-agent/k8s/issue-sandbox-rgd.yaml
+++ b/repo-agent/k8s/issue-sandbox-rgd.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: kro.run/v1alpha1
 kind: ResourceGraphDefinition
 metadata:
@@ -224,7 +223,7 @@ spec:
               matches:
                 - path:
                     type: PathPrefix
-                    value: /sandbox/${schema.metadata.name} # Route path based on the name provided by user
+                    value: /sandbox/${schema.metadata.namespace}/${schema.metadata.name} # Route path based on the name provided by user
               filters:
                 - type: URLRewrite
                   urlRewrite:

--- a/repo-agent/k8s/review-sandbox-rgd.yaml
+++ b/repo-agent/k8s/review-sandbox-rgd.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: kro.run/v1alpha1
 kind: ResourceGraphDefinition
 metadata:
@@ -209,7 +208,7 @@ spec:
               matches:
                 - path:
                     type: PathPrefix
-                    value: /sandbox/${schema.metadata.name} # Route path based on the name provided by user
+                    value: /sandbox/${schema.metadata.namespace}/${schema.metadata.name} # Route path based on the name provided by user
               filters:
                 - type: URLRewrite
                   urlRewrite:

--- a/repo-agent/review-sandbox/review-sandbox-rgd.yaml
+++ b/repo-agent/review-sandbox/review-sandbox-rgd.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: kro.run/v1alpha1
 kind: ResourceGraphDefinition
 metadata:
@@ -209,7 +208,7 @@ spec:
               matches:
                 - path:
                     type: PathPrefix
-                    value: /sandbox/${schema.metadata.name} # Route path based on the name provided by user
+                    value: /sandbox/${schema.metadata.namespace}/${schema.metadata.name} # Route path based on the name provided by user
               filters:
                 - type: URLRewrite
                   urlRewrite:

--- a/repo-agent/review-ui/ui/src/App.js
+++ b/repo-agent/review-ui/ui/src/App.js
@@ -454,6 +454,7 @@ function App() {
 
   const renderContent = () => {
     if (!activeRepo) return <p>Please select or add a repository to watch.</p>;
+    const namespace = user || 'default';
     if (activeSubTab.name === 'review') {
       if (prs.length === 0) return <p>No active Pull Requests found for this repository.</p>;
       return prs.map(pr => (
@@ -475,6 +476,7 @@ function App() {
           handleExportCurl={handleExportCurl}
           getSandboxStatusClass={getSandboxStatusClass}
           toggleCollapse={toggleCollapse}
+          namespace={namespace}
         />
       ));
     } else {
@@ -490,6 +492,7 @@ function App() {
           handleIssueSubmit={handleIssueSubmit}
           handleIssueDelete={handleIssueDelete}
           getSandboxStatusClass={getSandboxStatusClass}
+          namespace={namespace}
         />
       ));
     }

--- a/repo-agent/review-ui/ui/src/IssueCard.js
+++ b/repo-agent/review-ui/ui/src/IssueCard.js
@@ -9,6 +9,7 @@ function IssueCard({
   handleIssueSubmit,
   handleIssueDelete,
   getSandboxStatusClass,
+  namespace,
 }) {
   const [isCollapsed, setIsCollapsed] = useState(true);
   const [reviewFlairText, setReviewFlairText] = useState('');
@@ -56,7 +57,7 @@ function IssueCard({
             </span>
           )}
           {getSandboxStatusClass(issue) === 'green' ? (
-            <a href={`/sandbox/${issue.sandbox}/`} target="_blank" rel="noopener noreferrer" className={`pr-sandbox ${getSandboxStatusClass(issue)}`}>
+            <a href={`/sandbox/${namespace}/${issue.sandbox}/`} target="_blank" rel="noopener noreferrer" className={`pr-sandbox ${getSandboxStatusClass(issue)}`}>
               Sandbox &#9654;
             </a>
           ) : getSandboxStatusClass(issue) === 'yellow' ? (

--- a/repo-agent/review-ui/ui/src/PrReviewCard.js
+++ b/repo-agent/review-ui/ui/src/PrReviewCard.js
@@ -21,6 +21,7 @@ function PrReviewCard({
   handleExportCurl,
   toggleCollapse,
   getSandboxStatusClass,
+  namespace,
 }) {
   const [diff, setDiff] = useState(null);
   const [diffError, setDiffError] = useState(null);
@@ -260,7 +261,7 @@ function PrReviewCard({
             </span>
           )}
           {getSandboxStatusClass(pr) === 'green' ? (
-            <a href={`/sandbox/${pr.sandbox}/`} target="_blank" rel="noopener noreferrer" className={`pr-sandbox ${getSandboxStatusClass(pr)}`}>
+            <a href={`/sandbox/${namespace}/${pr.sandbox}/`} target="_blank" rel="noopener noreferrer" className={`pr-sandbox ${getSandboxStatusClass(pr)}`}>
               Sandbox &#9654;
             </a>
           ) : getSandboxStatusClass(pr) === 'yellow' ? (


### PR DESCRIPTION
Currently there is a bug where MT sandboxes currently collide on namespacing, to prevent this sandboxes should be namespaced.  This PR adds back the sandbox namespacing.  Currently the  multi-tenant isolation boundaries are:

User A cannot see, delete, or modify the RepoWatch or ReviewSandbox Custom Resources (CRs) of User B via the Dashboard.

This means that sandboxes are accessible across namespaces so this is friendly MT.  I have a WIP PR to make the sandboxes isolated via the gorilla sessions information.  This PR fixes a currently issue though where essentially User A will access User B's sandbox unintentionally with the current routing