### PR TITLE
Expand / commands in system prompt

### DIFF
--- a/repo-agent/.gitignore
+++ b/repo-agent/.gitignore
@@ -1,4 +1,5 @@
 keys.sh
+keys-local.sh
 bin/
 review-ui/ui/build/
 review-ui/ui/node_modules/

--- a/repo-agent/Makefile
+++ b/repo-agent/Makefile
@@ -2,6 +2,7 @@
 KIND_CLUSTER ?= repo-agent
 REGISTRY ?= kind.local/
 NAMESPACE ?= default
+LOCAL_PORT ?= 13380
 
 # if REGISTRY is kind.local/, then we are deploying to kind
 ifeq ($(REGISTRY), kind.local/)
@@ -160,7 +161,7 @@ delete-instance:
 .PHONY: port-forward
 port-forward:
 	while true; do \
-	ENVOY_SERVICE=$$(kubectl get svc -n envoy-gateway-system --selector=gateway.envoyproxy.io/owning-gateway-namespace=repo-agent-system,gateway.envoyproxy.io/owning-gateway-name=repo-agent-gateway -o jsonpath='{.items[0].metadata.name}') && kubectl port-forward -n envoy-gateway-system --address 0.0.0.0 service/$${ENVOY_SERVICE} 13380:13380;\
+	ENVOY_SERVICE=$$(kubectl get svc -n envoy-gateway-system --selector=gateway.envoyproxy.io/owning-gateway-namespace=repo-agent-system,gateway.envoyproxy.io/owning-gateway-name=repo-agent-gateway -o jsonpath='{.items[0].metadata.name}') && kubectl port-forward -n envoy-gateway-system --address 0.0.0.0 service/$${ENVOY_SERVICE} $(LOCAL_PORT):13380;\
 	done
 	# kubectl port-forward -n repo-agent-system --address 0.0.0.0 service/devc-agent-sandbox-pr-102-lb  13338:13338
 

--- a/repo-agent/examples/k8s-repowatch.yaml
+++ b/repo-agent/examples/k8s-repowatch.yaml
@@ -18,5 +18,5 @@ spec:
     #pullRequests:
     #- 12345
     #- 53434
-    devcontainerConfigRef: go-devcontainer-json
+    devcontainerConfigRef: devcontainer-json
     preferAssignedToSelf: true

--- a/repo-agent/examples/kcc-repowatch.yaml
+++ b/repo-agent/examples/kcc-repowatch.yaml
@@ -10,7 +10,7 @@ spec:
       provider: gemini-cli
       apiKeySecretRef: gemini-vscode-tokens
       prompt: |
-        google-internal:review-pr "{{.Number}}"
+        /google-internal:review-pr "{{.Number}}"
       configdirRef: kcc-review-gemini-config
     maxActiveSandboxes: 1
-    devcontainerConfigRef: go-devcontainer-json
+    devcontainerConfigRef: devcontainer-json

--- a/repo-agent/pkg/llm/claude.go
+++ b/repo-agent/pkg/llm/claude.go
@@ -103,6 +103,10 @@ func (c *Claude) Cleanup(_ string) error {
 	return nil
 }
 
+func (c *Claude) ExpandPrompt(prompt string) (string, error) {
+	return prompt, nil
+}
+
 func (c *Claude) Run(prompt string) ([]byte, error) {
 	log.Printf("Claude provider called with prompt: %s", prompt)
 

--- a/repo-agent/pkg/llm/command_expansion.go
+++ b/repo-agent/pkg/llm/command_expansion.go
@@ -1,0 +1,96 @@
+package llm
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Regex for finding commands: /namespace:command "args" or /namespace:command args
+// We'll support quoted args with simple quote handling.
+var commandRegex = regexp.MustCompile(`(?m)/([\w-]+):([\w-]+)(?:\s+(".*?"|[^\s]+))?`)
+
+func expandCommands(prompt string, geminiDir string) (string, error) {
+	return replaceCommands(prompt, geminiDir)
+}
+
+func replaceCommands(text string, geminiDir string) (string, error) {
+	// We iterate through all matches and replace them.
+	// Since we might have nested commands (unlikely but possible if a command prompt contains another command?),
+	// we'll just do one pass for now.
+
+	var errs []error
+
+	// FindAllStringSubmatchIndex is better if we want to replace ranges, but ReplaceAllStringFunc is easier.
+	result := commandRegex.ReplaceAllStringFunc(text, func(match string) string {
+		submatches := commandRegex.FindStringSubmatch(match)
+		namespace := submatches[1]
+		command := submatches[2]
+		args := ""
+		if len(submatches) > 3 {
+			args = submatches[3]
+		}
+
+		// Unquote args if quoted
+		if strings.HasPrefix(args, "\"") && strings.HasSuffix(args, "\"") {
+			args = args[1 : len(args)-1]
+			// TODO: handle escaped quotes if necessary
+		}
+
+		// Look for command file
+		cmdPath := filepath.Join(geminiDir, "commands", namespace, command+".toml")
+		if _, err := os.Stat(cmdPath); os.IsNotExist(err) {
+			// Try .json? Or maybe the user didn't define it.
+			// If not found, we return the original match (maybe it's not a command).
+			return match
+		}
+
+		content, err := os.ReadFile(cmdPath)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to read command file %s: %v", cmdPath, err))
+			return match
+		}
+
+		promptTemplate, err := extractPrompt(content, filepath.Ext(cmdPath))
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to extract prompt from %s: %v", cmdPath, err))
+			return match
+		}
+
+		promptTemplate = strings.TrimSpace(promptTemplate)
+
+		// Substitute {{args}}
+		replacement := strings.ReplaceAll(promptTemplate, "{{args}}", args)
+		return replacement
+	})
+
+	if len(errs) > 0 {
+		return result, fmt.Errorf("errors expanding commands: %v", errs)
+	}
+	return result, nil
+}
+
+func extractPrompt(content []byte, ext string) (string, error) {
+	s := string(content)
+	if ext == ".toml" {
+		// Regex for prompt = """...""" (multiline)
+		// We use (?s) to let . match newlines
+		reMultiline := regexp.MustCompile(`(?s)prompt\s*=\s*"""(.*?)"""`)
+		m := reMultiline.FindStringSubmatch(s)
+		if len(m) > 1 {
+			return m[1], nil
+		}
+
+		// Regex for prompt = "..." (single line)
+		reSingle := regexp.MustCompile(`prompt\s*=\s*"(.*?)"`)
+		m2 := reSingle.FindStringSubmatch(s)
+		if len(m2) > 1 {
+			return m2[1], nil
+		}
+		return "", fmt.Errorf("prompt field not found in TOML")
+	}
+	// Add JSON support if needed
+	return "", fmt.Errorf("unsupported command file extension: %s", ext)
+}

--- a/repo-agent/pkg/llm/command_expansion_test.go
+++ b/repo-agent/pkg/llm/command_expansion_test.go
@@ -1,0 +1,79 @@
+package llm
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExpandCommands(t *testing.T) {
+	// Setup temporary .gemini directory
+	tempDir := t.TempDir()
+	geminiDir := filepath.Join(tempDir, ".gemini")
+	commandsDir := filepath.Join(geminiDir, "commands")
+
+	// Create namespace directory
+	nsDir := filepath.Join(commandsDir, "google-internal")
+	if err := os.MkdirAll(nsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create command file
+	cmdFile := filepath.Join(nsDir, "review-pr.toml")
+	cmdContent := `
+description = "Test Command"
+prompt = """
+Reviewing PR {{args}}.
+"""
+`
+	if err := os.WriteFile(cmdFile, []byte(cmdContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name     string
+		prompt   string
+		expected string
+	}{
+		{
+			name:     "Basic command",
+			prompt:   `Run this: /google-internal:review-pr "123"`,
+			expected: `Run this: Reviewing PR 123.`,
+		},
+		{
+			name:     "Command with text around",
+			prompt:   `Start /google-internal:review-pr "456" End`,
+			expected: `Start Reviewing PR 456. End`,
+		},
+		{
+			name:     "Command with no args", // The template expects args, but if none provided?
+			prompt:   `Run /google-internal:review-pr`,
+			expected: `Run Reviewing PR .`, // Assuming empty string for args
+		},
+		{
+			name:     "Unknown command",
+			prompt:   "Run /google-internal:unknown",
+			expected: "Run /google-internal:unknown", // Should probably leave it alone or error? CLI usually errors. I'll leave it for now or log warning.
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := expandCommands(tt.prompt, geminiDir)
+			if err != nil {
+				// For unknown command, maybe we don't return error but leave it?
+				// But let's see.
+				t.Logf("Got error: %v", err)
+			}
+			// Check containment or exact match.
+			// My implementation might normalize spaces.
+			if result != tt.expected {
+				// If it's the unknown command case, we might accept it returning the original or error.
+				if tt.name == "Unknown command" && result == tt.prompt {
+					return
+				}
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}

--- a/repo-agent/pkg/llm/gemini.go
+++ b/repo-agent/pkg/llm/gemini.go
@@ -82,6 +82,10 @@ func (g *Gemini) Cleanup(workspacesDir string) error {
 	return nil
 }
 
+func (g *Gemini) ExpandPrompt(prompt string) (string, error) {
+	return expandCommands(prompt, ".gemini")
+}
+
 func (g *Gemini) Run(agentPrompt string) ([]byte, error) {
 	log.Println("running gemini")
 

--- a/repo-agent/pkg/llm/provider.go
+++ b/repo-agent/pkg/llm/provider.go
@@ -31,6 +31,7 @@ type PostProcessor func([]byte) ([]byte, error)
 type Provider interface {
 	Setup(workspacesDir, tokensDir string) error
 	Cleanup(workspacesDir string) error
+	ExpandPrompt(prompt string) (string, error)
 	Run(prompt string) ([]byte, error)
 	// AddPostProcessor adds a post-processing function to the provider.
 	// These functions are applied sequentially to the LLM's raw output.

--- a/repo-agent/review-sandbox/main.go
+++ b/repo-agent/review-sandbox/main.go
@@ -150,6 +150,12 @@ func runReview() error {
 			}
 		}
 
+		// Expand commands in the prompt
+		currentPrompt, err = provider.ExpandPrompt(currentPrompt)
+		if err != nil {
+			log.Printf("warning: failed to expand commands in prompt: %v", err)
+		}
+
 		// Write current prompt to file for debugging
 		promptFilename := fmt.Sprintf("../agent-prompt-run%d.txt", i+1)
 		if err := os.WriteFile(promptFilename, []byte(currentPrompt), 0644); err != nil {


### PR DESCRIPTION
Issue:
When using configdir and injecting custom gemini / commands, the review system prompt will not expand it. Typical cli users would type /namespace:command args in the gemini cli. When running in a script or a process we cannot use system prompt + / command.

Fix:
We will regex and expand the / commands inline in the system prompt.

1. New File: pkg/llm/command_expansion.go - Implements the parsing of /namespace:command "args" syntax and retrieval of the prompt from the corresponding .toml command file.
3. New File: pkg/llm/command_expansion_test.go - Tests for the expansion logic.
4. Modified: pkg/llm/gemini.go - Updated Gemini.Run to invoke expandCommands on the prompt before passing it to the CLI.

You can now use /namespace:command "args" within your system prompts (either in the reviewPromptTemplate in Go code or in the prompt field of your RepoWatch CRD), and they will be expanded using the definitions in .gemini/commands.

Verified manually. Additional review instructions section has the expanded / command

```
root ➜ /workspaces $ cat agent-prompt-run1.txt 
......

----------------
additional review instructions:
Please analyze the git pull request 5770 in GoogleCloudPlatform/k8s-config-connector.
Review pull request 5770.
Please also look at any checks or comments for that pull request.

## AI Pull Request Review Assistant

This section defines your role when I ask you to review a Pull Request.
You do not have the gh tool and cannot install it.

### 1. Persona and Goal

You are an expert AI assistant specializing in reviewing code, the Config Connector (kcc or cnrm) code base and providing feedback on pull requests.
Your primary goal is to provide actionable feedback for the Pull Request author.

**DO NOT** recommend whether to merge the PR.
**DO NOT** attempt to post any comments to the PR.
**DO NOT** post a review to the PR.

### 2. Information Gathering

You must analyze the PR description, comments from all contributors, and the code changes (`diff`).
Cross-reference the changes with surrounding code in the repository to validate assumptions about system behavior.

Please call the guthub MCP server to get the details of the pull request.
Please print the title of the PR after you call it.

Read @.gemini/commands/google-internal/KCC-Review.json for information about code reviews on KCC.
Read @.gemini/commands/google-internal/GO-Review.json for information about code reviews on golang code.

### 3. Analysis & Review Generation

The analysis should contain the following.
- Positive feedback on any good features of the change.
- Actionable feedback on any code which should be changed. Any such feedback should not have already been dealt with in the latest version of the code.
- All feedback should be done with a professional tone.
- You should flag if release notes are needed in the pull request description.
- You should flag if a desired milestone is missing in the pull request description.

#### Implementation Analysis
- Are there any potential bugs, logic errors, or race conditions in the implementation?
- Does the code adhere to established k8s coding conventions and best practices?

#### Backward Compatibility
- **Crucially, analyze backward compatibility implications.**
- For changes in the `apis/` directory (e.g., to exported Go types), confirm they are **backward
  compatible**.
- For changes in the `pkg/` directory, breaking changes are permissible only if **all internal call
  sites** within the kcc project have been updated accordingly. Please verify this.
- For changes in the `experiments/` direct breaking changes are permissable.

#### Testing Gaps
- How thorough is the test coverage for the new changes?
- Are there missing unit, integration, or e2e tests for critical code paths or edge cases?


### 4. Summary of review

- Briefly explain the **purpose** and **nature** of the requested code changes.
- Please give a confidence level on the correctness and completeness of the code review.

----------------

....
```