### PR TITLE
fix: Dont use single-branch cloning for issues

### DIFF
--- a/repo-agent/issue-sandbox/issue-sandbox-rgd.yaml
+++ b/repo-agent/issue-sandbox/issue-sandbox-rgd.yaml
@@ -137,8 +137,8 @@ spec:
                       value: /
                     #- name: ENVBUILDER_DOCKERFILE_PATH
                     #  value: ${schema.spec.devcontainerDockerfile}
-                    - name: ENVBUILDER_GIT_CLONE_SINGLE_BRANCH
-                      value: "true"
+                    #- name: ENVBUILDER_GIT_CLONE_SINGLE_BRANCH
+                    #  value: "true"
                     - name: ENVBUILDER_INIT_SCRIPT
                       value: /repo-agent/issue-sandbox
                     - name: ENVBUILDER_IGNORE_PATHS

--- a/repo-agent/k8s/issue-sandbox-rgd.yaml
+++ b/repo-agent/k8s/issue-sandbox-rgd.yaml
@@ -137,8 +137,8 @@ spec:
                       value: /
                     #- name: ENVBUILDER_DOCKERFILE_PATH
                     #  value: ${schema.spec.devcontainerDockerfile}
-                    - name: ENVBUILDER_GIT_CLONE_SINGLE_BRANCH
-                      value: "true"
+                    #- name: ENVBUILDER_GIT_CLONE_SINGLE_BRANCH
+                    #  value: "true"
                     - name: ENVBUILDER_INIT_SCRIPT
                       value: /repo-agent/issue-sandbox
                     - name: ENVBUILDER_IGNORE_PATHS


### PR DESCRIPTION
Envbuilder uses `main` branch when cloning a single branch and the giturl is not fork/branch specific. For some repos like k8s, main doesnt exists.

Seeing this error:
Failed to clone repository: clone https://github.com/kubernetes/kubernetes.git: couldn't find remote ref refs/heads/main