### PR TITLE
[WIP-DNM] feat: add .gemini/settings.json general.previewFeatures=true entry to allow for Gemini 3 usage

### DIFF
--- a/repo-agent/pkg/llm/gemini.go
+++ b/repo-agent/pkg/llm/gemini.go
@@ -15,6 +15,7 @@
 package llm
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -57,6 +58,49 @@ func (g *Gemini) Setup(workspacesDir, tokensDir string) error {
 		}
 	} else {
 		log.Println(".gemini directory does not exist in /workspaces")
+	}
+
+	// Ensure .gemini directory exists
+	if _, err := os.Stat(".gemini"); os.IsNotExist(err) {
+		if err := os.Mkdir(".gemini", 0755); err != nil {
+			return fmt.Errorf("failed to create .gemini directory: %v", err)
+		}
+	}
+
+	settingsPath := filepath.Join(".gemini", "settings.json")
+	var settings map[string]interface{}
+	if _, err := os.Stat(settingsPath); err == nil {
+		content, err := os.ReadFile(settingsPath)
+		if err != nil {
+			return fmt.Errorf("failed to read settings.json: %v", err)
+		}
+		if err := json.Unmarshal(content, &settings); err != nil {
+			log.Printf("failed to unmarshal settings.json, starting fresh: %v", err)
+			settings = make(map[string]interface{})
+		}
+	} else {
+		settings = make(map[string]interface{})
+	}
+
+	if settings["general"] == nil {
+		settings["general"] = make(map[string]interface{})
+	}
+
+	if general, ok := settings["general"].(map[string]interface{}); ok {
+		general["previewFeatures"] = true
+		settings["general"] = general
+	} else {
+		// Fallback if general is not a map (unexpected)
+		settings["general"] = map[string]interface{}{"previewFeatures": true}
+	}
+
+	newContent, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal settings.json: %v", err)
+	}
+
+	if err := os.WriteFile(settingsPath, newContent, 0644); err != nil {
+		return fmt.Errorf("failed to write settings.json: %v", err)
 	}
 
 	geminiTokenFile := filepath.Join(tokensDir, "gemini")

--- a/repo-agent/pkg/llm/gemini_test.go
+++ b/repo-agent/pkg/llm/gemini_test.go
@@ -67,6 +67,20 @@ func TestGemini_Setup(t *testing.T) {
 		if apiKey != "test-api-key" {
 			t.Errorf("Expected GEMINI_API_KEY to be 'test-api-key', but got '%s'", apiKey)
 		}
+
+		// Check if settings.json is created and has previewFeatures: true
+		settingsPath := filepath.Join(".gemini", "settings.json")
+		if _, err := os.Stat(settingsPath); os.IsNotExist(err) {
+			t.Errorf("Expected .gemini/settings.json to exist, but it does not")
+		} else {
+			content, err := os.ReadFile(settingsPath)
+			if err != nil {
+				t.Errorf("Failed to read settings.json: %v", err)
+			}
+			if !bytes.Contains(content, []byte(`"previewFeatures": true`)) {
+				t.Errorf("Expected settings.json to contain '\"previewFeatures\": true', but got: %s", string(content))
+			}
+		}
 	})
 
 	t.Run("read token error", func(t *testing.T) {
@@ -76,6 +90,18 @@ func TestGemini_Setup(t *testing.T) {
 		// Create dummy files and directories
 		workspacesDir := filepath.Join(tmpDir, "workspaces")
 		tokensDir := filepath.Join(tmpDir, "tokens")
+
+		// Change the current working directory to the temporary directory
+		wd, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("Failed to get current working directory: %v", err)
+		}
+		defer func() {
+			_ = os.Chdir(wd)
+		}()
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatalf("Failed to change working directory: %v", err)
+		}
 
 		// Create a Gemini provider and run Setup
 		g := &Gemini{}


### PR DESCRIPTION
This PR updates the repo-agent to automatically configure the gemini-cli environment to use Gemini 3 features. As identified in
  issue #184, this requires setting previewFeatures: true in the .gemini/settings.json configuration file.

  Changes:

   * `repo-agent/pkg/llm/gemini.go`: Updated the Setup method to programmatically ensure that .gemini/settings.json exists and that
     "previewFeatures": true is set under the "general" section. It preserves existing settings if the file already exists.
   * `repo-agent/pkg/llm/gemini_test.go`: Added a unit test case to verify that the settings.json file is correctly created/updated
     with the expected configuration during setup.

  Fixes: #184

  Testing:

   * Ran go test ./repo-agent/pkg/llm/... - All tests passed.
   * Verified that the settings.json is correctly marshaled with the new flag.

