### PR TITLE
feat: Add Update repo-watch in the UI

### DIFF
--- a/repo-agent/.gitignore
+++ b/repo-agent/.gitignore
@@ -1,4 +1,5 @@
 keys.sh
+keys-local.sh
 bin/
 review-ui/ui/build/
 review-ui/ui/node_modules/

--- a/repo-agent/Makefile
+++ b/repo-agent/Makefile
@@ -2,6 +2,7 @@
 KIND_CLUSTER ?= repo-agent
 REGISTRY ?= kind.local/
 NAMESPACE ?= default
+LOCAL_PORT ?= 13380
 
 # if REGISTRY is kind.local/, then we are deploying to kind
 ifeq ($(REGISTRY), kind.local/)
@@ -154,7 +155,7 @@ delete-instance:
 .PHONY: port-forward
 port-forward:
 	while true; do \
-	ENVOY_SERVICE=$$(kubectl get svc -n envoy-gateway-system --selector=gateway.envoyproxy.io/owning-gateway-namespace=repo-agent-system,gateway.envoyproxy.io/owning-gateway-name=repo-agent-gateway -o jsonpath='{.items[0].metadata.name}') && kubectl port-forward -n envoy-gateway-system --address 0.0.0.0 service/$${ENVOY_SERVICE} 13380:13380;\
+	ENVOY_SERVICE=$$(kubectl get svc -n envoy-gateway-system --selector=gateway.envoyproxy.io/owning-gateway-namespace=repo-agent-system,gateway.envoyproxy.io/owning-gateway-name=repo-agent-gateway -o jsonpath='{.items[0].metadata.name}') && kubectl port-forward -n envoy-gateway-system --address 0.0.0.0 service/$${ENVOY_SERVICE} $(LOCAL_PORT):13380;\
 	done
 	# kubectl port-forward -n repo-agent-system --address 0.0.0.0 service/devc-agent-sandbox-pr-102-lb  13338:13338
 
@@ -183,8 +184,10 @@ reload-ui:
 	make build-and-push-repo-agent
 	make install-repo-agent
 	kubectl scale  -n repo-agent-system deployment pr-review-ui --replicas=0
+	kubectl scale  -n repo-agent-system deployment pr-review-api --replicas=0
 	sleep 5
 	kubectl scale  -n repo-agent-system deployment pr-review-ui --replicas=1
+	kubectl scale  -n repo-agent-system deployment pr-review-api --replicas=1
 	sleep 5
 	make port-forward
 

--- a/repo-agent/review-ui/review-api/fix_yaml_integers_test.go
+++ b/repo-agent/review-ui/review-api/fix_yaml_integers_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFixYAMLIntegers(t *testing.T) {
+	tests := []struct {
+		name string
+		in   interface{}
+		want interface{}
+	}{
+		{
+			name: "int to int64",
+			in:   int(123),
+			want: int64(123),
+		},
+		{
+			name: "string remains string",
+			in:   "hello",
+			want: "hello",
+		},
+		{
+			name: "map with int",
+			in: map[string]interface{}{
+				"foo": int(1),
+				"bar": "baz",
+			},
+			want: map[string]interface{}{
+				"foo": int64(1),
+				"bar": "baz",
+			},
+		},
+		{
+			name: "slice with int",
+			in:   []interface{}{int(1), "two", int(3)},
+			want: []interface{}{int64(1), "two", int64(3)},
+		},
+		{
+			name: "nested map and slice",
+			in: map[string]interface{}{
+				"list": []interface{}{
+					map[string]interface{}{
+						"val": int(10),
+					},
+					int(20),
+				},
+			},
+			want: map[string]interface{}{
+				"list": []interface{}{
+					map[string]interface{}{
+						"val": int64(10),
+					},
+					int64(20),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fixYAMLIntegers(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("fixYAMLIntegers() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/repo-agent/review-ui/review-api/main.go
+++ b/repo-agent/review-ui/review-api/main.go
@@ -247,6 +247,7 @@ func main() {
 		api.GET("/repos", getRepos)
 		api.POST("/repos", createRepoWatch)
 		api.GET("/getRepoWatch", getDefaultRepoWatch)
+		api.GET("/repos/:repo/yaml", getRepoWatchYAML)
 		api.PUT("/repos/:repo", updateRepoWatch)
 		api.DELETE("/repos/:repo", deleteRepoWatch)
 
@@ -673,6 +674,7 @@ func createRepoWatch(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid YAML content"})
 		return
 	}
+	unstructuredObj = fixYAMLIntegers(unstructuredObj).(map[string]interface{})
 	repoWatch := &unstructured.Unstructured{Object: unstructuredObj}
 
 	// Enforce namespace
@@ -792,6 +794,32 @@ spec:
 	c.JSON(http.StatusOK, gin.H{"yaml": defaultRepoWatch})
 }
 
+func getRepoWatchYAML(c *gin.Context) {
+	namespace := c.MustGet(userKey).(string)
+	name := c.Param("repo")
+
+	repoWatch, err := getRepoWatch(c.Request.Context(), namespace, name)
+	if err != nil {
+		log.Printf("Failed to get RepoWatch %s/%s: %v", namespace, name, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get RepoWatch"})
+		return
+	}
+
+	spec, found, err := unstructured.NestedMap(repoWatch.Object, "spec")
+	if err != nil || !found {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get spec from RepoWatch"})
+		return
+	}
+
+	yamlBytes, err := yaml.Marshal(spec)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to marshal spec to YAML"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"yaml": string(yamlBytes)})
+}
+
 func updateRepoWatch(c *gin.Context) {
 	namespace := c.MustGet(userKey).(string)
 	name := c.Param("repo")
@@ -799,14 +827,15 @@ func updateRepoWatch(c *gin.Context) {
 	var payload struct {
 		RepoURL string `json:"repoURL"`
 		AddPR   int    `json:"addPR"`
+		YAML    string `json:"yaml"`
 	}
 	if err := c.ShouldBindJSON(&payload); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
-	if payload.RepoURL == "" && payload.AddPR == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "repoURL or addPR is required"})
+	if payload.AddPR == 0 && payload.YAML == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "addPR or yaml is required"})
 		return
 	}
 
@@ -824,17 +853,27 @@ func updateRepoWatch(c *gin.Context) {
 		return
 	}
 
-	// Update spec.repoURL if provided
-	if payload.RepoURL != "" {
-		if err := unstructured.SetNestedField(existing.Object, payload.RepoURL, "spec", "repoURL"); err != nil {
-			log.Printf("Failed to set repoURL: %v", err)
+	if payload.YAML != "" {
+		var spec map[string]interface{}
+		if err := yaml.Unmarshal([]byte(payload.YAML), &spec); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid YAML content"})
+			return
+		}
+
+		spec = fixYAMLIntegers(spec).(map[string]interface{})
+
+		if err := unstructured.SetNestedField(existing.Object, spec, "spec"); err != nil {
+			log.Printf("Failed to set spec: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update object structure"})
 			return
 		}
-		// Update Redis cache to reflect the change immediately
-		if err := rdb.HSet(c.Request.Context(), fmt.Sprintf("repo:ns:%s:name:%s", namespace, name), "url", payload.RepoURL).Err(); err != nil {
-			log.Printf("Failed to update repo URL in Redis for %s: %v", name, err)
-			// Don't fail the request if Redis fails, as K8s deletion is the source of truth
+
+		// If repoURL changed in YAML, we should update Redis too, but strictly speaking
+		// we should extract it from the new spec.
+		if newURL, found, _ := unstructured.NestedString(existing.Object, "spec", "repoURL"); found {
+			if err := rdb.HSet(c.Request.Context(), fmt.Sprintf("repo:ns:%s:name:%s", namespace, name), "url", newURL).Err(); err != nil {
+				log.Printf("Failed to update repo URL in Redis for %s: %v", name, err)
+			}
 		}
 	}
 
@@ -892,6 +931,27 @@ func convInt64SliceToInterfaceSlice(in []int64) []interface{} {
 		out[i] = v
 	}
 	return out
+}
+
+func fixYAMLIntegers(in interface{}) interface{} {
+	switch v := in.(type) {
+	case int:
+		return int64(v)
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(v))
+		for k, val := range v {
+			out[k] = fixYAMLIntegers(val)
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, len(v))
+		for i, val := range v {
+			out[i] = fixYAMLIntegers(val)
+		}
+		return out
+	default:
+		return v
+	}
 }
 
 func deleteRepoWatch(c *gin.Context) {

--- a/repo-agent/review-ui/ui/src/App.js
+++ b/repo-agent/review-ui/ui/src/App.js
@@ -6,6 +6,7 @@ import IssueCard from './IssueCard';
 import AddRepo from './AddRepo';
 import DeleteRepo from './DeleteRepo';
 import Settings from './Settings';
+import UpdateRepo from './UpdateRepo';
 
 function App() {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
@@ -752,6 +753,7 @@ function App() {
             <div className="repo-controls">
                 <button className="btn btn-refresh-lg" onClick={() => refreshData(true)} title="Refresh now">↻</button>
                 {lastUpdated && <span className={`last-updated ${Date.now() - lastUpdated > 60000 ? 'stale' : ''}`}>Updated {lastUpdated.toLocaleTimeString()}</span>}
+                <button className="btn" onClick={() => setView('update_repo')} style={{marginLeft: '10px', marginRight: '10px'}}>Update Repo</button>
                 <DeleteRepo repo={activeRepo} onRepoDeleted={handleRepoDeleted} />
             </div>
         </div>
@@ -805,6 +807,7 @@ function App() {
       {view === 'dashboard' && renderDashboard()}
       {view === 'settings' && <Settings onBack={() => setView('dashboard')} />}
       {view === 'add_repo' && <AddRepo onCancel={() => setView('dashboard')} onRepoAdded={() => { fetchRepos(); setView('dashboard'); }} />}
+      {view === 'update_repo' && <UpdateRepo repo={activeRepo} onCancel={() => setView('dashboard')} onRepoUpdated={() => { fetchRepos(); setView('dashboard'); }} />}
 
     </div>
   );

--- a/repo-agent/review-ui/ui/src/UpdateRepo.js
+++ b/repo-agent/review-ui/ui/src/UpdateRepo.js
@@ -1,0 +1,121 @@
+import React, { useState, useEffect } from 'react';
+import yaml from 'js-yaml';
+
+function UpdateRepo({ repo, onCancel, onRepoUpdated }) {
+    const [yamlContent, setYamlContent] = useState('');
+    const [originalYamlContent, setOriginalYamlContent] = useState('');
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState('');
+
+    useEffect(() => {
+        setIsLoading(true);
+        fetch(`/api/repos/${repo.name}/yaml`)
+            .then(res => {
+                if (!res.ok) throw new Error("Failed to fetch repo YAML");
+                return res.json();
+            })
+            .then(data => {
+                if (data.yaml) {
+                    setYamlContent(data.yaml);
+                    setOriginalYamlContent(data.yaml); // Store original YAML content
+                }
+                setIsLoading(false);
+            })
+            .catch(err => {
+                console.error(err);
+                setError(err.message);
+                setIsLoading(false);
+            });
+    }, [repo.name]);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setError('');
+        setIsLoading(true);
+
+        try {
+            // Validate YAML
+            const parsed = yaml.load(yamlContent);
+            if (!parsed) throw new Error("YAML is empty or invalid");
+
+            // Extract repoURL from current and original YAML for comparison
+            // Note: The YAML content here is the Spec, so repoURL is at the root.
+            const currentRepoURL = parsed?.repoURL;
+            const originalParsed = yaml.load(originalYamlContent);
+            const originalRepoURL = originalParsed?.repoURL;
+
+            if (currentRepoURL && originalRepoURL && currentRepoURL !== originalRepoURL) {
+                setError('Repository URL cannot be changed in this interface.');
+                setIsLoading(false);
+                return;
+            }
+
+        } catch (e) {
+            setError('Invalid YAML content: ' + e.message);
+            setIsLoading(false);
+            return;
+        }
+
+        fetch(`/api/repos/${repo.name}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ yaml: yamlContent })
+        })
+        .then(async (res) => {
+            if (!res.ok) {
+                const contentType = res.headers.get("content-type");
+                if (contentType && contentType.indexOf("application/json") !== -1) {
+                    const data = await res.json();
+                    throw new Error(data.error || 'Failed to update repository');
+                } else {
+                    const text = await res.text();
+                    throw new Error(text || `Failed to update repository (${res.status})`);
+                }
+            }
+            return res;
+        })
+        .then(() => {
+            setIsLoading(false);
+            onRepoUpdated();
+        })
+        .catch(err => {
+            console.error(err);
+            setError(err.message);
+            setIsLoading(false);
+        });
+    };
+
+    return (
+        <div className="add-repo-container"> {/* Reusing add-repo styles */}
+            <h2>Update Repository: {repo.name}</h2>
+            
+            {error && <div className="message error">{error}</div>}
+
+            <form onSubmit={handleSubmit} className="add-repo-form">
+                <div className="form-group">
+                    <label htmlFor="repoYaml">RepoWatch Spec (YAML):</label>
+                    <textarea
+                        id="repoYaml"
+                        value={yamlContent}
+                        onChange={(e) => setYamlContent(e.target.value)}
+                        className="yaml-editor"
+                        rows={20}
+                        disabled={isLoading}
+                        style={{fontFamily: 'monospace', width: '100%', whiteSpace: 'pre'}}
+                    />
+                </div>
+
+                <div className="form-actions">
+                    <button type="submit" className="btn btn-submit" disabled={isLoading}>
+                        {isLoading ? 'Updating...' : 'Update Repo'}
+                    </button>
+                    <button type="button" className="btn" onClick={onCancel} disabled={isLoading}>
+                        Cancel
+                    </button>
+                </div>
+            </form>
+        </div>
+    );
+}
+
+export default UpdateRepo;


### PR DESCRIPTION
Backend Changes (@review-ui/review-api/main.go)
1. New Endpoint: Added GET /api/repos/:repo/yaml which returns the .spec section of the RepoWatch custom resource as YAML.
2. Update Logic: Modified updateRepoWatch (handling PUT /api/repos/:repo) to accept a yaml field in the JSON payload. If present, it updates the .spec of the RepoWatch resource with the provided YAML.

Frontend Changes
1. New Component (`@review-ui/ui/src/UpdateRepo.js`): Created a new component that fetches the RepoWatch YAML, displays it in an editor (similar to "Watch New Repository"), and submits the updated YAML to the backend.
2. App Integration (`@review-ui/ui/src/App.js`):
   * Added an "Update Repo" button next to the "Delete Repo" button in the dashboard's repository controls.
   * Added a new view state update_repo to switch to the UpdateRepo component when the button is clicked.

<img width="491" height="162" alt="image" src="https://github.com/user-attachments/assets/6066f983-94af-47d4-bb1d-4e86435f95ce" />

<img width="685" height="556" alt="image" src="https://github.com/user-attachments/assets/73dba520-6143-421a-8f18-b33aecc3ddb2" />
