### PR TITLE
Adds unit tests for pkg/llm

### DIFF
--- a/repo-agent/pkg/llm/circular_buffer_test.go
+++ b/repo-agent/pkg/llm/circular_buffer_test.go
@@ -1,0 +1,94 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llm
+
+import (
+	"testing"
+)
+
+func TestCircularBuffer(t *testing.T) {
+	t.Run("NewCircularBuffer", func(t *testing.T) {
+		cb := NewCircularBuffer(10)
+		if cb.size != 10 {
+			t.Errorf("NewCircularBuffer() size = %v, want %v", cb.size, 10)
+		}
+		if cb.count != 0 {
+			t.Errorf("NewCircularBuffer() count = %v, want %v", cb.count, 0)
+		}
+		if cb.write != 0 {
+			t.Errorf("NewCircularBuffer() write = %v, want %v", cb.write, 0)
+		}
+	})
+
+	t.Run("Write and String", func(t *testing.T) {
+		cb := NewCircularBuffer(10)
+		_, _ = cb.Write([]byte("hello"))
+		if cb.String() != "hello" {
+			t.Errorf("Write() or String() got %v, want %v", cb.String(), "hello")
+		}
+		_, _ = cb.Write([]byte(" world"))
+		if cb.String() != "ello world" {
+			t.Errorf("Write() or String() got %v, want %v", cb.String(), "ello world")
+		}
+	})
+
+	t.Run("Write overflow", func(t *testing.T) {
+		cb := NewCircularBuffer(10)
+		_, _ = cb.Write([]byte("1234567890"))
+		_, _ = cb.Write([]byte("abc"))
+		if cb.String() != "4567890abc" {
+			t.Errorf("Write() overflow got %v, want %v", cb.String(), "4567890abc")
+		}
+	})
+
+	t.Run("Write more than size", func(t *testing.T) {
+		cb := NewCircularBuffer(5)
+		_, _ = cb.Write([]byte("1234567890"))
+		if cb.String() != "67890" {
+			t.Errorf("Write() more than size got %v, want %v", cb.String(), "67890")
+		}
+	})
+
+	t.Run("Bytes", func(t *testing.T) {
+		cb := NewCircularBuffer(10)
+		_, _ = cb.Write([]byte("hello"))
+		if string(cb.Bytes()) != "hello" {
+			t.Errorf("Bytes() got %v, want %v", string(cb.Bytes()), "hello")
+		}
+	})
+
+	t.Run("Empty buffer String", func(t *testing.T) {
+		cb := NewCircularBuffer(10)
+		if cb.String() != "" {
+			t.Errorf("Empty buffer String() got %v, want empty string", cb.String())
+		}
+	})
+
+	t.Run("Empty buffer Bytes", func(t *testing.T) {
+		cb := NewCircularBuffer(10)
+		if len(cb.Bytes()) != 0 {
+			t.Errorf("Empty buffer Bytes() got %v, want empty byte slice", cb.Bytes())
+		}
+	})
+
+	t.Run("Bytes overflow", func(t *testing.T) {
+		cb := NewCircularBuffer(10)
+		_, _ = cb.Write([]byte("1234567890"))
+		_, _ = cb.Write([]byte("abc"))
+		if string(cb.Bytes()) != "4567890abc" {
+			t.Errorf("Bytes() overflow got %v, want %v", string(cb.Bytes()), "4567890abc")
+		}
+	})
+}

--- a/repo-agent/pkg/llm/claude_test.go
+++ b/repo-agent/pkg/llm/claude_test.go
@@ -360,3 +360,10 @@ func TestClaudeRunWithStripYAMLMarkers(t *testing.T) {
 		t.Errorf("TestClaudeRunWithStripYAMLMarkers: Expected %q, got %q", expected, string(resp))
 	}
 }
+
+func TestClaudeCleanup(t *testing.T) {
+	c := &Claude{}
+	if err := c.Cleanup(""); err != nil {
+		t.Errorf("Cleanup() error = %v, want nil", err)
+	}
+}

--- a/repo-agent/pkg/llm/exec_test.go
+++ b/repo-agent/pkg/llm/exec_test.go
@@ -1,0 +1,59 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llm
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+)
+
+func TestRealCommandExecutor_Run(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		// This test will fail if `echo` is not in the path
+		executor := &RealCommandExecutor{}
+		output, err := executor.Run("echo", "-n", "hello")
+		if err != nil {
+			t.Fatalf("RealCommandExecutor.Run() failed: %v", err)
+		}
+		if string(output) != "hello" {
+			t.Errorf("Expected output %q, but got %q", "hello", string(output))
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		// This test will fail if `command-that-does-not-exist` is in the path
+		executor := &RealCommandExecutor{}
+		_, err := executor.Run("command-that-does-not-exist")
+		if err == nil {
+			t.Fatal("RealCommandExecutor.Run() should have failed, but it didn't")
+		}
+
+		// Check if the error is of type *exec.Error
+		var execErr *exec.Error
+		if !errors.As(err, &execErr) {
+			t.Errorf("Expected error of type *exec.Error, but got %T", err)
+		}
+	})
+
+	t.Run("stderr", func(t *testing.T) {
+		// This test will fail if `sh` is not in the path
+		executor := &RealCommandExecutor{}
+		_, err := executor.Run("sh", "-c", "echo -n hello >&2")
+		if err != nil {
+			t.Fatalf("RealCommandExecutor.Run() failed: %v", err)
+		}
+	})
+}

--- a/repo-agent/pkg/llm/gemini_test.go
+++ b/repo-agent/pkg/llm/gemini_test.go
@@ -17,48 +17,10 @@ package llm
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 )
-
-func TestNewProvider(t *testing.T) {
-	tests := []struct {
-		name         string
-		provider     string
-		wantErr      bool
-		expectedType string
-	}{
-		{
-			name:         "gemini-cli provider",
-			provider:     "gemini-cli",
-			wantErr:      false,
-			expectedType: "*llm.Gemini",
-		},
-		{
-			name:     "unknown provider",
-			provider: "unknown",
-			wantErr:  true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			provider, err := NewLLMProvider(tt.provider)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NewProvider() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !tt.wantErr {
-				providerType := fmt.Sprintf("%T", provider)
-				if providerType != tt.expectedType {
-					t.Errorf("NewProvider() type = %v, want %v", providerType, tt.expectedType)
-				}
-			}
-		})
-	}
-}
 
 func TestGemini_Setup(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
@@ -217,4 +179,11 @@ func TestGemini_Run(t *testing.T) {
 			t.Errorf("Expected error 'post-processing failed', but got '%v'", err)
 		}
 	})
+}
+
+func TestGeminiCleanup(t *testing.T) {
+	g := &Gemini{}
+	if err := g.Cleanup(""); err != nil {
+		t.Errorf("Cleanup() error = %v, want nil", err)
+	}
 }

--- a/repo-agent/pkg/llm/provider_test.go
+++ b/repo-agent/pkg/llm/provider_test.go
@@ -16,6 +16,7 @@ package llm
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 )
 
@@ -61,6 +62,49 @@ func TestStripYAMLMarkers(t *testing.T) {
 			}
 			if !bytes.Equal(got, tt.want) {
 				t.Errorf("StripYAMLMarkers() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewProvider(t *testing.T) {
+	tests := []struct {
+		name         string
+		provider     string
+		wantErr      bool
+		expectedType string
+	}{
+		{
+			name:         "gemini-cli provider",
+			provider:     "gemini-cli",
+			wantErr:      false,
+			expectedType: "*llm.Gemini",
+		},
+		{
+			name:     "unknown provider",
+			provider: "unknown",
+			wantErr:  true,
+		},
+		{
+			name:         "claude provider",
+			provider:     "claude",
+			wantErr:      false,
+			expectedType: "*llm.Claude",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, err := NewLLMProvider(tt.provider)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewProvider() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				providerType := fmt.Sprintf("%T", provider)
+				if providerType != tt.expectedType {
+					t.Errorf("NewProvider() type = %v, want %v", providerType, tt.expectedType)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
* Improves unit test coverage for `pkg/llm` from **55.0%** -> **91.8%**
* Adds unit tests for `pkg/llm/circular_buffer.go`
* Adds unit tests for `pkg/llm/exec.go`
* Improves test coverage for `pkg/llm/gemini.go`
* Improves test coverage for `pkg/llm/claude.go`
* Moves `NewProvider` test from `pkg/llm/gemini_test.go` to more appropriate `pkg/llm/provider_test.go`