### PR TITLE
Gracefully handle missing git configuration

### DIFF
--- a/repo-agent/installer.sh
+++ b/repo-agent/installer.sh
@@ -9,12 +9,12 @@ echo "Checking params"
 : ${NAMESPACE:=default}
 
 echo "Getting git config..."
-GIT_USER_NAME=$(git config --global user.name)
+GIT_USER_NAME=$(git config --global user.name || true)
 if [ -z "$GIT_USER_NAME" ]; then
     echo >&2 "Error: git config --global user.name is not set. Please configure it with 'git config --global user.name \"Your Name\"'."
     exit 1
 fi
-GIT_USER_EMAIL=$(git config --global user.email)
+GIT_USER_EMAIL=$(git config --global user.email || true)
 if [ -z "$GIT_USER_EMAIL" ]; then
     echo >&2 "Error: git config --global user.email is not set. Please configure it with 'git config --global user.email \"email@domain.com\"'."
     exit 1


### PR DESCRIPTION
The installer.sh script exits prematurely if git config --global user.name or user.email are not set, preventing the intended error messages from being displayed. This is because the `set -e` option causes the script to terminate immediately when the git config command fails.

This change ensures that the script does not exit if the git config values are not set.