### PR TITLE
Add HealthCheckPolicies for sandboxes in GKE clusters

### DIFF
--- a/dev/tools/deploy-to-kube
+++ b/dev/tools/deploy-to-kube
@@ -98,6 +98,10 @@ def main(args):
                 continue
 
             path = os.path.join(root, filename)
+            rel_path = os.path.relpath(path, working_dir)
+            if args.skip_files and rel_path in args.skip_files:
+                print(f"skipping manifest {rel_path}")
+                continue
 
             with open(path, "r") as f:
                 # Use safe_load_all for multi-document YAML files
@@ -135,7 +139,6 @@ def main(args):
             yaml.dump_all(docs, string_stream)
             modified_content = string_stream.getvalue()
 
-            rel_path = os.path.relpath(path, working_dir)
             if args.output_file is not None:
                 if all_manifests == "":
                     all_manifests = modified_content
@@ -176,6 +179,11 @@ if __name__ == "__main__":
     parser.add_argument("--replace",
                         dest="replace_params",
                         help="replace a value in the manifest, e.g. .spec.replicas=3",
+                        action="append",
+                        default=[])
+    parser.add_argument("--skip",
+                        dest="skip_files",
+                        help="skip a file from applying, e.g. 0 namespace.yaml",
                         action="append",
                         default=[])
     args = parser.parse_args()

--- a/repo-agent/.gitignore
+++ b/repo-agent/.gitignore
@@ -1,4 +1,5 @@
-keys.sh
+keys-preview.sh
+keys-staging.sh
 keys-local.sh
 keys-e2e.sh
 bin/

--- a/repo-agent/Makefile
+++ b/repo-agent/Makefile
@@ -6,6 +6,8 @@ LOCAL_PORT ?= 13380
 CLUSTER_NAME != kubectl config view --minify --output 'jsonpath={.clusters[0].name}'
 INSTALL_ENVOY = $(shell if [[ ${CLUSTER_NAME} == kind* ]]; then echo "yes"; else echo "no"; fi)
 GW_CLASS = $(shell if [[ ${CLUSTER_NAME} == kind* ]]; then echo "repo-agent-gatewayclass"; else echo "gke-l7-regional-external-managed"; fi)
+PLATFORM_SCHEMA_VALUE = $(shell if [[ ${CLUSTER_NAME} == kind* ]]; then echo "string | default=\"kind\""; else echo "string | default=\"gke\""; fi)
+SKIP_FILES_LIST = $(shell if [[ ${CLUSTER_NAME} == kind* ]]; then echo ""; else echo "--skip k8s/crds/healthcheckpolicies.networking.gke.io.yaml"; fi)
 
 # if REGISTRY is kind.local/, then we are deploying to kind
 ifeq ($(REGISTRY), kind.local/)
@@ -122,7 +124,9 @@ install-repo-agent:
 	cp dev-sandbox/dev-sandbox-rgd.yaml k8s/
 	../dev/tools/deploy-to-kube --image-prefix=$(REGISTRY) --working-dir . \
 	--replace .spec.installationName=${CLUSTER_NAME} \
-	--replace .spec.gatewayClassName=${GW_CLASS}
+	--replace .spec.gatewayClassName=${GW_CLASS} \
+	--replace .spec.schema.spec.platform='${PLATFORM_SCHEMA_VALUE}' \
+	${SKIP_FILES_LIST}
 
 bin/tls.crt:
 	openssl req -x509 -nodes -days 365 -newkey rsa:2048  -keyout bin/tls.key -out bin/tls.crt  -subj "/CN=repo-agent"
@@ -197,7 +201,9 @@ install-repo-agent-latest: install-dep-packages create-secrets
 	--image-tag=latest \
 	--replace .spec.installationName=${CLUSTER_NAME} \
 	--replace .spec.gatewayClassName=${GW_CLASS} \
-	--working-dir . --output-file=bin/repo-agent-manifest.yaml
+	--replace .spec.schema.spec.platform='${PLATFORM_SCHEMA_VALUE}' \
+	--working-dir . --output-file=bin/repo-agent-manifest.yaml \
+	${SKIP_FILES_LIST}
 	kubectl apply -f bin/repo-agent-manifest.yaml
 
 .PHONY: uninstall-repo-agent-latest
@@ -216,14 +222,18 @@ uninstall-repo-agent-latest:
 reinstall-repo-agent-latest: uninstall-repo-agent-latest install-repo-agent-latest
 # Dev targets
 
+.PHONY: show-repo-agent-ip
+show-repo-agent-ip:
+	@IP_ADDR=`kubectl get gateway -n repo-agent-system repo-agent-gateway -o json | jq -r ".status.addresses[0].value"`; \
+	echo; echo; echo -e "\e[1;34m REPO AGENT: https://$$IP_ADDR \e[0m"; echo; echo;
+
 .PHONY: update-repo-agent-latest
 update-repo-agent-latest: install-repo-agent-latest
 	kubectl rollout restart statefulset -n repo-agent-system
 	kubectl rollout status  statefulset  -n repo-agent-system
 	kubectl rollout restart deployment -n repo-agent-system
 	kubectl rollout status  deployment  -n repo-agent-system
-	@IP_ADDR=`kubectl get gateway -n repo-agent-system repo-agent-gateway -o json | jq -r ".status.addresses[0].value"`; \
-	echo; echo; echo -e "\e[1;34m REPO AGENT: https://$$IP_ADDR \e[0m"; echo; echo;
+	${MAKE} show-repo-agent-ip
 
 .PHONY: reload-ui
 reload-ui:

--- a/repo-agent/dev-sandbox/dev-sandbox-rgd.yaml
+++ b/repo-agent/dev-sandbox/dev-sandbox-rgd.yaml
@@ -36,12 +36,32 @@ spec:
       gateway:
         httpEnabled: boolean | default=false
         ref: string | default="repo-agent-gateway"
+      platform: string | default="generic"
     status:
       # Fields the controller will inject into instances status.
       agentDraft: "${sandbox.metadata.name}"
       fqdn: ${service.metadata.name}.${service.metadata.namespace}.svc.cluster.local
       sandboxConditions: ${sandbox.status.conditions}
   resources:
+    - id: healthcheckPolicy
+      includeWhen:
+        - ${schema.spec.platform == 'gke'}
+      template:
+        apiVersion: networking.gke.io/v1
+        kind: HealthCheckPolicy
+        metadata:
+          name: devc-${schema.metadata.name}
+        spec:
+          default:
+            config:
+              type: HTTP
+              httpHealthCheck:
+                requestPath: /healthz
+                port: 13337
+          targetRef:
+            group: ""
+            kind: Service
+            name: ${service.metadata.name}
     - id: sandbox
       readyWhen: # CEL expressions to determine when a resource is ready
       - ${sandbox.status.conditions.exists(x, x.type == 'Ready' && x.status == "True")}

--- a/repo-agent/issue-sandbox/issue-sandbox-rgd.yaml
+++ b/repo-agent/issue-sandbox/issue-sandbox-rgd.yaml
@@ -45,12 +45,32 @@ spec:
       gateway:
         httpEnabled: boolean | default=false
         ref: string | default="repo-agent-gateway"
+      platform: string | default="generic"
     status:
       # Fields the controller will inject into instances status.
       # agentDraft: "${sandbox.metadata.name}"
       fqdn: ${service.metadata.name}.${service.metadata.namespace}.svc.cluster.local
       sandboxConditions: ${sandbox.status.conditions}
   resources:
+    - id: healthcheckPolicy
+      includeWhen:
+        - ${schema.spec.platform == 'gke'}
+      template:
+        apiVersion: networking.gke.io/v1
+        kind: HealthCheckPolicy
+        metadata:
+          name: devc-${schema.metadata.name}
+        spec:
+          default:
+            config:
+              type: HTTP
+              httpHealthCheck:
+                requestPath: /healthz
+                port: 13337
+          targetRef:
+            group: ""
+            kind: Service
+            name: ${service.metadata.name}
     - id: sandbox
       readyWhen: # CEL expressions to determine when a resource is ready
       - ${sandbox.status.conditions.exists(x, x.type == 'Ready' && x.status == "True")}

--- a/repo-agent/k8s/crds/healthcheckpolicies.networking.gke.io.yaml
+++ b/repo-agent/k8s/crds/healthcheckpolicies.networking.gke.io.yaml
@@ -1,0 +1,641 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    components.gke.io/component-name: gateway-api-crds
+    components.gke.io/component-version: 1.3.0-gke.4
+    components.gke.io/layer: addon
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    gateway.networking.k8s.io/policy: "true"
+  name: healthcheckpolicies.networking.gke.io
+spec:
+  conversion:
+    strategy: None
+  group: networking.gke.io
+  names:
+    kind: HealthCheckPolicy
+    listKind: HealthCheckPolicyList
+    plural: healthcheckpolicies
+    singular: healthcheckpolicy
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: HealthCheckPolicy provides a way to create and attach a HealthCheck
+          to a BackendService with the GKE implementation of the Gateway API. This
+          policy can only be attached to a BackendService.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of HealthCheckPolicy.
+            properties:
+              default:
+                description: Default defines default policy configuration for the
+                  targeted resource.
+                properties:
+                  checkIntervalSec:
+                    description: How often (in seconds) to send a health check. If
+                      not specified, a default value of 5 seconds will be used.
+                    format: int64
+                    maximum: 300
+                    minimum: 1
+                    type: integer
+                  config:
+                    description: Specifies the type of the healthCheck, either TCP,
+                      HTTP, HTTPS, HTTP2 or GRPC. Exactly one of the protocol-specific
+                      health check field must be specified, which must match type
+                      field. Config contains per protocol (i.e. HTTP, HTTPS, HTTP2,
+                      TCP, GRPC) configuration. If not specified, health check type
+                      defaults to HTTP.
+                    maxProperties: 2
+                    minProperties: 2
+                    properties:
+                      grpcHealthCheck:
+                        description: GRPC is the health check configuration of type
+                          GRPC.
+                        properties:
+                          grpcServiceName:
+                            description: 'The gRPC service name for the health check.
+                              This field is optional. The value of grpcServiceName
+                              has the following meanings by convention: - Empty serviceName
+                              means the overall status of all services at the backend.
+                              - Non-empty serviceName means the health of that gRPC
+                              service, as defined by the owner of the service. The
+                              grpcServiceName can only be ASCII.'
+                            maxLength: 1024
+                            pattern: ^[\x00-\xFF]+$
+                            type: string
+                          port:
+                            description: The TCP port number for the health check
+                              request. Valid values are 1 through 65535.
+                            format: int64
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          portName:
+                            description: Port name as defined in InstanceGroup#NamedPort#name.
+                              If both port and portName are defined, port takes precedence.
+                            maxLength: 63
+                            pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          portSpecification:
+                            description: "Specifies how port is selected for health
+                              checking, can be one of following values: \n USE_FIXED_PORT:
+                              The port number in port is used for health checking.
+                              USE_NAMED_PORT: The portName is used for health checking.
+                              USE_SERVING_PORT: For NetworkEndpointGroup, the port
+                              specified for each network endpoint is used for health
+                              checking. For other backends, the port or named port
+                              specified in the Backend Service is used for health
+                              checking. \n If not specified, Protocol health check
+                              follows behavior specified in port and portName fields.
+                              If neither Port nor PortName is specified, this defaults
+                              to USE_SERVING_PORT."
+                            enum:
+                            - USE_FIXED_PORT
+                            - USE_NAMED_PORT
+                            - USE_SERVING_PORT
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                        - message: for portSpecification being USE_FIXED_PORT, port
+                            must be set and portName must be unset
+                          rule: 'has(self.portSpecification) && self.portSpecification
+                            == ''USE_FIXED_PORT'' ? has(self.port) && !has(self.portName)
+                            : true'
+                        - message: for portSpecification being USE_NAMED_PORT, port
+                            must be unset and portName must be set
+                          rule: 'has(self.portSpecification) && self.portSpecification
+                            == ''USE_NAMED_PORT'' ? !has(self.port) && has(self.portName)
+                            : true'
+                        - message: port and portName must be unset for portSpecification
+                            being USE_SERVING_PORT
+                          rule: 'has(self.portSpecification) && self.portSpecification
+                            == ''USE_SERVING_PORT'' ? !has(self.port) && !has(self.portName)
+                            : true'
+                      http2HealthCheck:
+                        description: HTTP2 is the health check configuration of type
+                          HTTP2.
+                        properties:
+                          host:
+                            description: Host is the value of the host header in the
+                              HTTP health check request. This matches the RFC 1123
+                              definition of a hostname with 1 notable exception that
+                              numeric IP addresses are not allowed. If not specified
+                              or left empty, the IP on behalf of which this health
+                              check is performed will be used.
+                            maxLength: 2048
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          port:
+                            description: The TCP port number for the health check
+                              request. Valid values are 1 through 65535.
+                            format: int64
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          portName:
+                            description: Port name as defined in InstanceGroup#NamedPort#name.
+                              If both port and portName are defined, port takes precedence.
+                            maxLength: 63
+                            pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          portSpecification:
+                            description: "Specifies how port is selected for health
+                              checking, can be one of following values: \n USE_FIXED_PORT:
+                              The port number in port is used for health checking.
+                              USE_NAMED_PORT: The portName is used for health checking.
+                              USE_SERVING_PORT: For NetworkEndpointGroup, the port
+                              specified for each network endpoint is used for health
+                              checking. For other backends, the port or named port
+                              specified in the Backend Service is used for health
+                              checking. \n If not specified, Protocol health check
+                              follows behavior specified in port and portName fields.
+                              If neither Port nor PortName is specified, this defaults
+                              to USE_SERVING_PORT."
+                            enum:
+                            - USE_FIXED_PORT
+                            - USE_NAMED_PORT
+                            - USE_SERVING_PORT
+                            type: string
+                          proxyHeader:
+                            description: Specifies the type of proxy header to append
+                              before sending data to the backend, either NONE or PROXY_V1.
+                              If not specified, this defaults to NONE.
+                            enum:
+                            - NONE
+                            - PROXY_V1
+                            type: string
+                          requestPath:
+                            description: The request path of the HTTP health check
+                              request. If not specified or left empty, a default value
+                              of "/" is used.
+                            maxLength: 2048
+                            pattern: ^\/[A-Za-z0-9\/\-._~%!?$&'()*+,;=:]*$
+                            type: string
+                          response:
+                            description: The string to match anywhere in the first
+                              1024 bytes of the response body. If not specified or
+                              left empty, the status code determines health. The response
+                              data can only be ASCII.
+                            maxLength: 1024
+                            pattern: ^[\x00-\xFF]+$
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                        - message: for portSpecification being USE_FIXED_PORT, port
+                            must be set and portName must be unset
+                          rule: 'has(self.portSpecification) && self.portSpecification
+                            == ''USE_FIXED_PORT'' ? has(self.port) && !has(self.portName)
+                            : true'
+                        - message: for portSpecification being USE_NAMED_PORT, port
+                            must be unset and portName must be set
+                          rule: 'has(self.portSpecification) && self.portSpecification
+                            == ''USE_NAMED_PORT'' ? !has(self.port) && has(self.portName)
+                            : true'
+                        - message: port and portName must be unset for portSpecification
+                            being USE_SERVING_PORT
+                          rule: 'has(self.portSpecification) && self.portSpecification
+                            == ''USE_SERVING_PORT'' ? !has(self.port) && !has(self.portName)
+                            : true'
+                      httpHealthCheck:
+                        description: HTTP is the health check configuration of type
+                          HTTP.
+                        properties:
+                          host:
+                            description: Host is the value of the host header in the
+                              HTTP health check request. This matches the RFC 1123
+                              definition of a hostname with 1 notable exception that
+                              numeric IP addresses are not allowed. If not specified
+                              or left empty, the IP on behalf of which this health
+                              check is performed will be used.
+                            maxLength: 2048
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          port:
+                            description: The TCP port number for the health check
+                              request. Valid values are 1 through 65535.
+                            format: int64
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          portName:
+                            description: Port name as defined in InstanceGroup#NamedPort#name.
+                              If both port and portName are defined, port takes precedence.
+                            maxLength: 63
+                            pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          portSpecification:
+                            description: "Specifies how port is selected for health
+                              checking, can be one of following values: \n USE_FIXED_PORT:
+                              The port number in port is used for health checking.
+                              USE_NAMED_PORT: The portName is used for health checking.
+                              USE_SERVING_PORT: For NetworkEndpointGroup, the port
+                              specified for each network endpoint is used for health
+                              checking. For other backends, the port or named port
+                              specified in the Backend Service is used for health
+                              checking. \n If not specified, Protocol health check
+                              follows behavior specified in port and portName fields.
+                              If neither Port nor PortName is specified, this defaults
+                              to USE_SERVING_PORT."
+                            enum:
+                            - USE_FIXED_PORT
+                            - USE_NAMED_PORT
+                            - USE_SERVING_PORT
+                            type: string
+                          proxyHeader:
+                            description: Specifies the type of proxy header to append
+                              before sending data to the backend, either NONE or PROXY_V1.
+                              If not specified, this defaults to NONE.
+                            enum:
+                            - NONE
+                            - PROXY_V1
+                            type: string
+                          requestPath:
+                            description: The request path of the HTTP health check
+                              request. If not specified or left empty, a default value
+                              of "/" is used.
+                            maxLength: 2048
+                            pattern: ^\/[A-Za-z0-9\/\-._~%!?$&'()*+,;=:]*$
+                            type: string
+                          response:
+                            description: The string to match anywhere in the first
+                              1024 bytes of the response body. If not specified or
+                              left empty, the status code determines health. The response
+                              data can only be ASCII.
+                            maxLength: 1024
+                            pattern: ^[\x00-\xFF]+$
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                        - message: for portSpecification being USE_FIXED_PORT, port
+                            must be set and portName must be unset
+                          rule: 'has(self.portSpecification) && self.portSpecification
+                            == ''USE_FIXED_PORT'' ? has(self.port) && !has(self.portName)
+                            : true'
+                        - message: for portSpecification being USE_NAMED_PORT, port
+                            must be unset and portName must be set
+                          rule: 'has(self.portSpecification) && self.portSpecification
+                            == ''USE_NAMED_PORT'' ? !has(self.port) && has(self.portName)
+                            : true'
+                        - message: port and portName must be unset for portSpecification
+                            being USE_SERVING_PORT
+                          rule: 'has(self.portSpecification) && self.portSpecification
+                            == ''USE_SERVING_PORT'' ? !has(self.port) && !has(self.portName)
+                            : true'
+                      httpsHealthCheck:
+                        description: HTTPS is the health check configuration of type
+                          HTTPS.
+                        properties:
+                          host:
+                            description: Host is the value of the host header in the
+                              HTTP health check request. This matches the RFC 1123
+                              definition of a hostname with 1 notable exception that
+                              numeric IP addresses are not allowed. If not specified
+                              or left empty, the IP on behalf of which this health
+                              check is performed will be used.
+                            maxLength: 2048
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          port:
+                            description: The TCP port number for the health check
+                              request. Valid values are 1 through 65535.
+                            format: int64
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          portName:
+                            description: Port name as defined in InstanceGroup#NamedPort#name.
+                              If both port and portName are defined, port takes precedence.
+                            maxLength: 63
+                            pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          portSpecification:
+                            description: "Specifies how port is selected for health
+                              checking, can be one of following values: \n USE_FIXED_PORT:
+                              The port number in port is used for health checking.
+                              USE_NAMED_PORT: The portName is used for health checking.
+                              USE_SERVING_PORT: For NetworkEndpointGroup, the port
+                              specified for each network endpoint is used for health
+                              checking. For other backends, the port or named port
+                              specified in the Backend Service is used for health
+                              checking. \n If not specified, Protocol health check
+                              follows behavior specified in port and portName fields.
+                              If neither Port nor PortName is specified, this defaults
+                              to USE_SERVING_PORT."
+                            enum:
+                            - USE_FIXED_PORT
+                            - USE_NAMED_PORT
+                            - USE_SERVING_PORT
+                            type: string
+                          proxyHeader:
+                            description: Specifies the type of proxy header to append
+                              before sending data to the backend, either NONE or PROXY_V1.
+                              If not specified, this defaults to NONE.
+                            enum:
+                            - NONE
+                            - PROXY_V1
+                            type: string
+                          requestPath:
+                            description: The request path of the HTTP health check
+                              request. If not specified or left empty, a default value
+                              of "/" is used.
+                            maxLength: 2048
+                            pattern: ^\/[A-Za-z0-9\/\-._~%!?$&'()*+,;=:]*$
+                            type: string
+                          response:
+                            description: The string to match anywhere in the first
+                              1024 bytes of the response body. If not specified or
+                              left empty, the status code determines health. The response
+                              data can only be ASCII.
+                            maxLength: 1024
+                            pattern: ^[\x00-\xFF]+$
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                        - message: for portSpecification being USE_FIXED_PORT, port
+                            must be set and portName must be unset
+                          rule: 'has(self.portSpecification) && self.portSpecification
+                            == ''USE_FIXED_PORT'' ? has(self.port) && !has(self.portName)
+                            : true'
+                        - message: for portSpecification being USE_NAMED_PORT, port
+                            must be unset and portName must be set
+                          rule: 'has(self.portSpecification) && self.portSpecification
+                            == ''USE_NAMED_PORT'' ? !has(self.port) && has(self.portName)
+                            : true'
+                        - message: port and portName must be unset for portSpecification
+                            being USE_SERVING_PORT
+                          rule: 'has(self.portSpecification) && self.portSpecification
+                            == ''USE_SERVING_PORT'' ? !has(self.port) && !has(self.portName)
+                            : true'
+                      tcpHealthCheck:
+                        description: TCP is the health check configuration of type
+                          TCP.
+                        properties:
+                          port:
+                            description: The TCP port number for the health check
+                              request. Valid values are 1 through 65535.
+                            format: int64
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          portName:
+                            description: Port name as defined in InstanceGroup#NamedPort#name.
+                              If both port and portName are defined, port takes precedence.
+                            maxLength: 63
+                            pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          portSpecification:
+                            description: "Specifies how port is selected for health
+                              checking, can be one of following values: \n USE_FIXED_PORT:
+                              The port number in port is used for health checking.
+                              USE_NAMED_PORT: The portName is used for health checking.
+                              USE_SERVING_PORT: For NetworkEndpointGroup, the port
+                              specified for each network endpoint is used for health
+                              checking. For other backends, the port or named port
+                              specified in the Backend Service is used for health
+                              checking. \n If not specified, Protocol health check
+                              follows behavior specified in port and portName fields.
+                              If neither Port nor PortName is specified, this defaults
+                              to USE_SERVING_PORT."
+                            enum:
+                            - USE_FIXED_PORT
+                            - USE_NAMED_PORT
+                            - USE_SERVING_PORT
+                            type: string
+                          proxyHeader:
+                            description: Specifies the type of proxy header to append
+                              before sending data to the backend, either NONE or PROXY_V1.
+                              If not specified, this defaults to NONE.
+                            enum:
+                            - NONE
+                            - PROXY_V1
+                            type: string
+                          request:
+                            description: The application data to send once the TCP
+                              connection has been established. If not specified, this
+                              defaults to empty. If both request and response are
+                              empty, the connection establishment alone will indicate
+                              health. The request data can only be ASCII.
+                            maxLength: 1024
+                            pattern: ^[\x00-\xFF]+$
+                            type: string
+                          response:
+                            description: The bytes to match against the beginning
+                              of the response data. If not specified or left empty,
+                              any response will indicate health. The response data
+                              can only be ASCII.
+                            maxLength: 1024
+                            pattern: ^[\x00-\xFF]+$
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                        - message: for portSpecification being USE_FIXED_PORT, port
+                            must be set and portName must be unset
+                          rule: 'has(self.portSpecification) && self.portSpecification
+                            == ''USE_FIXED_PORT'' ? has(self.port) && !has(self.portName)
+                            : true'
+                        - message: for portSpecification being USE_NAMED_PORT, port
+                            must be unset and portName must be set
+                          rule: 'has(self.portSpecification) && self.portSpecification
+                            == ''USE_NAMED_PORT'' ? !has(self.port) && has(self.portName)
+                            : true'
+                        - message: port and portName must be unset for portSpecification
+                            being USE_SERVING_PORT
+                          rule: 'has(self.portSpecification) && self.portSpecification
+                            == ''USE_SERVING_PORT'' ? !has(self.port) && !has(self.portName)
+                            : true'
+                      type:
+                        description: Specifies the type of the healthCheck, either
+                          TCP, HTTP, HTTPS, HTTP2 or GRPC. Exactly one of the protocol-specific
+                          health check field must be specified, which must match type
+                          field.
+                        enum:
+                        - TCP
+                        - HTTP
+                        - HTTPS
+                        - HTTP2
+                        - GRPC
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  healthyThreshold:
+                    description: A so-far unhealthy instance will be marked healthy
+                      after this many consecutive successes. If not specified, a default
+                      value of 2 will be used.
+                    format: int64
+                    maximum: 10
+                    minimum: 1
+                    type: integer
+                  logConfig:
+                    description: LogConfig configures logging on this health check.
+                    properties:
+                      enabled:
+                        description: Enabled indicates whether or not to export health
+                          check logs. If not specified, this defaults to false, which
+                          means health check logging will be disabled.
+                        type: boolean
+                    type: object
+                  timeoutSec:
+                    description: How long (in seconds) to wait before claiming failure.
+                      If not specified, a default value of 5 seconds will be used.
+                      It is invalid for timeoutSec to have greater value than checkIntervalSec.
+                    format: int64
+                    maximum: 300
+                    minimum: 1
+                    type: integer
+                  unhealthyThreshold:
+                    description: A so-far healthy instance will be marked unhealthy
+                      after this many consecutive failures. If not specified, a default
+                      value of 2 will be used.
+                    format: int64
+                    maximum: 10
+                    minimum: 1
+                    type: integer
+                type: object
+                x-kubernetes-validations:
+                - message: timeOutSec cannot exceed checkIntervalSec
+                  rule: 'has(self.checkIntervalSec) && has(self.timeoutSec) ? self.checkIntervalSec
+                    >= self.timeoutSec : true'
+                - message: when checkIntervalSec is unspecified, timeOutSec cannot
+                    exceed 5, which is the default value of checkIntervalSec
+                  rule: '!has(self.checkIntervalSec) && has(self.timeoutSec) ? 5 >=
+                    self.timeoutSec : true'
+                - message: when timeoutSec is unspecified, checkIntervalSec must be
+                    at least 5, which is the default value of timeoutSec
+                  rule: 'has(self.checkIntervalSec) && !has(self.timeoutSec) ? self.checkIntervalSec
+                    >= 5 : true'
+              targetRef:
+                description: TargetRef identifies an API object to apply policy to.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the referent. When
+                      unspecified, the local namespace is inferred. Even when policy
+                      targets a resource in a different namespace, it MUST only apply
+                      to traffic originating from the same namespace as the policy.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+            required:
+            - targetRef
+            type: object
+          status:
+            description: Status defines the current state of HealthCheckPolicy.
+            properties:
+              conditions:
+                description: Conditions describe the current conditions of the HealthCheckPolicy.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/repo-agent/k8s/dev-sandbox-rgd.yaml
+++ b/repo-agent/k8s/dev-sandbox-rgd.yaml
@@ -36,12 +36,32 @@ spec:
       gateway:
         httpEnabled: boolean | default=false
         ref: string | default="repo-agent-gateway"
+      platform: string | default="generic"
     status:
       # Fields the controller will inject into instances status.
       agentDraft: "${sandbox.metadata.name}"
       fqdn: ${service.metadata.name}.${service.metadata.namespace}.svc.cluster.local
       sandboxConditions: ${sandbox.status.conditions}
   resources:
+    - id: healthcheckPolicy
+      includeWhen:
+        - ${schema.spec.platform == 'gke'}
+      template:
+        apiVersion: networking.gke.io/v1
+        kind: HealthCheckPolicy
+        metadata:
+          name: devc-${schema.metadata.name}
+        spec:
+          default:
+            config:
+              type: HTTP
+              httpHealthCheck:
+                requestPath: /healthz
+                port: 13337
+          targetRef:
+            group: ""
+            kind: Service
+            name: ${service.metadata.name}
     - id: sandbox
       readyWhen: # CEL expressions to determine when a resource is ready
       - ${sandbox.status.conditions.exists(x, x.type == 'Ready' && x.status == "True")}

--- a/repo-agent/k8s/issue-sandbox-rgd.yaml
+++ b/repo-agent/k8s/issue-sandbox-rgd.yaml
@@ -45,12 +45,32 @@ spec:
       gateway:
         httpEnabled: boolean | default=false
         ref: string | default="repo-agent-gateway"
+      platform: string | default="generic"
     status:
       # Fields the controller will inject into instances status.
       # agentDraft: "${sandbox.metadata.name}"
       fqdn: ${service.metadata.name}.${service.metadata.namespace}.svc.cluster.local
       sandboxConditions: ${sandbox.status.conditions}
   resources:
+    - id: healthcheckPolicy
+      includeWhen:
+        - ${schema.spec.platform == 'gke'}
+      template:
+        apiVersion: networking.gke.io/v1
+        kind: HealthCheckPolicy
+        metadata:
+          name: devc-${schema.metadata.name}
+        spec:
+          default:
+            config:
+              type: HTTP
+              httpHealthCheck:
+                requestPath: /healthz
+                port: 13337
+          targetRef:
+            group: ""
+            kind: Service
+            name: ${service.metadata.name}
     - id: sandbox
       readyWhen: # CEL expressions to determine when a resource is ready
       - ${sandbox.status.conditions.exists(x, x.type == 'Ready' && x.status == "True")}

--- a/repo-agent/k8s/review-sandbox-rgd.yaml
+++ b/repo-agent/k8s/review-sandbox-rgd.yaml
@@ -38,6 +38,7 @@ spec:
         httpEnabled: boolean | default=false
         tcpEnabled: boolean | default=false
         ref: string | default="repo-agent-gateway"
+      platform: string | default="generic"
     status:
       # TODO (barney-s): 
       # Fields the controller will inject into instances status.
@@ -48,6 +49,25 @@ spec:
       fqdn: ${service.metadata.name}.${service.metadata.namespace}.svc.cluster.local
       sandboxConditions: ${sandbox.status.conditions}
   resources:
+    - id: healthcheckPolicy
+      includeWhen:
+        - ${schema.spec.platform == 'gke'}
+      template:
+        apiVersion: networking.gke.io/v1
+        kind: HealthCheckPolicy
+        metadata:
+          name: devc-${schema.metadata.name}
+        spec:
+          default:
+            config:
+              type: HTTP
+              httpHealthCheck:
+                requestPath: /healthz
+                port: 13337
+          targetRef:
+            group: ""
+            kind: Service
+            name: ${service.metadata.name}
     - id: sandbox
       readyWhen: # CEL expressions to determine when a resource is ready
       - ${sandbox.status.conditions.exists(x, x.type == 'Ready' && x.status == "True")}

--- a/repo-agent/review-sandbox/review-sandbox-rgd.yaml
+++ b/repo-agent/review-sandbox/review-sandbox-rgd.yaml
@@ -38,6 +38,7 @@ spec:
         httpEnabled: boolean | default=false
         tcpEnabled: boolean | default=false
         ref: string | default="repo-agent-gateway"
+      platform: string | default="generic"
     status:
       # TODO (barney-s): 
       # Fields the controller will inject into instances status.
@@ -48,6 +49,25 @@ spec:
       fqdn: ${service.metadata.name}.${service.metadata.namespace}.svc.cluster.local
       sandboxConditions: ${sandbox.status.conditions}
   resources:
+    - id: healthcheckPolicy
+      includeWhen:
+        - ${schema.spec.platform == 'gke'}
+      template:
+        apiVersion: networking.gke.io/v1
+        kind: HealthCheckPolicy
+        metadata:
+          name: devc-${schema.metadata.name}
+        spec:
+          default:
+            config:
+              type: HTTP
+              httpHealthCheck:
+                requestPath: /healthz
+                port: 13337
+          targetRef:
+            group: ""
+            kind: Service
+            name: ${service.metadata.name}
     - id: sandbox
       readyWhen: # CEL expressions to determine when a resource is ready
       - ${sandbox.status.conditions.exists(x, x.type == 'Ready' && x.status == "True")}


### PR DESCRIPTION
Fixes #219 

- Required to access sandbox code server
- GKE LBs by default hits / hence was failing since codeserver return 302 redirect for /
- Add HealthCheckPolicy to target /healthz instead
- This is needed only for platform=gke
- Add logic in RGD to conditionally install HealthCheckPolicy
- In Make based on platform, flip the RGD defaults
- In Make install the healthcheckpolicy CRD only for kind clusters so that RGD compiles (requires the CRDs to be present)
- make show-repo-agent-ip added
- update dev/deploy-to-kube to support --skip for conditionally skipping files