### PR TITLE
Copy claude secret to target namespace

### DIFF
--- a/repo-agent/review-ui/review-api/main.go
+++ b/repo-agent/review-ui/review-api/main.go
@@ -53,6 +53,7 @@ const (
 	systemNamespace  = "repo-agent-system"
 	githubSecretName = "github-pat"
 	geminiSecretName = "gemini-vscode-tokens"
+	claudeSecretName = "anthropic-api-key"
 	devContainerCM   = "devcontainer-json"
 )
 
@@ -484,6 +485,9 @@ func bootstrapNamespace(ctx context.Context, targetNS string) error {
 	}
 	if err := copySecret(ctx, systemNamespace, geminiSecretName, targetNS, geminiSecretName); err != nil {
 		log.Printf("Warning: failed to copy default gemini secret: %v", err)
+	}
+	if err := copySecret(ctx, systemNamespace, claudeSecretName, targetNS, claudeSecretName); err != nil {
+		log.Printf("Warning: failed to copy default claude secret: %v", err)
 	}
 	if err := copyConfigMap(ctx, systemNamespace, devContainerCM, targetNS, devContainerCM); err != nil {
 		log.Printf("Debug: failed to copy %s: %v", devContainerCM, err)


### PR DESCRIPTION
* Copies `claude` secret from `repo-agent-system` namespace to `target` namespace (like other LLM provider secrets).