### PR TITLE
dev-sandbox: embed simple SSH server over kubectl exec

### DIFF
--- a/repo-agent/dev-sandbox/dev-sandbox-rgd.yaml
+++ b/repo-agent/dev-sandbox/dev-sandbox-rgd.yaml
@@ -104,7 +104,7 @@ spec:
                     - name: ENVBUILDER_GIT_CLONE_SINGLE_BRANCH
                       value: "true"
                     - name: ENVBUILDER_INIT_SCRIPT
-                      value: /repo-agent/dev-sandbox
+                      value: /repo-agent/dev-sandbox init
                     - name: ENVBUILDER_IGNORE_PATHS
                       value: "/var/run,/product_uuid,/product_name,/tokens,/repo-agent/"
                   volumeMounts:

--- a/repo-agent/dev-sandbox/main.go
+++ b/repo-agent/dev-sandbox/main.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/dev-sandbox/sshd"
+	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 )
 
@@ -19,10 +21,56 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Fprintf(os.Stderr, "Completed successfully\n")
+	// fmt.Fprintf(os.Stderr, "Completed successfully\n")
 }
 
 func run(ctx context.Context) error {
+	// log := klog.FromContext(ctx)
+
+	rootCommand := &cobra.Command{}
+
+	initCommand := &cobra.Command{
+		Use: "init",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return fmt.Errorf("init command does not take any arguments")
+			}
+			return InitContainer(cmd.Context())
+		},
+	}
+	rootCommand.AddCommand(initCommand)
+
+	sshdCommand := &cobra.Command{
+		Use: "sshd",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return fmt.Errorf("sshd command does not take any arguments")
+			}
+			return RunSSHD(cmd.Context())
+		},
+	}
+	rootCommand.AddCommand(sshdCommand)
+
+	return rootCommand.ExecuteContext(ctx)
+}
+
+func RunSSHD(ctx context.Context) error {
+	log := klog.FromContext(ctx)
+
+	conn := sshd.NewStdinStdoutConn(os.Stdin, os.Stdout)
+
+	server := sshd.NewServer()
+
+	if err := server.Start(ctx, conn); err != nil {
+		log.Error(err, "SSH server exited with error")
+		return fmt.Errorf("ssh server: %w", err)
+	}
+
+	// log.Info("SSH server exited successfully")
+	return nil
+}
+
+func InitContainer(ctx context.Context) error {
 	log := klog.FromContext(ctx)
 
 	cmdCodeSrv, err := startCodeServer(ctx)

--- a/repo-agent/dev-sandbox/sshd/command_execution.go
+++ b/repo-agent/dev-sandbox/sshd/command_execution.go
@@ -1,0 +1,158 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sshd
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/creack/pty"
+	"golang.org/x/crypto/ssh"
+	"k8s.io/klog/v2"
+)
+
+func (s *Server) startCommand(ctx context.Context, sshChannel ssh.Channel, command string, ptyOptions *sshPayload) error {
+	log := klog.FromContext(ctx)
+
+	defer sshChannel.Close()
+
+	userHomeDir := os.Getenv("HOME")
+
+	cmd := exec.CommandContext(ctx, command)
+	cmd.Dir = userHomeDir
+	env := []string{}
+	env = append(env, os.Environ()...)
+	// env = append(env, "TERM=xterm-256color")
+	cmd.Env = env
+
+	inputPipeResults := make(chan error, 2)
+
+	if ptyOptions != nil {
+		ptmx, err := pty.Start(cmd)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err := ptmx.Close(); err != nil {
+				if !errors.Is(err, os.ErrClosed) {
+					log.Error(err, "closing pty")
+				}
+			}
+		}()
+
+		go func() {
+			// defer ptmx.Close()
+			_, err := io.Copy(ptmx, sshChannel)
+			if err != nil && !errors.Is(err, io.EOF) {
+				log.Error(err, "copying ssh channel to pty")
+			}
+		}()
+
+		go func() {
+			// defer sshChannel.CloseWrite()
+			_, err := io.Copy(sshChannel, ptmx)
+			inputPipeResults <- err
+			if err != nil && !errors.Is(err, io.EOF) {
+				log.V(2).Info("copying pty to ssh channel", "error", err)
+			}
+		}()
+
+		// We only have one channel when using a pty
+		inputPipeResults <- nil
+	} else {
+		stdin, err := cmd.StdinPipe()
+		if err != nil {
+			return fmt.Errorf("getting stdin pipe: %w", err)
+		}
+
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			return fmt.Errorf("getting stdout pipe: %w", err)
+		}
+		stderr, err := cmd.StderrPipe()
+		if err != nil {
+			return fmt.Errorf("getting stderr pipe: %w", err)
+		}
+
+		if err := cmd.Start(); err != nil {
+			return fmt.Errorf("starting exec command: %w", err)
+		}
+
+		go func() {
+			defer stdin.Close()
+			_, err := io.Copy(stdin, sshChannel)
+			if err != nil && !errors.Is(err, io.EOF) {
+				log.Error(err, "copying ssh channel to stdin")
+			}
+		}()
+
+		go func() {
+			// defer sshChannel.CloseWrite()
+			_, err := io.Copy(sshChannel, stdout)
+			inputPipeResults <- err
+			if err != nil && !errors.Is(err, io.EOF) {
+				log.Error(err, "copying stdout to ssh channel")
+			}
+		}()
+
+		go func() {
+			// defer sshChannel.CloseWrite()
+			_, err := io.Copy(sshChannel.Stderr(), stderr)
+			inputPipeResults <- err
+			if err != nil && !errors.Is(err, io.EOF) {
+				log.Error(err, "copying stderr to ssh channel")
+			}
+		}()
+	}
+
+	exitStatus := 0
+	if err := cmd.Wait(); err != nil {
+		log.Error(err, "command exited with error")
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			if status, ok := exitErr.Sys().(interface{ ExitStatus() int }); ok {
+				exitStatus = status.ExitStatus()
+			}
+		} else {
+			log.Error(err, "unexpected error waiting for command")
+			exitStatus = 255
+		}
+	}
+
+	exitStatusBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(exitStatusBytes, uint32(exitStatus))
+	if _, err := sshChannel.SendRequest("exit-status", false, exitStatusBytes); err != nil {
+		log.Error(err, "sending exit-status message")
+	}
+
+	// Wait for pipes to finish before sending exit code
+	err1 := <-inputPipeResults
+	if errors.Is(err1, io.EOF) {
+		err1 = nil
+	}
+	err2 := <-inputPipeResults
+	if errors.Is(err2, io.EOF) {
+		err2 = nil
+	}
+	if err := errors.Join(err1, err2); err != nil {
+		log.V(2).Info("error copying between pipes", "error", err)
+	}
+
+	return nil
+}

--- a/repo-agent/dev-sandbox/sshd/direct_tcpip.go
+++ b/repo-agent/dev-sandbox/sshd/direct_tcpip.go
@@ -1,0 +1,118 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sshd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+
+	"golang.org/x/crypto/ssh"
+	"k8s.io/klog/v2"
+)
+
+type directTCPIPExtraData struct {
+	HostToConnect  string
+	PortToConnect  uint32
+	OriginatorIP   string
+	OriginatorPort uint32
+}
+
+func (d *directTCPIPExtraData) Parse(b []byte) error {
+	payload := sshPayload{b: b}
+	var err error
+	d.HostToConnect, err = payload.PopString()
+	if err != nil {
+		return fmt.Errorf("parsing host to connect: %w", err)
+	}
+	d.PortToConnect, err = payload.PopUint32()
+	if err != nil {
+		return fmt.Errorf("parsing port to connect: %w", err)
+	}
+	d.OriginatorIP, err = payload.PopString()
+	if err != nil {
+		return fmt.Errorf("parsing originator IP: %w", err)
+	}
+	d.OriginatorPort, err = payload.PopUint32()
+	if err != nil {
+		return fmt.Errorf("parsing originator port: %w", err)
+	}
+	return nil
+}
+
+func (s *Server) runDirectTCPIPChannel(ctx context.Context, newChannel ssh.NewChannel) error {
+	log := klog.FromContext(ctx)
+
+	data := &directTCPIPExtraData{}
+	if err := data.Parse(newChannel.ExtraData()); err != nil {
+		if err := newChannel.Reject(ssh.UnknownChannelType, "payload parsing failed"); err != nil {
+			return fmt.Errorf("rejecting direct-tcpip channel: %w", err)
+		}
+		return fmt.Errorf("parsing direct-tcpip extra data: %w", err)
+	}
+
+	// The contract (seems to be) that we dial the target address before deciding whether to accept/reject the connection
+	targetAddr := net.JoinHostPort(data.HostToConnect, fmt.Sprintf("%d", data.PortToConnect))
+	targetConn, err := net.Dial("tcp", targetAddr)
+	if err != nil {
+		if err := newChannel.Reject(ssh.ConnectionFailed, "dialing target address failed"); err != nil {
+			return fmt.Errorf("rejecting direct-tcpip channel: %w", err)
+		}
+		return fmt.Errorf("dialing target address %q: %w", targetAddr, err)
+	}
+
+	sshChannel, requests, err := newChannel.Accept()
+	if err != nil {
+		targetConn.Close()
+		return fmt.Errorf("accepting direct-tcpip channel: %w", err)
+	}
+
+	go func() {
+		errChan := make(chan error, 2)
+		// Start copying data between sshChannel and targetConn
+		go func() {
+			defer targetConn.Close()
+			_, err := io.Copy(targetConn, sshChannel)
+			if err != nil {
+				errChan <- fmt.Errorf("copying from sshChannel to targetConn: %w", err)
+			} else {
+				errChan <- nil
+			}
+		}()
+		go func() {
+			defer sshChannel.Close()
+			_, err := io.Copy(sshChannel, targetConn)
+			if err != nil {
+				errChan <- fmt.Errorf("copying from targetConn to sshChannel: %w", err)
+			} else {
+				errChan <- nil
+			}
+		}()
+
+		go ssh.DiscardRequests(requests)
+
+		err1 := <-errChan
+		err2 := <-errChan
+
+		errs := errors.Join(err1, err2)
+		if errs != nil {
+			log.Error(errs, "direct-tcpip channel copy error")
+		}
+	}()
+
+	return nil
+}

--- a/repo-agent/dev-sandbox/sshd/session.go
+++ b/repo-agent/dev-sandbox/sshd/session.go
@@ -1,0 +1,96 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sshd
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/crypto/ssh"
+	"k8s.io/klog/v2"
+)
+
+func (s *Server) runSessionChannel(ctx context.Context, sshChannel ssh.Channel, requests <-chan *ssh.Request) error {
+	log := klog.FromContext(ctx)
+
+	defer sshChannel.Close()
+
+	var pty *sshPayload
+
+	for request := range requests {
+		sshPayload := sshPayload{b: request.Payload}
+		// log.Info("Received channel request", "type", request.Type)
+		switch request.Type {
+		case "pty-req":
+			// golang.org/x/crypto/ssh magically parses the PTY request payload for us
+			if request.WantReply {
+				if err := request.Reply(true, nil); err != nil {
+					return fmt.Errorf("replying to pty-req: %w", err)
+				}
+			}
+			pty = &sshPayload
+
+			// log.Info("PTY request accepted", "payload", string(sshPayload.b))
+		case "shell":
+			if sshPayload.Len() != 0 {
+				log.Error(fmt.Errorf("non-empty payload for shell request"), "invalid shell request payload")
+				if err := request.Reply(false, nil); err != nil {
+					return fmt.Errorf("replying to shell request: %w", err)
+				}
+				continue
+			}
+
+			if request.WantReply {
+				if err := request.Reply(true, nil); err != nil {
+					return fmt.Errorf("replying to shell request: %w", err)
+				}
+			}
+
+			shellCommand := "/bin/bash"
+			if err := s.startCommand(ctx, sshChannel, shellCommand, pty); err != nil {
+				return fmt.Errorf("running shell: %w", err)
+			}
+
+		case "exec":
+			command, err := sshPayload.PopString()
+			if err != nil {
+				log.Error(err, "parsing exec payload")
+				if err := request.Reply(false, nil); err != nil {
+					return fmt.Errorf("replying to exec request: %w", err)
+				}
+				continue
+			}
+
+			if request.WantReply {
+				if err := request.Reply(true, nil); err != nil {
+					return fmt.Errorf("replying to exec request: %w", err)
+				}
+			}
+
+			if err := s.startCommand(ctx, sshChannel, command, pty); err != nil {
+				return fmt.Errorf("running exec: %w", err)
+			}
+
+		default:
+			if request.WantReply {
+				if err := request.Reply(false, nil); err != nil {
+					return fmt.Errorf("replying to unknown channel request %q: %w", request.Type, err)
+				}
+			}
+			return fmt.Errorf("unknown channel request type: %s", request.Type)
+		}
+	}
+	return nil
+}

--- a/repo-agent/dev-sandbox/sshd/ssh_payload.go
+++ b/repo-agent/dev-sandbox/sshd/ssh_payload.go
@@ -1,0 +1,54 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sshd
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// sshPayload helps parse SSH request payloads.
+type sshPayload struct {
+	b []byte
+}
+
+// PopString pops a string from the payload.
+func (p *sshPayload) PopString() (string, error) {
+	if len(p.b) < 4 {
+		return "", fmt.Errorf("payload too short to read string length")
+	}
+	strLen := binary.BigEndian.Uint32(p.b)
+	if uint32(len(p.b)) < 4+strLen {
+		return "", fmt.Errorf("payload too short to read string (length %d)", strLen)
+	}
+	str := string(p.b[4 : 4+strLen])
+	p.b = p.b[4+strLen:]
+	return str, nil
+}
+
+// PopUint32 pops a uint32 from the payload.
+func (p *sshPayload) PopUint32() (uint32, error) {
+	if len(p.b) < 4 {
+		return 0, fmt.Errorf("payload too short to read uint32")
+	}
+	v := binary.BigEndian.Uint32(p.b)
+	p.b = p.b[4:]
+	return v, nil
+}
+
+// Len returns the length of the remaining payload.
+func (p *sshPayload) Len() int {
+	return len(p.b)
+}

--- a/repo-agent/dev-sandbox/sshd/ssh_server.go
+++ b/repo-agent/dev-sandbox/sshd/ssh_server.go
@@ -1,0 +1,157 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sshd
+
+import (
+	"context"
+	"crypto/ed25519"
+	cryptorand "crypto/rand"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/crypto/ssh"
+	"k8s.io/klog/v2"
+)
+
+type Server struct {
+}
+
+func NewServer() *Server {
+	return &Server{}
+}
+
+func (s *Server) Start(ctx context.Context, conn net.Conn) error {
+	log := klog.FromContext(ctx)
+
+	// TODO: Real auth
+	sshServerCfg := &ssh.ServerConfig{
+		NoClientAuth: true,
+		NoClientAuthCallback: func(conn ssh.ConnMetadata) (*ssh.Permissions, error) {
+			log.V(2).Info("NoClientAuthCallback called", "remoteAddr", conn.RemoteAddr())
+			permissions := &ssh.Permissions{}
+			return permissions, nil
+		},
+	}
+
+	sshDir := os.Getenv("SSHD_ROOT_DIR")
+	if sshDir == "" {
+		sshDir = "/etc/ssh"
+	}
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		return fmt.Errorf("creating ssh dir: %w", err)
+	}
+	privateKeyPath := filepath.Join(sshDir, "ssh_host_ed25519_key")
+	publicKeyPath := filepath.Join(sshDir, "ssh_host_ed25519_key.pub")
+	privateKeyBytes, err := os.ReadFile(privateKeyPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			log.Info("Host key file does not exist, generating new one", "path", privateKeyPath)
+			publicKey, privateKey, err := ed25519.GenerateKey(cryptorand.Reader)
+			if err != nil {
+				return fmt.Errorf("generating new host key: %w", err)
+			}
+			// Write private key to file
+			privateKeyPEMBlock, err := ssh.MarshalPrivateKey(privateKey, "")
+			if err != nil {
+				return fmt.Errorf("marshaling private key: %w", err)
+			}
+			privateKeyBytes = pem.EncodeToMemory(privateKeyPEMBlock)
+			if err := os.WriteFile(privateKeyPath, privateKeyBytes, 0600); err != nil {
+				return fmt.Errorf("writing new host key file: %w", err)
+			}
+			log.Info("Generated new host key", "path", privateKeyPath)
+
+			// Write public key to file
+			publicSSHKey, err := ssh.NewPublicKey(publicKey)
+			if err != nil {
+				return fmt.Errorf("creating ssh public key: %w", err)
+			}
+			publicKeyString := "ssh-ed25519" + " " + base64.StdEncoding.EncodeToString(publicSSHKey.Marshal())
+			if err := os.WriteFile(publicKeyPath, []byte(publicKeyString), 0644); err != nil {
+				return fmt.Errorf("writing new host public key file %q: %w", publicKeyPath, err)
+			}
+		} else {
+			return fmt.Errorf("reading private key file: %w", err)
+		}
+	}
+
+	hostKey, err := ssh.ParsePrivateKey(privateKeyBytes)
+	if err != nil {
+		return fmt.Errorf("parsing host key: %w", err)
+	}
+	sshServerCfg.AddHostKey(hostKey)
+	sshConnection, newChannels, sshRequests, err := ssh.NewServerConn(conn, sshServerCfg)
+	if err != nil {
+		return fmt.Errorf("starting ssh server: %w", err)
+	}
+	defer sshConnection.Close()
+
+	// Discard all requests
+	// go ssh.DiscardRequests(sshRequests)
+	go func() {
+		for req := range sshRequests {
+			switch req.Type {
+			case "keepalive@openssh.com":
+				if req.WantReply {
+					if err := req.Reply(true, nil); err != nil {
+						log.Error(err, "replying to keepalive request")
+					}
+				}
+
+			default:
+				log.Info("Received unknown SSH request", "type", req.Type)
+				if req.WantReply {
+					if err := req.Reply(false, nil); err != nil {
+						log.Error(err, "replying to unknown request")
+					}
+				}
+			}
+		}
+	}()
+
+	// log.Info("SSH server: new connection", "user", sshConnection.User(), "remoteAddr", sshConnection.RemoteAddr())
+
+	for newChannel := range newChannels {
+		// log.Info("SSH server: new channel", "type", newChannel.ChannelType())
+
+		switch newChannel.ChannelType() {
+		case "session":
+			channel, requests, err := newChannel.Accept()
+			if err != nil {
+				return fmt.Errorf("accepting session channel: %w", err)
+			}
+			go func() {
+				if err := s.runSessionChannel(ctx, channel, requests); err != nil {
+					log.Error(err, "running session channel")
+				}
+			}()
+		case "direct-tcpip":
+			if err := s.runDirectTCPIPChannel(ctx, newChannel); err != nil {
+				log.Error(err, "running direct-tcpip channel")
+			}
+
+		default:
+			if err := newChannel.Reject(ssh.UnknownChannelType, "unknown channel type"); err != nil {
+				return fmt.Errorf("rejecting unknown channel type: %w", err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/repo-agent/dev-sandbox/sshd/stdin_stdout_conn.go
+++ b/repo-agent/dev-sandbox/sshd/stdin_stdout_conn.go
@@ -1,0 +1,76 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sshd
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"time"
+)
+
+// StdinStdoutConn is a net.Conn implementation that uses os.Stdin and os.Stdout
+type StdinStdoutConn struct {
+	stdin  *os.File
+	stdout *os.File
+}
+
+var _ net.Conn = &StdinStdoutConn{}
+
+func NewStdinStdoutConn(stdin *os.File, stdout *os.File) *StdinStdoutConn {
+	return &StdinStdoutConn{
+		stdin:  stdin,
+		stdout: stdout,
+	}
+}
+
+func (c *StdinStdoutConn) Read(b []byte) (n int, err error) {
+	return c.stdin.Read(b)
+}
+
+func (c *StdinStdoutConn) Write(b []byte) (n int, err error) {
+	return c.stdout.Write(b)
+}
+func (c *StdinStdoutConn) Close() error {
+	var errs []error
+	if err := c.stdin.Close(); err != nil {
+		errs = append(errs, err)
+	}
+	if err := c.stdout.Close(); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+func (c *StdinStdoutConn) LocalAddr() net.Addr {
+	return &net.UnixAddr{Name: "stdin", Net: "unix"}
+}
+
+func (c *StdinStdoutConn) RemoteAddr() net.Addr {
+	return &net.UnixAddr{Name: "stdout", Net: "unix"}
+}
+
+func (c *StdinStdoutConn) SetDeadline(_ time.Time) error {
+	return fmt.Errorf("SetDeadline not supported")
+}
+
+func (c *StdinStdoutConn) SetReadDeadline(_ time.Time) error {
+	return fmt.Errorf("SetReadDeadline not supported")
+}
+
+func (c *StdinStdoutConn) SetWriteDeadline(_ time.Time) error {
+	return fmt.Errorf("SetWriteDeadline not supported")
+}

--- a/repo-agent/go.mod
+++ b/repo-agent/go.mod
@@ -4,18 +4,22 @@ go 1.24.7
 
 require (
 	github.com/bluekeyes/go-gitdiff v0.8.1
+	github.com/creack/pty v1.1.24
 	github.com/gin-contrib/sessions v1.0.4
 	github.com/gin-gonic/gin v1.11.0
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v39 v39.2.0
 	github.com/onsi/gomega v1.38.2
+	github.com/spf13/cobra v1.9.1
 	go.yaml.in/yaml/v3 v3.0.4
+	golang.org/x/crypto v0.45.0
 	golang.org/x/oauth2 v0.31.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.34.1
 	k8s.io/apimachinery v0.34.1
 	k8s.io/client-go v0.34.1
+	k8s.io/klog/v2 v2.130.1
 	sigs.k8s.io/controller-runtime v0.22.2
 )
 
@@ -81,7 +85,6 @@ require (
 	github.com/prometheus/procfs v0.17.0 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/quic-go/quic-go v0.54.1 // indirect
-	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.0 // indirect
@@ -91,7 +94,6 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/arch v0.20.0 // indirect
-	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/mod v0.29.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect
@@ -108,7 +110,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.34.1 // indirect
 	k8s.io/code-generator v0.34.1 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250604051438-85fd79dbfd9f // indirect
-	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect
 	sigs.k8s.io/controller-tools v0.19.0 // indirect

--- a/repo-agent/go.sum
+++ b/repo-agent/go.sum
@@ -21,6 +21,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/repo-agent/images/dev-sandbox/Dockerfile
+++ b/repo-agent/images/dev-sandbox/Dockerfile
@@ -9,14 +9,14 @@ COPY go.sum go.sum
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 # Prebuilds for speed
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -v k8s.io/klog/v2
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -v k8s.io/klog/v2 golang.org/x/crypto/ssh
 
 
 # Copy the llm directory
 COPY pkg/llm/ ./pkg/llm/
 
-COPY dev-sandbox/ .
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -v -o /dev-sandbox .
+COPY dev-sandbox/ dev-sandbox/
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -v -o /dev-sandbox ./dev-sandbox
 
 # Envbuilder root
 FROM ghcr.io/coder/envbuilder


### PR DESCRIPTION
Can be used easily with something like this in ~/.ssh/config:

```
Match host devc-mypod
  ProxyCommand kubectl exec -i devc-mypod -- /repo-agent/dev-sandbox sshd
  StrictHostKeyChecking no
  UserKnownHostsFile /dev/null
```
