### PR TITLE
feat: option to swap default llm provider

### DIFF
--- a/repo-agent/Makefile
+++ b/repo-agent/Makefile
@@ -6,6 +6,8 @@ LOCAL_PORT ?= 13380
 CLUSTER_NAME != kubectl config view --minify --output 'jsonpath={.clusters[0].name}'
 INSTALL_ENVOY = $(shell if [[ ${CLUSTER_NAME} == kind* ]]; then echo "yes"; else echo "no"; fi)
 GW_CLASS = $(shell if [[ ${CLUSTER_NAME} == kind* ]]; then echo "repo-agent-gatewayclass"; else echo "gke-l7-regional-external-managed"; fi)
+LLM_PROVIDER ?= gemini-cli
+DEFAULT_LLM_PROVIDER = $(shell if [[ ${CLUSTER_NAME} == kind* ]]; then echo ${LLM_PROVIDER}; else echo "gemini-cli"; fi)
 
 # if REGISTRY is kind.local/, then we are deploying to kind
 ifeq ($(REGISTRY), kind.local/)
@@ -122,7 +124,10 @@ install-repo-agent:
 	cp dev-sandbox/dev-sandbox-rgd.yaml k8s/
 	../dev/tools/deploy-to-kube --image-prefix=$(REGISTRY) --working-dir . \
 	--replace .spec.installationName=${CLUSTER_NAME} \
-	--replace .spec.gatewayClassName=${GW_CLASS}
+	--replace .spec.gatewayClassName=${GW_CLASS} \
+	--replace .spec.versions[].schema.openAPIV3Schema.properties.spec.properties.dev.properties.llm.properties.provider.default=${DEFAULT_LLM_PROVIDER} \
+	--replace .spec.versions[].schema.openAPIV3Schema.properties.spec.properties.review.properties.llm.properties.provider.default=${DEFAULT_LLM_PROVIDER} \
+	--replace .spec.versions[].schema.openAPIV3Schema.properties.spec.properties.issueHandlers.items.properties.llm.properties.provider.default=${DEFAULT_LLM_PROVIDER}
 
 bin/tls.crt:
 	openssl req -x509 -nodes -days 365 -newkey rsa:2048  -keyout bin/tls.key -out bin/tls.crt  -subj "/CN=repo-agent"

--- a/repo-agent/review-ui/review-api/pkg/api/handlers_repo.go
+++ b/repo-agent/review-ui/review-api/pkg/api/handlers_repo.go
@@ -116,7 +116,6 @@ spec:
     devcontainerConfigRef: devcontainer-json
     llm:
       apiKeySecretRef: gemini-vscode-tokens
-      provider: gemini-cli
   review:
     preferAssignedToSelf: true
     reviewShutdownAfterMinutes: 30
@@ -131,7 +130,6 @@ spec:
         1. Does the fix resolve the original problem.
         2. Look for linked issues to understand the original problem.
         3. Are there tests to check the fix.
-      provider: gemini-cli
     maxActiveSandboxes: 3
     maxSandboxes: 5
   issueHandlers:
@@ -164,7 +162,6 @@ spec:
           Issue Title: "{{.Title}}"
           Issue Body: "{{.Body}}"
           HTML URL: "{{.HTMLURL}}"
-        provider: gemini-cli
       issueShutdownAfterMinutes: 30
       maxActiveSandboxes: 1
       maxSandboxes: 3


### PR DESCRIPTION
why: when testing on kind we end up using LLM quota for tests

- Only for kind installations
- usage: `LLM_PROVIDER=dummy make`
  - swaps the default LLM provider to dummy when adding repo via UI
- when not set the default is `gemini-cli`