### PR TITLE
Updates claude test binary to use Setup correctly

### DIFF
--- a/repo-agent/llm/cmd/claude-test/main.go
+++ b/repo-agent/llm/cmd/claude-test/main.go
@@ -18,17 +18,49 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/llm"
 )
 
-// claude-test is a simple binary to test the Claude LLM provider.
+// This binary tests the Claude LLM provider implementation found in `pkg/llm/claude.go`.
+// It demonstrates how the Claude LLM is set up, including securely handling API keys via
+// temporary files to validate the primary Setup function path.
 // It takes an optional prompt as a command-line argument, sends it to the
 // Claude LLM provider, and prints the response.
 func main() {
+	// Initialize the Claude LLM client. The implementation for Claude LLM provider
+	// is located at `pkg/llm/claude.go`.
 	claude := &llm.Claude{}
 
-	if err := claude.Setup("", ""); err != nil {
+	// --- Secure API Key Handling for Testing Primary Setup Path ---
+	// The Setup function in `pkg/llm/claude.go` prioritizes reading the API key from a file.
+	// To test this primary path securely without hardcoding or exposing the API key,
+	// we create a temporary directory and a temporary file within it.
+	// The API key is read from the ANTHROPIC_API_KEY environment variable (securely provided
+	// to this test execution environment) and then written into this temporary file.
+	// The path to this temporary directory is then passed to the claude.Setup function.
+	// The temporary directory and its contents are deleted when the main function exits.
+	tempDir, err := os.MkdirTemp("", "claude-test-")
+	if err != nil {
+		log.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir) // Clean up the temporary directory on exit
+
+	// Retrieve the API key from environment variable
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey == "" {
+		log.Fatal("ANTHROPIC_API_KEY environment variable not set")
+	}
+	// Write the API key to a file named 'claude' within the temporary directory.
+	// The filename 'claude' is what the Setup function expects by default.
+	if err := os.WriteFile(filepath.Join(tempDir, "claude"), []byte(apiKey), 0600); err != nil {
+		log.Fatalf("failed to write api key file: %v", err)
+	}
+
+	// Call the Setup function, passing the temporary directory as the tokens directory.
+	// This ensures the file-based API key retrieval path is tested.
+	if err := claude.Setup("", tempDir); err != nil {
 		log.Fatalf("failed to setup claude: %v", err)
 	}
 


### PR DESCRIPTION
* Now that Claude LLM provider mounts a file for the API key, use this pathway in the `claude-test` binary.