### PR TITLE
Limit the stdout size for LLM calls

### DIFF
--- a/repo-agent/pkg/llm/circular_buffer.go
+++ b/repo-agent/pkg/llm/circular_buffer.go
@@ -68,3 +68,21 @@ func (b *CircularBuffer) String() string {
 	}
 	return string(b.data[:b.count])
 }
+
+// Bytes returns the contents of the buffer starting from the oldest data.
+func (b *CircularBuffer) Bytes() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.count == 0 {
+		return []byte{}
+	}
+
+	if b.write < b.size && b.count == b.size {
+		buf := make([]byte, b.size)
+		copy(buf, b.data[b.write:])
+		copy(buf[b.size-b.write:], b.data[:b.write])
+		return buf
+	}
+	return b.data[:b.count]
+}

--- a/repo-agent/pkg/llm/exec.go
+++ b/repo-agent/pkg/llm/exec.go
@@ -15,7 +15,6 @@
 package llm
 
 import (
-	"bytes"
 	"os/exec"
 )
 
@@ -28,14 +27,14 @@ type CommandExecutor interface {
 type RealCommandExecutor struct{}
 
 func (e *RealCommandExecutor) Run(command string, args ...string) ([]byte, error) {
-	const bufferSize = 25 * 1024 * 1024 // 25MB
-	stderrBuffer := NewCircularBuffer(bufferSize)
+	const errBufferSize = 25 * 1024 * 1024 // 25MB
+	const outBufferSize = 1024 * 1024      // 1MB
+	stderrBuffer := NewCircularBuffer(errBufferSize)
+	stdoutBuffer := NewCircularBuffer(outBufferSize)
 	cmd := exec.Command(command, args...)
 	// Dont return combined output. Return only stdout and log stderr separately.
-	// Create a buffer to capture stdout
-	var stdout bytes.Buffer
 	cmd.Stderr = stderrBuffer
-	cmd.Stdout = &stdout
+	cmd.Stdout = stdoutBuffer
 	err := cmd.Run()
 	// Retrieve the captured output from the buffer
 	capturedOutput := stderrBuffer.String()
@@ -49,5 +48,5 @@ func (e *RealCommandExecutor) Run(command string, args ...string) ([]byte, error
 		return nil, err
 	}
 
-	return stdout.Bytes(), nil
+	return stdoutBuffer.Bytes(), nil
 }


### PR DESCRIPTION
Since stdout ends up in the custom resource, we are limiting to 1MB for now