### PR TITLE
re-architect: Enable secure access to sandbox

### DIFF
--- a/repo-agent/dev-sandbox/dev-sandbox-rgd.yaml
+++ b/repo-agent/dev-sandbox/dev-sandbox-rgd.yaml
@@ -170,32 +170,4 @@ spec:
               targetPort: 13337
               appProtocol: kubernetes.io/ws
               #appProtocol: kubernetes.io/h2c
-    - id: httproute
-      includeWhen:
-        - ${schema.spec.gateway.httpEnabled} # Only include if the user wants to create an Gateway route
-      template:
-        apiVersion: gateway.networking.k8s.io/v1
-        kind: HTTPRoute
-        metadata:
-          name: devc-${schema.metadata.name} # Use the name provided by user
-        spec:
-          parentRefs:
-            - name: ${schema.spec.gateway.ref} # Reference to the Gateway created outside of this RGD
-              namespace: repo-agent-system
-          rules:
-            - backendRefs:
-                - name: ${service.metadata.name}
-                  port: 13338
-                  #group: ""
-                  #kind: Service
-                  #weight: 1
-              matches:
-                - path:
-                    type: PathPrefix
-                    value: /sandbox/${schema.metadata.namespace}/${schema.metadata.name} # Route path based on the name provided by user
-              filters:
-                - type: URLRewrite
-                  urlRewrite:
-                    path:
-                      type: ReplacePrefixMatch
-                      replacePrefixMatch: / # Repl
+

--- a/repo-agent/issue-sandbox/issue-sandbox-rgd.yaml
+++ b/repo-agent/issue-sandbox/issue-sandbox-rgd.yaml
@@ -201,32 +201,4 @@ spec:
             - namespaceSelector:
                 matchLabels: ${schema.spec.networkPolicy.ingress.namespaceLabels}
           egress: ${schema.spec.networkPolicy.egress}
-    - id: httproute
-      includeWhen:
-        - ${schema.spec.gateway.httpEnabled} # Only include if the user wants to create an Gateway route
-      template:
-        apiVersion: gateway.networking.k8s.io/v1
-        kind: HTTPRoute
-        metadata:
-          name: devc-${schema.metadata.name} # Use the name provided by user
-        spec:
-          parentRefs:
-            - name: ${schema.spec.gateway.ref} # Reference to the Gateway created outside of this RGD
-              namespace: repo-agent-system
-          rules:
-            - backendRefs:
-                - name: ${service.metadata.name}
-                  port: 13338
-                  #group: ""
-                  #kind: Service
-                  #weight: 1
-              matches:
-                - path:
-                    type: PathPrefix
-                    value: /sandbox/${schema.metadata.namespace}/${schema.metadata.name} # Route path based on the name provided by user
-              filters:
-                - type: URLRewrite
-                  urlRewrite:
-                    path:
-                      type: ReplacePrefixMatch
-                      replacePrefixMatch: / # Repl
+

--- a/repo-agent/k8s/dev-sandbox-rgd.yaml
+++ b/repo-agent/k8s/dev-sandbox-rgd.yaml
@@ -170,32 +170,4 @@ spec:
               targetPort: 13337
               appProtocol: kubernetes.io/ws
               #appProtocol: kubernetes.io/h2c
-    - id: httproute
-      includeWhen:
-        - ${schema.spec.gateway.httpEnabled} # Only include if the user wants to create an Gateway route
-      template:
-        apiVersion: gateway.networking.k8s.io/v1
-        kind: HTTPRoute
-        metadata:
-          name: devc-${schema.metadata.name} # Use the name provided by user
-        spec:
-          parentRefs:
-            - name: ${schema.spec.gateway.ref} # Reference to the Gateway created outside of this RGD
-              namespace: repo-agent-system
-          rules:
-            - backendRefs:
-                - name: ${service.metadata.name}
-                  port: 13338
-                  #group: ""
-                  #kind: Service
-                  #weight: 1
-              matches:
-                - path:
-                    type: PathPrefix
-                    value: /sandbox/${schema.metadata.namespace}/${schema.metadata.name} # Route path based on the name provided by user
-              filters:
-                - type: URLRewrite
-                  urlRewrite:
-                    path:
-                      type: ReplacePrefixMatch
-                      replacePrefixMatch: / # Repl
+

--- a/repo-agent/k8s/issue-sandbox-rgd.yaml
+++ b/repo-agent/k8s/issue-sandbox-rgd.yaml
@@ -201,32 +201,4 @@ spec:
             - namespaceSelector:
                 matchLabels: ${schema.spec.networkPolicy.ingress.namespaceLabels}
           egress: ${schema.spec.networkPolicy.egress}
-    - id: httproute
-      includeWhen:
-        - ${schema.spec.gateway.httpEnabled} # Only include if the user wants to create an Gateway route
-      template:
-        apiVersion: gateway.networking.k8s.io/v1
-        kind: HTTPRoute
-        metadata:
-          name: devc-${schema.metadata.name} # Use the name provided by user
-        spec:
-          parentRefs:
-            - name: ${schema.spec.gateway.ref} # Reference to the Gateway created outside of this RGD
-              namespace: repo-agent-system
-          rules:
-            - backendRefs:
-                - name: ${service.metadata.name}
-                  port: 13338
-                  #group: ""
-                  #kind: Service
-                  #weight: 1
-              matches:
-                - path:
-                    type: PathPrefix
-                    value: /sandbox/${schema.metadata.namespace}/${schema.metadata.name} # Route path based on the name provided by user
-              filters:
-                - type: URLRewrite
-                  urlRewrite:
-                    path:
-                      type: ReplacePrefixMatch
-                      replacePrefixMatch: / # Repl
+

--- a/repo-agent/k8s/review-sandbox-rgd.yaml
+++ b/repo-agent/k8s/review-sandbox-rgd.yaml
@@ -187,32 +187,4 @@ spec:
             - namespaceSelector:
                 matchLabels: ${schema.spec.networkPolicy.ingress.namespaceLabels}
           egress: ${schema.spec.networkPolicy.egress}
-    - id: httproute
-      includeWhen:
-        - ${schema.spec.gateway.httpEnabled} # Only include if the user wants to create an Gateway route
-      template:
-        apiVersion: gateway.networking.k8s.io/v1
-        kind: HTTPRoute
-        metadata:
-          name: devc-${schema.metadata.name} # Use the name provided by user
-        spec:
-          parentRefs:
-            - name: ${schema.spec.gateway.ref} # Reference to the Gateway created outside of this RGD
-              namespace: repo-agent-system
-          rules:
-            - backendRefs:
-                - name: ${service.metadata.name}
-                  port: 13338
-                  #group: ""
-                  #kind: Service
-                  #weight: 1
-              matches:
-                - path:
-                    type: PathPrefix
-                    value: /sandbox/${schema.metadata.namespace}/${schema.metadata.name} # Route path based on the name provided by user
-              filters:
-                - type: URLRewrite
-                  urlRewrite:
-                    path:
-                      type: ReplacePrefixMatch
-                      replacePrefixMatch: / # Repl
+

--- a/repo-agent/k8s/ui-gateway.yaml
+++ b/repo-agent/k8s/ui-gateway.yaml
@@ -36,6 +36,9 @@ spec:
     - path:
         type: PathPrefix
         value: /api
+    - path:
+        type: PathPrefix
+        value: /sandbox
     backendRefs:
     - name: pr-review-api
       port: 80

--- a/repo-agent/review-sandbox/review-sandbox-rgd.yaml
+++ b/repo-agent/review-sandbox/review-sandbox-rgd.yaml
@@ -187,32 +187,4 @@ spec:
             - namespaceSelector:
                 matchLabels: ${schema.spec.networkPolicy.ingress.namespaceLabels}
           egress: ${schema.spec.networkPolicy.egress}
-    - id: httproute
-      includeWhen:
-        - ${schema.spec.gateway.httpEnabled} # Only include if the user wants to create an Gateway route
-      template:
-        apiVersion: gateway.networking.k8s.io/v1
-        kind: HTTPRoute
-        metadata:
-          name: devc-${schema.metadata.name} # Use the name provided by user
-        spec:
-          parentRefs:
-            - name: ${schema.spec.gateway.ref} # Reference to the Gateway created outside of this RGD
-              namespace: repo-agent-system
-          rules:
-            - backendRefs:
-                - name: ${service.metadata.name}
-                  port: 13338
-                  #group: ""
-                  #kind: Service
-                  #weight: 1
-              matches:
-                - path:
-                    type: PathPrefix
-                    value: /sandbox/${schema.metadata.namespace}/${schema.metadata.name} # Route path based on the name provided by user
-              filters:
-                - type: URLRewrite
-                  urlRewrite:
-                    path:
-                      type: ReplacePrefixMatch
-                      replacePrefixMatch: / # Repl
+

--- a/repo-agent/review-ui/review-api/pkg/api/handlers_sandbox_proxy.go
+++ b/repo-agent/review-ui/review-api/pkg/api/handlers_sandbox_proxy.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/review-ui/review-api/pkg/auth"
+)
+
+func (s *Server) proxySandbox(c *gin.Context) {
+	namespace := c.Param("namespace")
+	name := c.Param("name")
+	// The path parameter will include the leading slash, e.g. "/some/file"
+	proxyPath := c.Param("path")
+
+	user := c.GetString(auth.UserKey)
+	if user == "" {
+		c.String(http.StatusUnauthorized, "Unauthorized")
+		return
+	}
+	if user != namespace {
+		c.String(http.StatusUnauthorized, "Unauthorized")
+		log.Printf("Unauthorized access %s for %s", user, c.Request.URL.String())
+		return
+	}
+
+	// The sandbox service name pattern from RGD: devc-<name>-lb
+	targetHost := fmt.Sprintf("devc-%s-lb.%s.svc.cluster.local:13338", name, namespace)
+
+	targetURL := &url.URL{
+		Scheme: "http",
+		Host:   targetHost,
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(targetURL)
+
+	//This forces the proxy to flush data to the client immediately after writing to the response body, instead of
+	// buffering. This is crucial for interactive applications and streaming protocols, ensuring low latency.
+	proxy.FlushInterval = -1
+
+	// Customize the director to rewrite the path and set headers
+	originalDirector := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		originalDirector(req)
+
+		// Set the Host header to the target service
+		req.Host = targetHost
+
+		// Rewrite the path.
+		// The request coming in is /sandbox/:namespace/:name/*path
+		// The target expects /*path (from root)
+		req.URL.Path = proxyPath
+
+		// If the path was empty or just "/", proxyPath might be "/" or empty depending on Gin.
+		// Ensure we don't send empty path if root is requested.
+		if req.URL.Path == "" {
+			req.URL.Path = "/"
+		}
+
+		// Strip Origin header to prevent VS Code Server from rejecting the request due to CORS/Origin mismatch
+		// VS Code Server (and many other web applications) strictly validates the Origin header against the Host header to
+		// prevent CSRF. Since the proxy changes the Host header to the internal service name but the browser sends the external
+		// Origin, this mismatch often causes the backend to reject the connection (especially WebSocket upgrades) immediately,
+		// leading to a 1006 Close error. Removing it forces the backend to treat it as a same-origin request or skip the check.
+		req.Header.Del("Origin")
+
+		// Set X-Forwarded headers
+		// Explicitly setting X-Forwarded-Host and X-Forwarded-Proto allows the backend to know the original external URL, which
+		// is often needed for generating correct self-referencing links or redirects
+		req.Header.Set("X-Forwarded-Host", c.Request.Host)
+		if c.Request.TLS != nil {
+			req.Header.Set("X-Forwarded-Proto", "https")
+		} else {
+			req.Header.Set("X-Forwarded-Proto", "http")
+		}
+	}
+
+	// Error handling
+	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+		// Log the error
+		log.Printf("Proxy error for URL %s: %v\n", r.URL.String(), err)
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(fmt.Sprintf("Bad Gateway: %v", err)))
+	}
+
+	proxy.ServeHTTP(c.Writer, c.Request)
+}

--- a/repo-agent/review-ui/review-api/pkg/api/server.go
+++ b/repo-agent/review-ui/review-api/pkg/api/server.go
@@ -29,22 +29,24 @@ func NewServer(manager *k8s.Manager, authenticator *auth.Authenticator, store st
 }
 
 func (s *Server) RegisterRoutes(router *gin.Engine) {
+	// Standard group for routes that require logging (non-streaming/non-websocket)
+	standard := router.Group("/")
 	// Add middleware to log requests and responses
-	router.Use(RequestLoggerMiddleware())
-	router.Use(ResponseLoggerMiddleware())
+	standard.Use(RequestLoggerMiddleware())
+	standard.Use(ResponseLoggerMiddleware())
 
 	// Public routes
-	router.GET("/", s.healthCheckOk)
-	router.GET("/api/", s.healthCheckOk)
-	router.GET("/api/auth/login", s.Auth.Login)
-	router.GET("/api/auth/callback", s.Auth.Callback)
-	router.GET("/api/auth/status", s.Auth.Status)
-	router.POST("/api/auth/logout", s.Auth.Logout)
-	router.GET("/api/auth/providers", s.Auth.GetProviders)
-	router.POST("/api/auth/github-config", s.Auth.UpdateGithubConfig)
+	standard.GET("/", s.healthCheckOk)
+	standard.GET("/api/", s.healthCheckOk)
+	standard.GET("/api/auth/login", s.Auth.Login)
+	standard.GET("/api/auth/callback", s.Auth.Callback)
+	standard.GET("/api/auth/status", s.Auth.Status)
+	standard.POST("/api/auth/logout", s.Auth.Logout)
+	standard.GET("/api/auth/providers", s.Auth.GetProviders)
+	standard.POST("/api/auth/github-config", s.Auth.UpdateGithubConfig)
 
 	// Protected routes
-	api := router.Group("/api")
+	api := standard.Group("/api")
 	api.Use(s.Auth.Middleware())
 	{
 		api.GET("/repos", s.getRepos)
@@ -74,6 +76,15 @@ func (s *Server) RegisterRoutes(router *gin.Engine) {
 		api.POST("/repo/:repo/dev/:name/scaleup", s.scaleUpDevSandbox)
 		api.POST("/repo/:repo/dev/:name/scaledown", s.scaleDownDevSandbox)
 		api.GET("/proxy", s.proxy)
+	}
+
+	// Protected sandbox proxy routes
+	// These are attached directly to router to bypass the logging middleware which buffers responses
+	// and breaks WebSockets/Streaming.
+	sandbox := router.Group("/sandbox")
+	sandbox.Use(s.Auth.Middleware())
+	{
+		sandbox.Any("/:namespace/:name/*path", s.proxySandbox)
 	}
 }
 

--- a/repo-agent/review-ui/review-api/pkg/auth/auth.go
+++ b/repo-agent/review-ui/review-api/pkg/auth/auth.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-contrib/sessions"
@@ -25,10 +26,11 @@ const (
 )
 
 type Authenticator struct {
-	OAuthConfig  *oauth2.Config
-	OAuthState   string
-	K8sManager   *k8s.Manager
-	AllowedUsers []string
+	OAuthConfig       *oauth2.Config
+	OAuthState        string
+	K8sManager        *k8s.Manager
+	AllowedUsers      []string
+	bootstrappedUsers sync.Map
 }
 
 func NewAuthenticator(manager *k8s.Manager, allowedUsers []string) *Authenticator {
@@ -250,9 +252,22 @@ func (a *Authenticator) Middleware() gin.HandlerFunc {
 			user = userVal.(string)
 		}
 
-		// Lazy bootstrap checks if namespace exists, creating it if needed.
-		if err := a.K8sManager.BootstrapNamespace(c.Request.Context(), user); err != nil {
-			log.Printf("Lazy bootstrap failed for user %s: %v", user, err)
+		// The Auth.Middleware is calling BootstrapNamespace (which makes ~10 Kubernetes API calls) for every single request.
+		// When loading the VS Code UI, the browser requests hundreds of static assets (JS, CSS, icons). This triggers
+		//  thousands of K8s API calls in seconds, causing the client to throttle itself and eventually timing out the requests
+		// (context canceled, 502/504 errors).
+		// Use in-memory cache (sync.Map) for the Authenticator.
+		// First Request: The middleware checks the cache, finds it empty for the user, calls BootstrapNamespace once, and stores
+		//   the result.
+		// Subsequent Requests: The middleware finds the user in the cache and skips the K8s operations entirely.
+		// dramatically reduce latency and eliminate the 502/504 errors caused by client-side throttling, allowing the VS Code UI to load correctly
+		if _, ok := a.bootstrappedUsers.Load(user); !ok {
+			// Lazy bootstrap checks if namespace exists, creating it if needed.
+			if err := a.K8sManager.BootstrapNamespace(c.Request.Context(), user); err != nil {
+				log.Printf("Lazy bootstrap failed for user %s: %v", user, err)
+			} else {
+				a.bootstrappedUsers.Store(user, true)
+			}
 		}
 
 		c.Set(UserKey, user)


### PR DESCRIPTION
Also fixes #219 
Obsoletes #220 

We are completely rearchitecting sandbox access. Earlier we used a HTTPRoute to route to each sandbox. But the route /sandbox/... was not protected by authentication. To make the access of sanbox secure and protected we need to rearchitect it.

### Architecture Change:

* Instead of having each Sandbox RGD create its own HTTPRoute pointing directly to the sandbox service, we now route all /sandbox/... traffic to the review-api service via the main Gateway.
* `review-api` Proxy: Add a new proxy handler in review-api that authenticates the request and then transparently forwards it to the correct internal sandbox service (devc-<name>-lb.<namespace>.svc.cluster.local).
* Cleanup: Removed the direct (unprotected) HTTPRoute definitions from the RGDs (review-sandbox, dev-sandbox, and issue-sandbox).

### Detailed Changes:

1. Modified `@k8s/ui-gateway.yaml`:
  * Updated the pr-review-api rule to match /sandbox in addition to /api. This ensures the Gateway sends sandbox traffic to your API service.

2. Updated `review-api`:
  * New File `@review-ui/review-api/pkg/api/handlers_sandbox_proxy.go`: Implemented proxySandbox, a handler that parses the namespace and name from the URL, constructs the internal service DNS name, and uses httputil.ReverseProxy to forward the request. It correctly handles path rewriting (stripping the /sandbox/ns/name prefix).
  * Modified `@review-ui/review-api/pkg/api/server.go`: Registered the new protected route group:

3. Updated RGDs:
  * Removed the httproute resource definition from:
    * @review-sandbox/review-sandbox-rgd.yaml
    * @dev-sandbox/dev-sandbox-rgd.yaml
    * @issue-sandbox/issue-sandbox-rgd.yaml

### New access

Now, when a user accesses https://<gateway>/sandbox/namespace/name, the request is:
1. Received by the Gateway.
2. Routed to review-api.
3. Authenticated by your existing AuthMiddleware.
4. Proxied to the specific sandbox service within the cluster.