### PR TITLE
feat: Add advanced YAML editing for RepoWatch creation

### DIFF
--- a/repo-agent/k8s/issue-sandbox-rgd.yaml
+++ b/repo-agent/k8s/issue-sandbox-rgd.yaml
@@ -102,6 +102,8 @@ spec:
                       value: ${schema.spec.source.issue}
                     - name: ISSUE_BRANCH
                       value: ${schema.spec.destination.branch}
+                    - name: GIT_HTML_URL
+                      value: ${schema.spec.source.htmlURL}
                     - name: GITHUB_USER_ORIGIN
                       value: ${schema.spec.destination.origin}
                     - name: GITHUB_USER_LOGIN

--- a/repo-agent/review-ui/review-api/main.go
+++ b/repo-agent/review-ui/review-api/main.go
@@ -245,6 +245,7 @@ func main() {
 	{
 		api.GET("/repos", getRepos)
 		api.POST("/repos", createRepoWatch)
+		api.GET("/getRepoWatch", getDefaultRepoWatch)
 		api.PUT("/repos/:repo", updateRepoWatch)
 		api.DELETE("/repos/:repo", deleteRepoWatch)
 
@@ -642,46 +643,13 @@ func updateSecret(ctx context.Context, namespace, name string, data map[string][
 
 func createRepoWatch(c *gin.Context) {
 	namespace := c.MustGet(userKey).(string)
-	// TODO: Improve this - Prompts, Issue handlers, etc.
 	var payload struct {
-		Name string `json:"name"`
-		URL  string `json:"url"`
+		YAML string `json:"yaml"`
 	}
 	if err := c.ShouldBindJSON(&payload); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-
-	var repoName string
-	var err error
-	if payload.Name != "" {
-		repoName = payload.Name
-	} else {
-		_, repoName, err = parseRepoURL(payload.URL)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid GitHub URL"})
-			return
-		}
-	}
-
-	// Standard prompts
-	reviewPrompt := `You are an expert kubernetes developer who is helping with code reviews. Please look at the most recent commit and provide a review feedback. Would you approve it ?
-Please pay attention to the following:
-1. Does the fix resolve the original problem.
-2. Look for linked issues to understand the original problem.
-3. Are there tests to check the fix.`
-	triagePrompt := `You are a helpful assistant that triages GitHub issues for a Kubernetes-related open source project.
-Your task is to categorize incoming issues based on their content and assign appropriate labels.
-Analyze the issue title and body to determine the most relevant category from the following options:
-1. bug: Issues that describe unexpected behavior, errors, or malfunctions in the software.
-2. feature: Suggestions for new features, enhancements, or improvements to existing functionality.
-2. cleanup: Suggestions for cleaning up code, removing deprecated features, or improving code quality.
-3. document: Issues related to documentation errors, omissions, or requests for clarification.
-4. support: Questions or requests for help regarding the use of the software.
-5. other: Any issue that does not fit into the above categories.
-
-Start the response with "/kind <Category>" where <Category> is one of bug , feature , document, support, cleanup or other
-In the next line, provide a concise explanation of your reasoning for the assigned category.`
 
 	gvr := schema.GroupVersionResource{
 		Group:    "review.gemini.google.com",
@@ -689,49 +657,86 @@ In the next line, provide a concise explanation of your reasoning for the assign
 		Resource: "repowatches",
 	}
 
-	repoWatch := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "review.gemini.google.com/v1alpha1",
-			"kind":       "RepoWatch",
-			"metadata": map[string]interface{}{
-				"name":      repoName,
-				"namespace": namespace,
-			},
-			"spec": map[string]interface{}{
-				"repoURL":             payload.URL,
-				"githubSecretName":    "github-pat",
-				"pollIntervalSeconds": 300,
-				"review": map[string]interface{}{
-					"maxActiveSandboxes":    int64(1),
-					"devcontainerConfigRef": devContainerCM,
-					"llm": map[string]interface{}{
-						"provider":        "gemini-cli",
-						"apiKeySecretRef": "gemini-vscode-tokens",
-						"prompt":          reviewPrompt,
-					},
-				},
-				"issueHandlers": []interface{}{
-					map[string]interface{}{
-						"name":               "triage",
-						"maxActiveSandboxes": int64(1),
-						"llm": map[string]interface{}{
-							"provider": "gemini-cli",
-							"prompt":   triagePrompt,
-						},
-					},
-				},
-			},
-		},
+	if payload.YAML == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "YAML content is required"})
+		return
 	}
 
-	_, err = k8sClient.Resource(gvr).Namespace(namespace).Create(c.Request.Context(), repoWatch, v1.CreateOptions{})
+	// Create from YAML
+	var unstructuredObj map[string]interface{}
+	if err := yaml.Unmarshal([]byte(payload.YAML), &unstructuredObj); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid YAML content"})
+		return
+	}
+	repoWatch := &unstructured.Unstructured{Object: unstructuredObj}
+
+	// Enforce namespace
+	repoWatch.SetNamespace(namespace)
+
+	_, err := k8sClient.Resource(gvr).Namespace(namespace).Create(c.Request.Context(), repoWatch, v1.CreateOptions{})
 	if err != nil {
-		log.Printf("Failed to create RepoWatch: %v", err)
+		log.Printf("Failed to create RepoWatch from YAML: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Failed to create RepoWatch: %v", err)})
 		return
 	}
 
 	c.Status(http.StatusOK)
+}
+
+func getDefaultRepoWatch(c *gin.Context) {
+	defaultRepoWatch := `
+apiVersion: review.gemini.google.com/v1alpha1
+kind: RepoWatch
+metadata:
+  name: change-name
+spec:
+  repoURL: https://github.com/gke-labs/gemini-for-kubernetes-development
+  pollIntervalSeconds: 300
+  githubSecretName: github-pat
+  review:
+    devcontainerConfigRef: devcontainer-json
+    llm:
+      apiKeySecretRef: gemini-vscode-tokens
+      prompt: >-
+        You are an expert kubernetes developer who is helping with code reviews.
+        Please look at the most recent commit and provide a review feedback.
+        Would you approve it ?
+        Please pay attention to the following:
+        1. Does the fix resolve the original problem.
+        2. Look for linked issues to understand the original problem.
+        3. Are there tests to check the fix.
+      provider: gemini-cli
+    maxActiveSandboxes: 3
+  issueHandlers:
+    - llm:
+        prompt: >-
+          You are a helpful assistant that triages GitHub issues for a
+          Kubernetes-related open source project.
+          Your task is to categorize incoming issues based on their content and
+          assign appropriate labels.
+          Analyze the issue title and body to determine the most relevant
+          category from the following options:
+          1. bug: Issues that describe unexpected behavior, errors, or
+          malfunctions in the software.
+          2. feature: Suggestions for new features, enhancements, or
+          improvements to existing functionality.
+          2. cleanup: Suggestions for cleaning up code, removing deprecated
+          features, or improving code quality.
+          3. document: Issues related to documentation errors, omissions, or
+          requests for clarification.
+          4. support: Questions or requests for help regarding the use of the
+          software.
+          5. other: Any issue that does not fit into the above categories.
+
+          Start the response with "/kind <Category>" where <Category> is one of
+          bug , feature , document, support, cleanup or other
+          In the next line, provide a concise explanation of your reasoning for
+          the assigned category.
+        provider: gemini-cli
+      maxActiveSandboxes: 1
+      name: triage
+`
+	c.JSON(http.StatusOK, gin.H{"yaml": defaultRepoWatch})
 }
 
 func updateRepoWatch(c *gin.Context) {

--- a/repo-agent/review-ui/ui/src/AddRepo.js
+++ b/repo-agent/review-ui/ui/src/AddRepo.js
@@ -1,31 +1,135 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import yaml from 'js-yaml';
 
 function AddRepo({ onCancel, onRepoAdded }) {
     const [url, setUrl] = useState('');
     const [name, setName] = useState('');
+    const [yamlMode, setYamlMode] = useState(false);
+    const [yamlContent, setYamlContent] = useState('');
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState('');
 
-    const handleSubmit = (e) => {
+    useEffect(() => {
+        setIsLoading(true);
+        fetch('/api/getRepoWatch')
+            .then(res => res.json())
+            .then(data => {
+                if (data.yaml) {
+                    setYamlContent(data.yaml);
+                }
+                setIsLoading(false);
+            })
+            .catch(err => {
+                console.error(err);
+                setError('Failed to load default YAML');
+                setIsLoading(false);
+            });
+    }, []);
+
+    const updateYamlWithInputs = (currentContent, currentUrl, currentName) => {
+        try {
+            let parsed = yaml.load(currentContent);
+            if (!parsed) parsed = {};
+            if (!parsed.spec) parsed.spec = {};
+            if (!parsed.metadata) parsed.metadata = {};
+
+            parsed.spec.repoURL = currentUrl.trim();
+            
+            let finalName = currentName.trim();
+            // Derive name from URL if not provided
+            if (!finalName && currentUrl.trim()) {
+                try {
+                    const urlParts = new URL(currentUrl.trim()).pathname.split('/');
+                    if (urlParts.length >= 3) {
+                        finalName = urlParts[2].replace(".git", ""); 
+                    }
+                } catch (e) {
+                    // ignore
+                }
+            }
+            parsed.metadata.name = finalName;
+
+            return yaml.dump(parsed);
+        } catch (e) {
+            console.error("Error updating YAML", e);
+            return currentContent;
+        }
+    };
+
+    const handleSwitchToYaml = () => {
+        // Update YAML with current inputs before switching
+        const updatedYaml = updateYamlWithInputs(yamlContent, url, name);
+        setYamlContent(updatedYaml);
+        setYamlMode(true);
+    };
+
+    const handleYamlChange = (e) => {
+        const newYaml = e.target.value;
+        setYamlContent(newYaml);
+        try {
+            const parsed = yaml.load(newYaml);
+            // We don't strictly sync back to inputs while typing to avoid fighting the user
+            // but we could potentially update them if valid. 
+            // For now, let's keep the one-way sync or loose sync as implemented previously,
+            // or just leave inputs as is.
+            // The previous implementation updated inputs:
+            if (parsed && parsed.spec && parsed.spec.repoURL) {
+                setUrl(parsed.spec.repoURL);
+            }
+            if (parsed && parsed.metadata && parsed.metadata.name) {
+                setName(parsed.metadata.name);
+            }
+        } catch (e) {
+            // Ignore parsing errors while typing
+        }
+    };
+
+    const handleSubmit = async (e) => {
         e.preventDefault();
         setError('');
+        setIsLoading(true);
 
-        // Basic validation
-        if (!url.trim()) {
-            setError('Please enter a repository URL.');
+        let finalYaml = yamlContent;
+
+        if (!yamlMode) {
+            finalYaml = updateYamlWithInputs(yamlContent, url, name);
+        }
+
+        // Common Validation
+        try {
+            const parsed = yaml.load(finalYaml);
+            if (!parsed) throw new Error("YAML is empty or invalid");
+
+            const repoUrl = parsed.spec?.repoURL || '';
+            const repoName = parsed.metadata?.name || '';
+
+            if (!repoUrl.trim()) {
+                setError('Repository URL is required.');
+                setIsLoading(false);
+                return;
+            }
+            if (!repoUrl.startsWith('https://github.com/')) {
+                setError('Repository URL must start with https://github.com/');
+                setIsLoading(false);
+                return;
+            }
+            if (!repoName.trim()) {
+                 setError('Repository Name is required (or could not be derived from URL).');
+                 setIsLoading(false);
+                 return;
+            }
+
+            // If we are here, validation passed. 
+            // Re-dump to ensure we submit clean YAML if we just modified it in memory via updateYamlWithInputs
+            // (updateYamlWithInputs already returns string, but good to be sure)
+            
+        } catch (e) {
+            setError('Invalid YAML content: ' + e.message);
+            setIsLoading(false);
             return;
         }
-        if (!url.startsWith('https://github.com/')) {
-             setError('URL must start with https://github.com/');
-             return;
-        }
 
-        setIsLoading(true);
-        
-        const payload = { url: url.trim() };
-        if (name.trim()) {
-            payload.name = name.trim();
-        }
+        const payload = { yaml: finalYaml };
 
         fetch('/api/repos', {
             method: 'POST',
@@ -58,35 +162,65 @@ function AddRepo({ onCancel, onRepoAdded }) {
             {error && <div className="message error">{error}</div>}
 
             <form onSubmit={handleSubmit} className="add-repo-form">
-                <div className="form-group">
-                    <label htmlFor="repoUrl">Repository URL:</label>
-                    <input
-                        type="text"
-                        id="repoUrl"
-                        value={url}
-                        onChange={(e) => setUrl(e.target.value)}
-                        placeholder="https://github.com/owner/repo"
-                        disabled={isLoading}
-                    />
-                </div>
+                {!yamlMode && (
+                    <>
+                        <div className="form-group">
+                            <label htmlFor="repoUrl">Repository URL:</label>
+                            <input
+                                type="text"
+                                id="repoUrl"
+                                value={url}
+                                onChange={(e) => setUrl(e.target.value)}
+                                placeholder="https://github.com/owner/repo"
+                                disabled={isLoading}
+                            />
+                        </div>
 
-                <div className="form-group">
-                    <label htmlFor="repoName">Name (Optional):</label>
-                    <input
-                        type="text"
-                        id="repoName"
-                        value={name}
-                        onChange={(e) => setName(e.target.value)}
-                        placeholder="Custom name for this watch"
-                        disabled={isLoading}
-                    />
-                    <small>Leave blank to use the repository name.</small>
-                </div>
+                        <div className="form-group">
+                            <label htmlFor="repoName">Name (Optional):</label>
+                            <input
+                                type="text"
+                                id="repoName"
+                                value={name}
+                                onChange={(e) => setName(e.target.value)}
+                                placeholder="Custom name for this watch"
+                                disabled={isLoading}
+                            />
+                            <small>Leave blank to use the repository name.</small>
+                        </div>
+                    </>
+                )}
+
+                {yamlMode && (
+                    <div className="form-group">
+                        <label htmlFor="repoYaml">RepoWatch YAML:</label>
+                        <textarea
+                            id="repoYaml"
+                            value={yamlContent}
+                            onChange={handleYamlChange}
+                            className="yaml-editor"
+                            rows={15}
+                            disabled={isLoading}
+                            style={{fontFamily: 'monospace', width: '100%', whiteSpace: 'pre'}}
+                        />
+                    </div>
+                )}
 
                 <div className="form-actions">
                     <button type="submit" className="btn btn-submit" disabled={isLoading}>
                         {isLoading ? 'Adding...' : 'Start Watching'}
                     </button>
+                    
+                    {!yamlMode ? (
+                        <button type="button" className="btn" onClick={handleSwitchToYaml} disabled={isLoading}>
+                            Advanced YAML
+                        </button>
+                    ) : (
+                        <button type="button" className="btn" onClick={() => setYamlMode(false)} disabled={isLoading}>
+                            Simple Mode
+                        </button>
+                    )}
+
                     <button type="button" className="btn" onClick={onCancel} disabled={isLoading}>
                         Cancel
                     </button>


### PR DESCRIPTION
1. Backend (`review-ui/review-api/main.go`):
  * Added a new GET /api/getRepoWatch endpoint to provide a default RepoWatch YAML.
  * Updated the POST /api/repos endpoint to accept yaml field for direct YAML
2. Frontend (`review-ui/ui/src/AddRepo.js`):
  * Added js-yaml to imports.
  * Implemented a toggle between "Simple" mode (URL/Name inputs) and "Advanced YAML" mode.
  * When switching to "Advanced YAML" mode, the default YAML is fetched from the backend, and the current URL/Name inputs are merged into it.
  * When editing the YAML, the URL and Name state variables are updated in real-time (best-effort parsing) to keep them in sync if the user switches back to "Simple" mode.
  * The form submission now sends the full YAML content if the user is in "Advanced YAML" mode.


<img width="726" height="442" alt="image" src="https://github.com/user-attachments/assets/5af64030-71a1-4cc1-b1eb-feac5cfac12d" />

<img width="726" height="1089" alt="image" src="https://github.com/user-attachments/assets/a5386c91-6b16-4dfa-854d-e1050e7c7fa5" />
