### PR TITLE
ui: improve review flairs and sandbox state

### DIFF
--- a/repo-agent/k8s/dev-sandbox-rbac.yaml
+++ b/repo-agent/k8s/dev-sandbox-rbac.yaml
@@ -19,6 +19,7 @@ rules:
   verbs:
   - get
   - update
+  - patch
 - apiGroups:
   - "configdir.gke.io"
   resources:

--- a/repo-agent/k8s/issue-sandbox-rbac.yaml
+++ b/repo-agent/k8s/issue-sandbox-rbac.yaml
@@ -19,6 +19,7 @@ rules:
   verbs:
   - get
   - update
+  - patch
 - apiGroups:
   - "configdir.gke.io"
   resources:

--- a/repo-agent/k8s/review-sandbox-rbac.yaml
+++ b/repo-agent/k8s/review-sandbox-rbac.yaml
@@ -19,6 +19,7 @@ rules:
   verbs:
   - get
   - update
+  - patch
 - apiGroups:
   - "configdir.gke.io"
   resources:

--- a/repo-agent/pkg/agentoutput/watcher.go
+++ b/repo-agent/pkg/agentoutput/watcher.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"time"
 
@@ -137,8 +138,10 @@ func SetAgentState(gvr schema.GroupVersionResource, state string, message string
 		return err
 	}
 
+	log.Printf("patching resource %s/%s with: %s\n", namespace, name, patchBytes)
 	_, err = dc.Resource(gvr).Namespace(namespace).Patch(context.TODO(), name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
+		log.Printf("error patching resource %s/%s: %v\n", namespace, name, err)
 		return err
 	}
 	return nil

--- a/repo-agent/pkg/llm/dummy.go
+++ b/repo-agent/pkg/llm/dummy.go
@@ -61,7 +61,7 @@ func (d *Dummy) response(prompt string) []byte {
 
 func (d *Dummy) Run(prompt string) ([]byte, error) {
 	var err error
-	log.Printf("Dummy provider run with prompt: %s", prompt)
+	log.Printf("Dummy provider running with prompt")
 	output := d.response(prompt)
 	for _, p := range d.processors {
 		output, err = p(output)

--- a/repo-agent/review-ui/review-api/pkg/api/handlers_pr.go
+++ b/repo-agent/review-ui/review-api/pkg/api/handlers_pr.go
@@ -85,24 +85,39 @@ func (s *Server) fetchAndPopulatePRs(ctx context.Context, namespace, repo string
 
 		// get draft from annotation[agentDraft]
 		draft := ""
+		agentState := ""
+		agentStateMessage := ""
+		reviewState := ""
 		annotations := item.GetAnnotations()
 		if annotations == nil {
-			log.Printf("agentDraft (annotations=nil) not found in ReviewSandbox %s", item.GetName())
-		} else if _, ok := annotations["agentDraft"]; !ok {
-			log.Printf("agentDraft (annotations[agentDraft]) not found in ReviewSandbox %s", item.GetName())
+			log.Printf("annotations (annotations=nil) not found in ReviewSandbox %s", item.GetName())
 		} else {
-			draft = annotations["agentDraft"]
+			if val, ok := annotations["agentDraft"]; ok {
+				draft = val
+			}
+			if val, ok := annotations["agentState"]; ok {
+				agentState = val
+			}
+			if val, ok := annotations["agentStateMessage"]; ok {
+				agentStateMessage = val
+			}
+			if val, ok := annotations["reviewState"]; ok {
+				reviewState = val
+			}
 		}
 
 		pr := models.PR{
-			ID:             prID,
-			Title:          title,
-			Sandbox:        item.GetName(),
-			HTMLURL:        htmlurl,
-			DiffURL:        diffurl,
-			SandboxReplica: fmt.Sprintf("%d", replicas),
-			Draft:          draft,
-			AgentDraft:     draft,
+			ID:                prID,
+			Title:             title,
+			Sandbox:           item.GetName(),
+			HTMLURL:           htmlurl,
+			DiffURL:           diffurl,
+			SandboxReplica:    fmt.Sprintf("%d", replicas),
+			Draft:             draft,
+			AgentDraft:        draft,
+			AgentState:        agentState,
+			AgentStateMessage: agentStateMessage,
+			ReviewState:       reviewState,
 		}
 
 		if err := s.Store.SavePR(ctx, namespace, repo, pr); err != nil {
@@ -259,6 +274,12 @@ func (s *Server) submitReview(c *gin.Context) {
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to scaledown Sandbox after review submission", "details": err.Error()})
 		return
+	}
+
+	if sandboxName != "" {
+		if err := s.K8sManager.UpdateReviewSandboxAnnotation(ctx, namespace, sandboxName, "reviewState", "submitted"); err != nil {
+			log.Printf("Failed to update reviewState annotation for PR %s in repo %s: %v", prID, repo, err)
+		}
 	}
 
 	c.Status(http.StatusOK)

--- a/repo-agent/review-ui/review-api/pkg/k8s/k8s.go
+++ b/repo-agent/review-ui/review-api/pkg/k8s/k8s.go
@@ -333,6 +333,33 @@ func (m *Manager) UpdateReviewSandboxUserDraft(ctx context.Context, namespace, s
 	return nil
 }
 
+func (m *Manager) UpdateReviewSandboxAnnotation(ctx context.Context, namespace, sandboxName, key, value string) error {
+	gvr := schema.GroupVersionResource{
+		Group:    "custom.agents.x-k8s.io",
+		Version:  "v1alpha1",
+		Resource: "reviewsandboxes",
+	}
+
+	sandbox, err := m.Client.Resource(gvr).Namespace(namespace).Get(ctx, sandboxName, v1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get reviewsandbox %s: %w", sandboxName, err)
+	}
+
+	if sandbox.GetAnnotations() == nil {
+		sandbox.SetAnnotations(make(map[string]string))
+	}
+	annotations := sandbox.GetAnnotations()
+	annotations[key] = value
+	sandbox.SetAnnotations(annotations)
+
+	_, err = m.Client.Resource(gvr).Namespace(namespace).Update(ctx, sandbox, v1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to update reviewsandbox annotation: %w", err)
+	}
+
+	return nil
+}
+
 func (m *Manager) GetGitHubToken(ctx context.Context, repoWatch *unstructured.Unstructured) (string, error) {
 	secretName, found, err := unstructured.NestedString(repoWatch.Object, "spec", "githubSecretName")
 	if err != nil || !found {

--- a/repo-agent/review-ui/review-api/pkg/models/models.go
+++ b/repo-agent/review-ui/review-api/pkg/models/models.go
@@ -12,15 +12,18 @@ type AgentOutput struct {
 
 // PR represents a pull request
 type PR struct {
-	ID             string `json:"id"`
-	Title          string `json:"title"`
-	Draft          string `json:"draft,omitempty"`
-	Sandbox        string `json:"sandbox,omitempty"`
-	SandboxReplica string `json:"sandboxReplica,omitempty"`
-	Review         string `json:"review,omitempty"`
-	HTMLURL        string `json:"htmlURL,omitempty"`
-	DiffURL        string `json:"diffURL,omitempty"`
-	AgentDraft     string `json:"agentDraft,omitempty"`
+	ID                string `json:"id"`
+	Title             string `json:"title"`
+	Draft             string `json:"draft,omitempty"`
+	Sandbox           string `json:"sandbox,omitempty"`
+	SandboxReplica    string `json:"sandboxReplica,omitempty"`
+	Review            string `json:"review,omitempty"`
+	HTMLURL           string `json:"htmlURL,omitempty"`
+	DiffURL           string `json:"diffURL,omitempty"`
+	AgentDraft        string `json:"agentDraft,omitempty"`
+	AgentState        string `json:"agentState,omitempty"`
+	AgentStateMessage string `json:"agentStateMessage,omitempty"`
+	ReviewState       string `json:"reviewState,omitempty"`
 }
 
 // Issue represents a GitHub issue

--- a/repo-agent/review-ui/review-api/pkg/store/redis.go
+++ b/repo-agent/review-ui/review-api/pkg/store/redis.go
@@ -316,6 +316,15 @@ func (s *RedisStore) ListPRs(ctx context.Context, namespace, repo string) ([]mod
 		if val, ok := prData["agentDraft"]; ok {
 			pr.AgentDraft = val
 		}
+		if val, ok := prData["agentState"]; ok {
+			pr.AgentState = val
+		}
+		if val, ok := prData["agentStateMessage"]; ok {
+			pr.AgentStateMessage = val
+		}
+		if val, ok := prData["reviewState"]; ok {
+			pr.ReviewState = val
+		}
 		prs = append(prs, pr)
 	}
 	if err := iter.Err(); err != nil {
@@ -335,6 +344,9 @@ func (s *RedisStore) SavePR(ctx context.Context, namespace, repo string, pr mode
 		"sandboxReplica", pr.SandboxReplica,
 		"draft", pr.Draft,
 		"agentDraft", pr.AgentDraft,
+		"agentState", pr.AgentState,
+		"agentStateMessage", pr.AgentStateMessage,
+		"reviewState", pr.ReviewState,
 	).Err()
 }
 
@@ -373,6 +385,15 @@ func (s *RedisStore) GetPR(ctx context.Context, namespace, repo, prID string) (*
 	}
 	if val, ok := prData["agentDraft"]; ok {
 		pr.AgentDraft = val
+	}
+	if val, ok := prData["agentState"]; ok {
+		pr.AgentState = val
+	}
+	if val, ok := prData["agentStateMessage"]; ok {
+		pr.AgentStateMessage = val
+	}
+	if val, ok := prData["reviewState"]; ok {
+		pr.ReviewState = val
 	}
 
 	return pr, nil

--- a/repo-agent/review-ui/ui/src/PrReviewCard.js
+++ b/repo-agent/review-ui/ui/src/PrReviewCard.js
@@ -35,30 +35,29 @@ function PrReviewCard({
   const lastDragTargetRef = useRef(null);
 
   const getReviewFlairColor = (flairText) => {
-    switch (flairText) {
-      case 'Ready':
-        return 'green';
-      case 'Generating ...':
-        return 'orange';
-      case 'Submitted':
-        return '#3f5398ff';
-      default:
-        return '#3e7f67ff'; // Default color
-    }
+    if (!flairText) return '#3e7f67ff';
+    const text = flairText.toLowerCase();
+    if (text === 'done') return 'green';
+    if (text.includes('reviewing')) return 'orange';
+    if (text.includes('error')) return '#9e2a2aff';
+    if (text === 'submitted') return '#3f5398ff';
+    return '#cd9945ff'; // Default color
   };
 
   const isCollapsed = collapsedReviews[pr.id];
   useEffect(() => {
     if (pr.type === 'pending' || pr.type === 'excluded') return;
 
-    if (pr.review) {
+    if (pr.reviewState === 'submitted' || pr.review) {
       setReviewFlairText('Submitted');
+    } else if (pr.agentState) {
+      setReviewFlairText(pr.agentState);
     } else if (drafts[pr.id] && drafts[pr.id].note && drafts[pr.id].note.trim() !== '') {
       setReviewFlairText('Ready');
     } else {
       setReviewFlairText('Generating ...');
     }
-  }, [pr.review, drafts, pr.id, pr.type]);
+  }, [pr.review, drafts, pr.id, pr.type, pr.agentState, pr.reviewState]);
 
   useEffect(() => {
     if (pr.type === 'pending' || pr.type === 'excluded') return;
@@ -409,16 +408,25 @@ function PrReviewCard({
           </span>
         </h3>
         <div className="pr-card-actions-header">
-          {reviewFlairText && (
-            <span style={{ marginRight: '10px', backgroundColor: getReviewFlairColor(reviewFlairText), color: 'white', padding: '5px 10px', borderRadius: '5px', fontSize: 'small' }}>
+          {reviewFlairText && pr.agentState !== 'provisioning' && (
+            <span 
+              style={{ marginRight: '10px', backgroundColor: getReviewFlairColor(reviewFlairText), color: 'white', padding: '5px 10px', borderRadius: '5px', fontSize: 'small' }}
+              title={pr.agentStateMessage || ''}
+            >
               {reviewFlairText}
             </span>
           )}
           {getSandboxStatusClass(pr) === 'green' ? (
             <div style={{display: 'flex', alignItems: 'center', gap: '5px'}}>
-              <a href={`/sandbox/${namespace}/${pr.sandbox}/`} target="_blank" rel="noopener noreferrer" className={`pr-sandbox ${getSandboxStatusClass(pr)}`}>
-                Sandbox Active
-              </a>
+              {pr.agentState === 'provisioning' ? (
+                <span className="pr-sandbox" style={{backgroundColor: '#2196F3', color: 'white', cursor: 'default'}}>
+                  Sandbox Provisioning
+                </span>
+              ) : (
+                <a href={`/sandbox/${namespace}/${pr.sandbox}/`} target="_blank" rel="noopener noreferrer" className={`pr-sandbox ${getSandboxStatusClass(pr)}`}>
+                  Sandbox Active
+                </a>
+              )}
               <button className="btn btn-sm pr-sandbox yellow" style={{padding: '4px 10px', fontSize: '14px'}} onClick={(e) => { e.stopPropagation(); handleScaleDown(pr.id); }} title="Scale Down">
                 &#9646;&#9646;
               </button>


### PR DESCRIPTION
- missing patch permissions added for all sandboxes
- dummy provider was verbose with logging the prompt. removed that
- return agentState, reviewState via api. Update models.
- add k8s api to update sandbox annotation
- update redis provider to handle changes in PR model
- UI:
  - Change PR flair to display agentState
  - Change PR sandbox flair to not link to sandbox when provisioning


<img width="754" height="1044" alt="image" src="https://github.com/user-attachments/assets/d34a5d3e-76bf-4de0-b8d6-d5811cbd8308" />
