### PR TITLE
Fix the default repowatch issue handler prompt.

### DIFF
--- a/repo-agent/review-ui/review-api/main.go
+++ b/repo-agent/review-ui/review-api/main.go
@@ -773,6 +773,10 @@ spec:
           bug , feature , document, support, cleanup or other
           In the next line, provide a concise explanation of your reasoning for
           the assigned category.
+
+          Issue Title: "{{.Title}}"
+          Issue Body: "{{.Body}}"
+          HTML URL: "{{.HTMLURL}}"
         provider: gemini-cli
       maxActiveSandboxes: 1
       name: triage


### PR DESCRIPTION
We see this output currently: Please provide the issue title and body so I can categorize it.