### PR TITLE
Add a healthcheck endpoint that GKE GW checks

### DIFF
--- a/repo-agent/review-ui/review-api/main.go
+++ b/repo-agent/review-ui/review-api/main.go
@@ -262,6 +262,8 @@ func main() {
 	router.Use(ResponseLoggerMiddleware())
 
 	// Public routes: Authentication flows and initial configuration do not require a session.
+	router.GET("/", healthCheckOk)
+	router.GET("/api/", healthCheckOk)
 	router.GET("/api/auth/login", authLogin)
 	router.GET("/api/auth/callback", authCallback)
 	router.GET("/api/auth/status", authStatus)
@@ -306,6 +308,11 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to start router: %v", err)
 	}
+}
+
+// --- Health Check ---
+func healthCheckOk(c *gin.Context) {
+	c.String(http.StatusOK, "OK")
 }
 
 // --- Auth Handlers ---


### PR DESCRIPTION
The /api endpoint in marked as unhealthy by the GKE GW.

Suspecting this is because of default healthcheck logic.
```
2025/12/10 21:18:54 Request Method: GET
2025/12/10 21:18:54 Request URL: /
2025/12/10 21:18:54 Request Body: 
2025/12/10 21:18:54 Response Status: 404
2025/12/10 21:18:54 Response Headers: map[]
2025/12/10 21:18:54 Response Body: 
```