### PR TITLE
Dont set imagepull policy to ifnotpresent

### DIFF
--- a/repo-agent/k8s/api-deployment.yaml
+++ b/repo-agent/k8s/api-deployment.yaml
@@ -17,7 +17,6 @@ spec:
       containers:
       - name: api
         image: ko://repo-agent/review-ui/images/review-api # This will be built locally
-        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
         env:

--- a/repo-agent/k8s/github-mcp-server.yaml
+++ b/repo-agent/k8s/github-mcp-server.yaml
@@ -16,7 +16,6 @@ spec:
       containers:
       - name: mcp
         image: ko://repo-agent/review-ui/images/github-mcp-server # This will be built locally
-        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8000
         env:

--- a/repo-agent/k8s/ui-deployment.yaml
+++ b/repo-agent/k8s/ui-deployment.yaml
@@ -16,6 +16,5 @@ spec:
       containers:
       - name: ui
         image: ko://repo-agent/review-ui/images/review-ui # This will be built locally
-        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80


### PR DESCRIPTION
When updating GKE auto[pilot cluster, the UI is serving stale image. 
