### PR TITLE
Use circular buffer to capture stderr from agent calls

### DIFF
--- a/repo-agent/pkg/llm/circular_buffer.go
+++ b/repo-agent/pkg/llm/circular_buffer.go
@@ -1,0 +1,70 @@
+package llm
+
+import (
+	"sync"
+)
+
+// CircularBuffer is a simple thread-safe, fixed-size circular buffer that implements io.Writer.
+type CircularBuffer struct {
+	mu    sync.Mutex // May not be needed if only used in single goroutine
+	data  []byte
+	size  int
+	write int // write index
+	count int // number of bytes currently in buffer
+}
+
+// NewCircularBuffer creates a new CircularBuffer with a given size.
+func NewCircularBuffer(size int) *CircularBuffer {
+	return &CircularBuffer{
+		data: make([]byte, size),
+		size: size,
+	}
+}
+
+// Write writes p to the buffer, overwriting old data if the buffer is full.
+func (b *CircularBuffer) Write(p []byte) (n int, err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	n = len(p)
+	if n > b.size {
+		p = p[n-b.size:]
+		n = b.size
+	}
+
+	if b.write+len(p) <= b.size {
+		copy(b.data[b.write:], p)
+		b.write += len(p)
+	} else {
+		remain := b.size - b.write
+		copy(b.data[b.write:], p[:remain])
+		copy(b.data[0:], p[remain:])
+		b.write = len(p) - remain
+	}
+
+	if b.count < b.size {
+		b.count += n
+		if b.count > b.size {
+			b.count = b.size
+		}
+	}
+	return len(p), nil
+}
+
+// String returns the contents of the buffer as a string, starting from the oldest data.
+func (b *CircularBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.count == 0 {
+		return ""
+	}
+
+	if b.write < b.size && b.count == b.size {
+		buf := make([]byte, b.size)
+		copy(buf, b.data[b.write:])
+		copy(buf[b.size-b.write:], b.data[:b.write])
+		return string(buf)
+	}
+	return string(b.data[:b.count])
+}

--- a/repo-agent/pkg/llm/exec.go
+++ b/repo-agent/pkg/llm/exec.go
@@ -16,7 +16,6 @@ package llm
 
 import (
 	"bytes"
-	"os"
 	"os/exec"
 )
 
@@ -29,15 +28,26 @@ type CommandExecutor interface {
 type RealCommandExecutor struct{}
 
 func (e *RealCommandExecutor) Run(command string, args ...string) ([]byte, error) {
+	const bufferSize = 25 * 1024 * 1024 // 25MB
+	stderrBuffer := NewCircularBuffer(bufferSize)
 	cmd := exec.Command(command, args...)
 	// Dont return combined output. Return only stdout and log stderr separately.
 	// Create a buffer to capture stdout
 	var stdout bytes.Buffer
-	cmd.Stderr = os.Stderr
+	cmd.Stderr = stderrBuffer
 	cmd.Stdout = &stdout
 	err := cmd.Run()
+	// Retrieve the captured output from the buffer
+	capturedOutput := stderrBuffer.String()
+	if len(capturedOutput) > 0 {
+		// Log the stderr output
+		// In real implementation, use a proper logging framework
+		println("Captured Stderr Output (truncated to 25MB):")
+		println(capturedOutput)
+	}
 	if err != nil {
 		return nil, err
 	}
+
 	return stdout.Bytes(), nil
 }


### PR DESCRIPTION
Preferable to unbounded stderr
Preferable to dropping stderr to /dev/null

logs:
```
=== Running init command as user "root": ["/bin/sh" "-c" "/repo-agent/review-sandbox"]
2025/11/24 23:28:34 starting code-server
2025/11/24 23:28:34 Running code-server in subprocess 86
....
2025/11/24 23:28:35 Running Agent gemini-cli (attempt 1/10, successful runs 0)
2025/11/24 23:28:35 running gemini


Captured Stderr Output (truncated to 25MB):
YOLO mode is enabled. All tool calls will be automatically approved.
```