### PR TITLE
feat: Add MaxSandboxes field to PRReviewSpec and IssueHandlerSpec

### DIFF
--- a/repo-agent/k8s/crds/review.gemini.google.com_repowatches.yaml
+++ b/repo-agent/k8s/crds/review.gemini.google.com_repowatches.yaml
@@ -57,6 +57,8 @@ spec:
                       type: object
                     maxActiveSandboxes:
                       type: integer
+                    maxSandboxes:
+                      type: integer
                     name:
                       type: string
                     pushEnabled:
@@ -97,6 +99,8 @@ spec:
                         type: string
                     type: object
                   maxActiveSandboxes:
+                    type: integer
+                  maxSandboxes:
                     type: integer
                   preferAssignedToSelf:
                     type: boolean

--- a/repo-agent/repowatch/api/v1alpha1/repowatch_types.go
+++ b/repo-agent/repowatch/api/v1alpha1/repowatch_types.go
@@ -62,6 +62,10 @@ type PRReviewSpec struct {
 	// +kubebuilder:validation:Required
 	MaxActiveSandboxes int `json:"maxActiveSandboxes"`
 
+	// The maximum number of sandboxes to have (active + inactive) at any given time.
+	// +kubebuilder:validation:Optional
+	MaxSandboxes int `json:"maxSandboxes,omitempty"`
+
 	// The time in seconds after which a review sandbox will be scaled down to 0 replicas.
 	// +kubebuilder:validation:Optional
 	ReviewShutdownAfterMinutes int `json:"reviewShutdownAfterMinutes,omitempty"`
@@ -102,6 +106,10 @@ type IssueHandlerSpec struct {
 	// The maximum number of sandboxes to have active (replicas > 0) at any given time.
 	// +kubebuilder:validation:Required
 	MaxActiveSandboxes int `json:"maxActiveSandboxes"`
+
+	// The maximum number of sandboxes to have (active + inactive) at any given time.
+	// +kubebuilder:validation:Optional
+	MaxSandboxes int `json:"maxSandboxes,omitempty"`
 
 	// PushEnabled - allow pushing to user origin
 	// +kubebuilder:validation:Optional

--- a/repo-agent/repowatch/controllers/repowatch_controller.go
+++ b/repo-agent/repowatch/controllers/repowatch_controller.go
@@ -443,6 +443,7 @@ func (r *RepoWatchReconciler) reconcileReviewSandboxes(ctx context.Context, repo
 	log := log.FromContext(ctx)
 	log.Info("reconciling review sandboxes")
 	activeSandboxes := 0
+	totalSandboxes := 0
 	watchedPRs := []reviewv1alpha1.WatchedPR{}
 	pendingPRs := []reviewv1alpha1.PendingPR{}
 
@@ -458,6 +459,8 @@ func (r *RepoWatchReconciler) reconcileReviewSandboxes(ctx context.Context, repo
 		if !isOwned {
 			continue
 		}
+
+		totalSandboxes++
 
 		prNumber, err := strconv.Atoi(strings.Split(sandbox.GetName(), "-pr-")[1])
 		if err != nil {
@@ -478,6 +481,7 @@ func (r *RepoWatchReconciler) reconcileReviewSandboxes(ctx context.Context, repo
 			if err := r.Delete(ctx, &sandbox); err != nil {
 				log.Error(err, "unable to delete sandbox", "sandbox", sandbox.GetName())
 			}
+			totalSandboxes--
 		}
 	}
 
@@ -534,13 +538,14 @@ func (r *RepoWatchReconciler) reconcileReviewSandboxes(ctx context.Context, repo
 		}
 
 		if !sandboxExists {
-			if prIsExplicit || (activeSandboxes < repoWatch.Spec.Review.MaxActiveSandboxes) {
+			if prIsExplicit || ((activeSandboxes < repoWatch.Spec.Review.MaxActiveSandboxes) && (repoWatch.Spec.Review.MaxSandboxes == 0 || totalSandboxes < repoWatch.Spec.Review.MaxSandboxes)) {
 				log.Info("processing pr", "pr", *pr.Number, "sandboxName", sandboxName)
 				if err := r.createReviewSandboxForPR(ctx, repoWatch, pr); err != nil {
 					log.Error(err, "unable to create sandbox for pr", "pr", *pr.Number)
 				} else {
 					log.Info("sandbox created successfully for pr", "pr", *pr.Number)
 					activeSandboxes++
+					totalSandboxes++
 					watchedPRs = append(watchedPRs, reviewv1alpha1.WatchedPR{
 						Number:      *pr.Number,
 						SandboxName: sandboxName,
@@ -566,6 +571,7 @@ func (r *RepoWatchReconciler) reconcileReviewSandboxes(ctx context.Context, repo
 func (r *RepoWatchReconciler) reconcileIssueHandlerSandboxes(ctx context.Context, user *github.User, handler reviewv1alpha1.IssueHandlerSpec, repoWatch *reviewv1alpha1.RepoWatch, issues []*github.Issue, sandboxes *unstructured.UnstructuredList) error {
 	log := log.FromContext(ctx)
 	activeSandboxes := 0
+	totalSandboxes := 0
 	watchedIssues := []reviewv1alpha1.WatchedIssue{}
 	pendingIssues := []reviewv1alpha1.PendingIssue{}
 
@@ -607,6 +613,8 @@ func (r *RepoWatchReconciler) reconcileIssueHandlerSandboxes(ctx context.Context
 			continue
 		}
 
+		totalSandboxes++
+
 		found := false
 		for _, issue := range issues {
 			if *issue.Number == issueNumber {
@@ -620,6 +628,7 @@ func (r *RepoWatchReconciler) reconcileIssueHandlerSandboxes(ctx context.Context
 			if err := r.Delete(ctx, &sandbox); err != nil {
 				log.Error(err, "unable to delete sandbox", "sandbox", sandbox.GetName())
 			}
+			totalSandboxes--
 		}
 	}
 
@@ -648,12 +657,13 @@ func (r *RepoWatchReconciler) reconcileIssueHandlerSandboxes(ctx context.Context
 		}
 
 		if !sandboxExists {
-			if activeSandboxes < handler.MaxActiveSandboxes {
+			if activeSandboxes < handler.MaxActiveSandboxes && (handler.MaxSandboxes == 0 || totalSandboxes < handler.MaxSandboxes) {
 				log.Info("creating sandbox for issue", "issue", *issue.Number)
 				if err := r.createSandboxForIssueHandler(ctx, user, handler, repoWatch, issue); err != nil {
 					log.Error(err, "unable to create sandbox for issue", "issue", *issue.Number)
 				} else {
 					activeSandboxes++
+					totalSandboxes++
 					watchedIssues = append(watchedIssues, reviewv1alpha1.WatchedIssue{
 						Number:      *issue.Number,
 						SandboxName: sandboxName,

--- a/repo-agent/repowatch/controllers/repowatch_controller_maxsandboxes_test.go
+++ b/repo-agent/repowatch/controllers/repowatch_controller_maxsandboxes_test.go
@@ -1,0 +1,276 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-github/v39/github"
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	reviewv1alpha1 "github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/repowatch/api/v1alpha1"
+)
+
+// TestReconcileReviewSandboxes_MaxSandboxes verifies that the MaxSandboxes limit is respected.
+func TestReconcileReviewSandboxes_MaxSandboxes(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	s := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(s)
+	_ = reviewv1alpha1.AddToScheme(s)
+
+	repoURL := "https://github.com/test/repo"
+
+	repoWatch := &reviewv1alpha1.RepoWatch{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-repowatch",
+			Namespace: "default",
+			UID:       "test-uid",
+		},
+		Spec: reviewv1alpha1.RepoWatchSpec{
+			RepoURL:          repoURL,
+			GithubSecretName: "github-secret",
+			Review: reviewv1alpha1.PRReviewSpec{
+				MaxActiveSandboxes: 10,
+				MaxSandboxes:       2, // Total limit (active + inactive)
+			},
+		},
+	}
+
+	// 1. Existing Active Sandbox (PR 1)
+	activeSandbox := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "custom.agents.x-k8s.io/v1alpha1",
+			"kind":       "ReviewSandbox",
+			"metadata": map[string]interface{}{
+				"name":      "repo-pr-1",
+				"namespace": "default",
+				"ownerReferences": []interface{}{
+					map[string]interface{}{
+						"apiVersion": "review.gemini.google.com/v1alpha1",
+						"kind":       "RepoWatch",
+						"name":       "test-repowatch",
+						"uid":        "test-uid",
+					},
+				},
+			},
+			"spec": map[string]interface{}{
+				"replicas": int64(1),
+			},
+		},
+	}
+
+	// 2. Existing Inactive Sandbox (PR 2) - scaled down
+	inactiveSandbox := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "custom.agents.x-k8s.io/v1alpha1",
+			"kind":       "ReviewSandbox",
+			"metadata": map[string]interface{}{
+				"name":      "repo-pr-2",
+				"namespace": "default",
+				"ownerReferences": []interface{}{
+					map[string]interface{}{
+						"apiVersion": "review.gemini.google.com/v1alpha1",
+						"kind":       "RepoWatch",
+						"name":       "test-repowatch",
+						"uid":        "test-uid",
+					},
+				},
+			},
+			"spec": map[string]interface{}{
+				"replicas": int64(0),
+			},
+		},
+	}
+
+	// 3. New PR (PR 3) - should be blocked by MaxSandboxes
+	pr3Number := 3
+	pr3 := &github.PullRequest{
+		Number: &pr3Number,
+		Head: &github.PullRequestBranch{
+			Repo: &github.Repository{CloneURL: github.String(repoURL)},
+			Ref:  github.String("main"),
+		},
+		HTMLURL: github.String("https://github.com/test/repo/pull/3"),
+		Title:   github.String("Test PR 3"),
+	}
+
+	// PRs 1 and 2 are needed so sandboxes aren't deleted
+	pr1Number := 1
+	pr1 := &github.PullRequest{Number: &pr1Number}
+	pr2Number := 2
+	pr2 := &github.PullRequest{Number: &pr2Number}
+
+	r := &RepoWatchReconciler{
+		Client: clientfake.NewClientBuilder().WithScheme(s).WithObjects(repoWatch, activeSandbox, inactiveSandbox).WithStatusSubresource(repoWatch).Build(),
+		Scheme: s,
+		NewGithubClient: func(_ context.Context, _ client.Client, _ *reviewv1alpha1.RepoWatch) (*github.Client, map[string]string, error) {
+			return &github.Client{}, map[string]string{}, nil
+		},
+	}
+
+	// Call reconcile
+	err := r.reconcileReviewSandboxes(context.Background(), repoWatch, []*github.PullRequest{}, []*github.PullRequest{pr1, pr2, pr3}, &unstructured.UnstructuredList{Items: []unstructured.Unstructured{*activeSandbox, *inactiveSandbox}})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Verify results
+	sandboxList := &unstructured.UnstructuredList{}
+	sandboxList.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "custom.agents.x-k8s.io",
+		Version: "v1alpha1",
+		Kind:    "ReviewSandbox",
+	})
+	g.Expect(r.Client.List(context.Background(), sandboxList)).To(gomega.Succeed())
+	g.Expect(sandboxList.Items).To(gomega.HaveLen(2)) // Should still be 2
+
+	// Verify Status
+	fetchedRepoWatch := &reviewv1alpha1.RepoWatch{}
+	g.Expect(r.Client.Get(context.Background(), types.NamespacedName{Name: repoWatch.Name, Namespace: repoWatch.Namespace}, fetchedRepoWatch)).To(gomega.Succeed())
+
+	// PR 3 should be pending
+	g.Expect(fetchedRepoWatch.Status.PendingPRs).To(gomega.HaveLen(1))
+	g.Expect(fetchedRepoWatch.Status.PendingPRs[0].Number).To(gomega.Equal(3))
+}
+
+// TestReconcileIssueHandlerSandboxes_MaxSandboxes verifies that the MaxSandboxes limit is respected for Issues.
+func TestReconcileIssueHandlerSandboxes_MaxSandboxes(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	s := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(s)
+	_ = reviewv1alpha1.AddToScheme(s)
+
+	repoURL := "https://github.com/test/repo"
+	handlerName := "testhandler"
+
+	currentUser := &github.User{Login: github.String("test-user")}
+
+	repoWatch := &reviewv1alpha1.RepoWatch{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-repowatch",
+			Namespace: "default",
+			UID:       "test-uid",
+		},
+		Spec: reviewv1alpha1.RepoWatchSpec{
+			RepoURL:          repoURL,
+			GithubSecretName: "github-secret",
+			IssueHandlers: []reviewv1alpha1.IssueHandlerSpec{
+				{
+					Name:               handlerName,
+					MaxActiveSandboxes: 10,
+					MaxSandboxes:       2,
+				},
+			},
+		},
+	}
+	handler := repoWatch.Spec.IssueHandlers[0]
+
+	// 1. Existing Active Sandbox (Issue 1)
+	activeSandbox := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "custom.agents.x-k8s.io/v1alpha1",
+			"kind":       "IssueSandbox",
+			"metadata": map[string]interface{}{
+				"name":      "repo-issue-1-testhandler",
+				"namespace": "default",
+				"ownerReferences": []interface{}{
+					map[string]interface{}{
+						"apiVersion": "review.gemini.google.com/v1alpha1",
+						"kind":       "RepoWatch",
+						"name":       "test-repowatch",
+						"uid":        "test-uid",
+					},
+				},
+			},
+			"spec": map[string]interface{}{
+				"replicas": int64(1),
+			},
+		},
+	}
+
+	// 2. Existing Inactive Sandbox (Issue 2)
+	inactiveSandbox := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "custom.agents.x-k8s.io/v1alpha1",
+			"kind":       "IssueSandbox",
+			"metadata": map[string]interface{}{
+				"name":      "repo-issue-2-testhandler",
+				"namespace": "default",
+				"ownerReferences": []interface{}{
+					map[string]interface{}{
+						"apiVersion": "review.gemini.google.com/v1alpha1",
+						"kind":       "RepoWatch",
+						"name":       "test-repowatch",
+						"uid":        "test-uid",
+					},
+				},
+			},
+			"spec": map[string]interface{}{
+				"replicas": int64(0),
+			},
+		},
+	}
+
+	// 3. New Issue (Issue 3) - should be blocked
+	issue3Number := 3
+	issue3 := &github.Issue{
+		Number:        &issue3Number,
+		HTMLURL:       github.String("https://github.com/test/repo/issues/3"),
+		Title:         github.String("Test Issue 3"),
+		RepositoryURL: github.String("https://api.github.com/repos/test/repo"),
+	}
+
+	issue1Number := 1
+	issue1 := &github.Issue{Number: &issue1Number}
+	issue2Number := 2
+	issue2 := &github.Issue{Number: &issue2Number}
+
+	r := &RepoWatchReconciler{
+		Client: clientfake.NewClientBuilder().WithScheme(s).WithObjects(repoWatch, activeSandbox, inactiveSandbox).WithStatusSubresource(repoWatch).Build(),
+		Scheme: s,
+		NewGithubClient: func(_ context.Context, _ client.Client, _ *reviewv1alpha1.RepoWatch) (*github.Client, map[string]string, error) {
+			return &github.Client{}, map[string]string{}, nil
+		},
+	}
+
+	err := r.reconcileIssueHandlerSandboxes(context.Background(), currentUser, handler, repoWatch, []*github.Issue{issue1, issue2, issue3}, &unstructured.UnstructuredList{Items: []unstructured.Unstructured{*activeSandbox, *inactiveSandbox}})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	sandboxList := &unstructured.UnstructuredList{}
+	sandboxList.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "custom.agents.x-k8s.io",
+		Version: "v1alpha1",
+		Kind:    "IssueSandbox",
+	})
+	g.Expect(r.Client.List(context.Background(), sandboxList)).To(gomega.Succeed())
+	g.Expect(sandboxList.Items).To(gomega.HaveLen(2))
+
+	fetchedRepoWatch := &reviewv1alpha1.RepoWatch{}
+	g.Expect(r.Client.Get(context.Background(), types.NamespacedName{Name: repoWatch.Name, Namespace: repoWatch.Namespace}, fetchedRepoWatch)).To(gomega.Succeed())
+
+	g.Expect(fetchedRepoWatch.Status.PendingIssues[handlerName]).To(gomega.HaveLen(1))
+	g.Expect(fetchedRepoWatch.Status.PendingIssues[handlerName][0].Number).To(gomega.Equal(3))
+}

--- a/repo-agent/review-ui/review-api/main.go
+++ b/repo-agent/review-ui/review-api/main.go
@@ -753,6 +753,7 @@ spec:
         3. Are there tests to check the fix.
       provider: gemini-cli
     maxActiveSandboxes: 3
+    maxSandboxes: 5
   issueHandlers:
     - llm:
         prompt: >-
@@ -784,6 +785,7 @@ spec:
           HTML URL: "{{.HTMLURL}}"
         provider: gemini-cli
       maxActiveSandboxes: 1
+      maxSandboxes: 3
       name: triage
 `
 	c.JSON(http.StatusOK, gin.H{"yaml": defaultRepoWatch})


### PR DESCRIPTION
Why this change:

With `reviewShutdownAfterMinutes`, sandbox would be paused and newer sandbox would be created with an older PR. This keeps continuing till all PRs are addressed. This could potentially be unbounded in a larger repo like K8s. So we want an upper bound on active + paused sandboxes. 

About the change:

Implemented the logic to limit the total number of sandboxes (active and inactive) The logic ensures that:
- MaxSandboxes is optional (defaults to 0, which means no limit on total sandboxes).
- If MaxSandboxes is set (> 0), new sandboxes are not created if the total number of sandboxes (active + inactive) owned by the RepoWatch (for reviews) or the specific handler (for issues) meets or exceeds the limit.
- Existing MaxActiveSandboxes logic is preserved.
- Explicit PRs bypass the limits, consistent with previous behavior.