### PR TITLE
Make the login page simpler

### DIFF
--- a/repo-agent/review-ui/ui/src/App.js
+++ b/repo-agent/review-ui/ui/src/App.js
@@ -633,35 +633,12 @@ function App() {
         </header>
         <main className="login-container">
           <h2>Welcome to Repo Agent</h2>
-          <p>Please log in with GitHub to manage your review sandboxes.</p>
           <div className="login-actions">
             {githubAuthEnabled ? (
                 <button className="btn btn-submit" onClick={handleLogin}>Login with GitHub</button>
             ) : (
-                <div className="github-config-section">
-                    <p className="message info">GitHub OAuth is not configured. You can continue as Guest or configure it below.</p>
-                    {!showGithubConfig ? (
-                        <button className="btn" onClick={() => setShowGithubConfig(true)}>Configure GitHub OAuth</button>
-                    ) : (
-                        <form onSubmit={handleGithubConfigSubmit} className="settings-form">
-                            {configError && <div className="message error">{configError}</div>}
-                            <div className="form-group">
-                                <label>Client ID:</label>
-                                <input type="text" value={githubClientId} onChange={e => setGithubClientId(e.target.value)} required />
-                            </div>
-                            <div className="form-group">
-                                <label>Client Secret:</label>
-                                <input type="password" value={githubClientSecret} onChange={e => setGithubClientSecret(e.target.value)} required />
-                            </div>
-                            <div className="form-actions">
-                                <button type="submit" className="btn btn-submit">Save & Enable</button>
-                                <button type="button" className="btn" onClick={() => setShowGithubConfig(false)}>Cancel</button>
-                            </div>
-                        </form>
-                    )}
-                </div>
+                <button className="btn btn-submit" onClick={handleGuestLogin}>Continue</button>
             )}
-            <button className="btn" onClick={handleGuestLogin}>Continue as Guest</button>
           </div>
         </main>
       </div>


### PR DESCRIPTION
* If only GITHUB_PAT is set, show only "Continue" for logging into guest mode
* If GITHUB_CLIENT_SECRET is also set, show only "Login With Github" for MT mode
* This is to disallow guest mode in multi-user installation
* Also this is to make it less complicated for single user installation

Single-tenant mode:
<img width="1498" height="422" alt="image" src="https://github.com/user-attachments/assets/29823f8e-9521-4d9d-afa9-b6cbd4943d0e" />

Multi-tenant mode:
<img width="1492" height="414" alt="image" src="https://github.com/user-attachments/assets/b9f5a39b-aee6-4a0a-a608-d8a92aab9b4f" />