### PR TITLE
Update scripts to allow install/update on GKE cluster

### DIFF
--- a/dev/tools/deploy-to-kube
+++ b/dev/tools/deploy-to-kube
@@ -51,6 +51,16 @@ def find_and_replace_images(doc, service_name, image_prefix, image_tag):
     walk_object(doc, fn)
 
 
+def find_and_replace(doc, path, value):
+    """Recursively finds and replaces values in a Kubernetes manifest."""
+    def fn(field_path, v):
+        if field_path == path:
+            print(f"{path}: replaced value with {value}")
+            return value
+        return v
+    walk_object(doc, fn)
+
+
 def walk_object(obj, fn, field_path=""):
     """Recursively walks an object, and calls fn with the field_path to allow for value replacement."""
     if isinstance(obj, dict):
@@ -105,6 +115,20 @@ def main(args):
                 if not doc: # Skip empty documents
                     continue
                 find_and_replace_images(doc, service_name, image_prefix, image_tag)
+                if args.replace_params:
+                    for param in args.replace_params:
+                        if "=" not in param:
+                            print(f"invalid replace param {param}. must be in the form .spec.<path>=value")
+                            continue
+                        parts = param.split("=", 1)
+                        path = parts[0]
+                        val_str = parts[1]
+                        try:
+                            # Attempt to parse as YAML (handles int, bool, etc.)
+                            val = yaml.safe_load(val_str)
+                        except yaml.YAMLError:
+                            val = val_str
+                        find_and_replace(doc, path, val)
 
             # Dump the modified documents back to a string
             string_stream = io.StringIO()
@@ -149,6 +173,11 @@ if __name__ == "__main__":
                         help="output to file instead of applying to cluster",
                         type=str,
                         default=None)
+    parser.add_argument("--replace",
+                        dest="replace_params",
+                        help="replace a value in the manifest, e.g. .spec.replicas=3",
+                        action="append",
+                        default=[])
     args = parser.parse_args()
 
     if args.working_dir:

--- a/dev/tools/install-envoy
+++ b/dev/tools/install-envoy
@@ -44,6 +44,13 @@ def main():
         eg_version = get_latest_eg_version()
         print(f"Installing Envoy GW version: {eg_version}")
 
+        # if Envoy GW is already installed, skip installation
+        helm_list_command = ["helm", "-n", "envoy-gateway-system", "list"]
+        result = subprocess.run(helm_list_command, capture_output=True, text=True)
+        if "eg" in result.stdout:
+            print("Envoy GW is already installed. Skipping installation.")
+            return
+
         helm_install_command = [
             "helm", "install", "eg", "oci://docker.io/envoyproxy/gateway-helm", 
             f"--version={eg_version}",

--- a/dev/tools/install-kro
+++ b/dev/tools/install-kro
@@ -49,6 +49,13 @@ def main():
         kro_version = "0.5.1"
         print(f"Installing kro version: {kro_version}")
 
+        # Check if Kro is already installed
+        helm_list_command = ["helm", "-n", "kro", "list"]
+        result = subprocess.run(helm_list_command, capture_output=True, text=True)
+        if "kro" in result.stdout:
+            print("Kro is already installed. Skipping installation.")
+            return
+
         helm_install_command = [
             "helm", "install", "kro", "oci://registry.k8s.io/kro/charts/kro",
             "--namespace", "kro",

--- a/repo-agent/Makefile
+++ b/repo-agent/Makefile
@@ -3,7 +3,9 @@ KIND_CLUSTER ?= repo-agent
 REGISTRY ?= kind.local/
 NAMESPACE ?= default
 LOCAL_PORT ?= 13380
-INSTALL_ENVOY ?= yes
+CLUSTER_NAME != kubectl config view --minify --output 'jsonpath={.clusters[0].name}'
+INSTALL_ENVOY = $(shell if [[ ${CLUSTER_NAME} == kind* ]]; then echo "yes"; else echo "no"; fi)
+GW_CLASS = $(shell if [[ ${CLUSTER_NAME} == kind* ]]; then echo "repo-agent-gatewayclass"; else echo "gke-l7-regional-external-managed"; fi)
 
 # if REGISTRY is kind.local/, then we are deploying to kind
 ifeq ($(REGISTRY), kind.local/)
@@ -85,20 +87,21 @@ lint-go:
 .PHONY: install-dep-packages
 install-dep-packages:
 	../dev/tools/install-kro
-ifeq ($(strip $(INSTALL_ENVOY)),yes)
-	@echo "INSTALL_ENVOY is true."
-	../dev/tools/install-envoy
-else
-	@echo "INSTALL_ENVOY is not true. Skipping."
-endif
+	echo "INSTALL_ENVOY is set to $(INSTALL_ENVOY)"
+	@if [ "$(INSTALL_ENVOY)" == "yes" ]; then \
+	  	echo "Installing Envoy..."; \
+		../dev/tools/install-envoy; \
+	fi;
 	../dev/tools/install-agent-sandbox
 
 .PHONY: uninstall-dep-packages
 uninstall-dep-packages:
 	../dev/tools/install-kro --uninstall || true
-ifeq ($(strip $(INSTALL_ENVOY)),yes)
-	../dev/tools/install-envoy --uninstall || true
-endif
+	echo "INSTALL_ENVOY is set to $(INSTALL_ENVOY)"
+	@if [ "$(INSTALL_ENVOY)" == "yes" ]; then \
+	  	echo "UnInstalling Envoy..."; \
+		../dev/tools/install-envoy --uninstall || true; \
+	fi;
 	../dev/tools/install-agent-sandbox --uninstall || true
 
 .PHONY: create-kind
@@ -129,7 +132,7 @@ bin/key.json:
 .PHONY: create-secrets
 create-secrets: bin/tls.crt bin/key.json
 	kubectl create namespace repo-agent-system || true
-	@kubectl create secret -n repo-agent-system tls repo-agent-tls --cert=bin/tls.crt --key=bin/tls.key
+	@kubectl create secret -n repo-agent-system tls repo-agent-tls --cert=bin/tls.crt --key=bin/tls.key --dry-run=client -o yaml | kubectl apply -f -
 	@kubectl create secret -n repo-agent-system generic gcs-credentials --from-file=key.json=./bin/key.json --dry-run=client -o yaml | kubectl apply -f -
 	@kubectl create secret -n repo-agent-system generic dummy-provider-token --from-literal=dummy=testtoken --dry-run=client -o yaml | kubectl apply -f -
 	@kubectl create secret -n repo-agent-system generic gemini-vscode-tokens --from-literal=gemini=${GEMINI_API_KEY} --dry-run=client -o yaml | kubectl apply -f -
@@ -185,19 +188,21 @@ port-forward:
 	done
 	# kubectl port-forward -n repo-agent-system --address 0.0.0.0 service/devc-agent-sandbox-pr-102-lb  13338:13338
 
-# non-ephemeral (kind) cluster install targets
+# non-ephemeral (GKE) cluster install targets
 .PHONY: install-repo-agent-latest
-install-repo-agent-latest:
-	INSTALL_ENVOY=no ${MAKE} install-dep-packages
-	${MAKE} create-secrets
-	../dev/tools/deploy-to-kube --image-prefix=ghcr.io/gke-labs/gemini-for-kubernetes-development/ --image-tag=latest --working-dir . --output-file=bin/repo-agent-manifest.yaml
+install-repo-agent-latest: install-dep-packages create-secrets
+	../dev/tools/deploy-to-kube --image-prefix=ghcr.io/gke-labs/gemini-for-kubernetes-development/ \
+	--image-tag=latest \
+	--replace .spec.installationName=${CLUSTER_NAME} \
+	--replace .spec.gatewayClassName=${GW_CLASS} \
+	--working-dir . --output-file=bin/repo-agent-manifest.yaml
 	kubectl apply -f bin/repo-agent-manifest.yaml
 
 .PHONY: uninstall-repo-agent-latest
 uninstall-repo-agent-latest:
 	../dev/tools/deploy-to-kube --image-prefix=ghcr.io/gke-labs/gemini-for-kubernetes-development/ --image-tag=latest --working-dir . --output-file=bin/repo-agent-manifest.yaml
 	kubectl delete -f bin/repo-agent-manifest.yaml || true
-	INSTALL_ENVOY=no ${MAKE} uninstall-dep-packages
+	${MAKE} uninstall-dep-packages
 	kubectl delete crd issuesandboxes.custom.agents.x-k8s.io --wait=false || true
 	kubectl patch crd issuesandboxes.custom.agents.x-k8s.io --type=json -p='[{"op":"remove", "path":"/metadata/finalizers", "value":["customresourcecleanup.apiextensions.k8s.io"]}]' || true
 	kubectl delete crd reviewsandboxes.custom.agents.x-k8s.io --wait=false || true
@@ -208,6 +213,15 @@ uninstall-repo-agent-latest:
 .PHONY: reinstall-repo-agent-latest
 reinstall-repo-agent-latest: uninstall-repo-agent-latest install-repo-agent-latest
 # Dev targets
+
+.PHONY: update-repo-agent-latest
+update-repo-agent-latest: install-repo-agent-latest
+	kubectl rollout restart statefulset -n repo-agent-system
+	kubectl rollout status  statefulset  -n repo-agent-system
+	kubectl rollout restart deployment -n repo-agent-system
+	kubectl rollout status  deployment  -n repo-agent-system
+	@IP_ADDR=`kubectl get gateway -n repo-agent-system repo-agent-gateway -o json | jq -r ".status.addresses[0].value"`; \
+	echo; echo; echo -e "\e[1;34m REPO AGENT: https://$$IP_ADDR \e[0m"; echo; echo;
 
 .PHONY: reload-ui
 reload-ui:

--- a/repo-agent/k8s/syncer-cr.yaml
+++ b/repo-agent/k8s/syncer-cr.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: repo-agent-system
 spec:
   # kubectl config view --minify --output 'jsonpath={.clusters[0].name}'
-  installationName: kind-repo-agent
+  installationName: will-be-replaced-during-deploy
   gcsBucketName: repo-agent-storage
   rules:
     - group: custom.agents.x-k8s.io

--- a/repo-agent/k8s/ui-gateway.yaml
+++ b/repo-agent/k8s/ui-gateway.yaml
@@ -4,7 +4,7 @@ metadata:
   name: repo-agent-gateway
   namespace: repo-agent-system
 spec:
-  gatewayClassName: gke-l7-regional-external-managed
+  gatewayClassName: will-be-replaced-during-deploy
   listeners:
   - name: https
     protocol: HTTPS

--- a/repo-agent/k8s/ui-gatewayclass.yaml
+++ b/repo-agent/k8s/ui-gatewayclass.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
-  name: gke-l7-regional-external-managed
+  name: repo-agent-gatewayclass 
   namespace: repo-agent-system
 spec:
   controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/repo-agent/scripts/ops/backup.sh
+++ b/repo-agent/scripts/ops/backup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+# Default backup directory
+BACKUP_ROOT="./backups"
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+BACKUP_DIR="${BACKUP_ROOT}/${TIMESTAMP}"
+
+mkdir -p "${BACKUP_DIR}"
+
+echo "Backing up resources to ${BACKUP_DIR}..."
+
+# Backup Repowatch
+echo "Backing up RepoWatches..."
+kubectl get repowatches -A -o yaml > "${BACKUP_DIR}/repowatches.yaml" || echo "Warning: Failed to backup RepoWatches"
+
+# Backup ReviewSandbox
+echo "Backing up ReviewSandboxes..."
+kubectl get reviewsandboxes -A -o yaml > "${BACKUP_DIR}/reviewsandboxes.yaml" || echo "Warning: Failed to backup ReviewSandboxes"
+
+# Backup IssueSandbox
+echo "Backing up IssueSandboxes..."
+kubectl get issuesandboxes -A -o yaml > "${BACKUP_DIR}/issuesandboxes.yaml" || echo "Warning: Failed to backup IssueSandboxes"
+
+echo "Backup complete: ${BACKUP_DIR}"

--- a/repo-agent/scripts/ops/restore.sh
+++ b/repo-agent/scripts/ops/restore.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <backup-directory>"
+  exit 1
+fi
+
+BACKUP_DIR="$1"
+
+if [ ! -d "${BACKUP_DIR}" ]; then
+  echo "Error: Directory ${BACKUP_DIR} does not exist."
+  exit 1
+fi
+
+echo "Restoring resources from ${BACKUP_DIR}..."
+
+# Helper function to apply if file exists and has content
+apply_resource() {
+    local file="$1"
+    local resource_name="$2"
+    
+    if [ -f "${file}" ]; then
+        if [ -s "${file}" ]; then
+            echo "Restoring ${resource_name} from ${file}..."
+            # We use --validate=false to avoid schema validation errors during restore of CRDs/custom resources 
+            # if the CRDs are not fully consistent, though here they should be.
+            # We filter out resourceVersion, uid, creationTimestamp to ensure clean apply
+            # This is a naive filter using grep/sed which might be fragile but better than nothing without yq.
+            # However, for complex nested structures, this is risky. 
+            # Let's try direct apply first, if it fails, the user might need to clean it.
+            # Actually, standard kubectl apply usually works if we accept that we might overwrite.
+            
+            kubectl apply -f "${file}" || echo "Warning: Failed to apply ${file}"
+        else
+             echo "Skipping ${resource_name} (file empty)"
+        fi
+    else
+        echo "Skipping ${resource_name} (file not found)"
+    fi
+}
+
+apply_resource "${BACKUP_DIR}/repowatches.yaml" "RepoWatches"
+apply_resource "${BACKUP_DIR}/reviewsandboxes.yaml" "ReviewSandboxes"
+apply_resource "${BACKUP_DIR}/issuesandboxes.yaml" "IssueSandboxes"
+
+echo "Restore operation completed."


### PR DESCRIPTION
* Update deploy-to-kube to allow --replace semantics
* Update kro, Envoy install scripts to check if already installed
* Update makefile to inject cluster-name based vars
* replace GW class based on cluster name
* set syncer installationName to cluster name
* Based on cluster name conditionally install envoy
  * kind needs envoy installation
  * GKE comes with envoy preinstalled
* Add scripts/ops for backup and restore
  * `scripts/ops/backup.sh`: Creates a timestamped directory (e.g., backups/20251215_120000/) and exports all RepoWatch, ReviewSandbox, and IssueSandbox resources from all namespaces to YAML files.
  * `scripts/ops/restore.sh`: Usage: ./scripts/ops/restore.sh <backup-directory-path> ; Applies the YAML files from the specified backup directory. Note that this is a best-effort restore using kubectl apply.