### PR TITLE
feat: UI to update/approve instructions

### DIFF
--- a/repo-agent/review-ui/review-api/pkg/api/server.go
+++ b/repo-agent/review-ui/review-api/pkg/api/server.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"log"
+	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/review-ui/review-api/pkg/auth"
@@ -11,6 +12,7 @@ import (
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/review-ui/review-api/pkg/store"
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/review-ui/review-api/pkg/templates"
 	"github.com/go-redis/redis/v8"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 type Server struct {
@@ -59,6 +61,8 @@ func (s *Server) RegisterRoutes(router *gin.Engine) {
 		api.GET("/repos/:repo/yaml", s.getRepoWatchYAML)
 		api.PUT("/repos/:repo", s.updateRepoWatch)
 		api.DELETE("/repos/:repo", s.deleteRepoWatch)
+		api.GET("/repos/:repo/instructions", s.getInstructions)
+		api.POST("/repos/:repo/instructions", s.updateInstructions)
 
 		api.GET("/settings", s.getSettings)
 		api.POST("/settings", s.updateSettings)
@@ -132,4 +136,123 @@ func ResponseLoggerMiddleware() gin.HandlerFunc {
 		log.Printf("Response Headers: %v\n", c.Writer.Header())
 		log.Printf("Response Body: %s\n", blw.body.String())
 	}
+}
+
+func (s *Server) getInstructions(c *gin.Context) {
+	repoName := c.Param("repo")
+	user := s.Auth.GetUserFromContext(c)
+	namespace := user // Assuming tenant model where user == namespace
+	if user == "" {
+		namespace = "default"
+	}
+
+	rw, err := s.K8sManager.GetRepoWatch(c.Request.Context(), namespace, repoName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get RepoWatch", "details": err.Error()})
+		return
+	}
+
+	configDirRef, found, err := unstructured.NestedString(rw.Object, "spec", "review", "llm", "configdirRef")
+	if err != nil || !found {
+		// Try root level or other locations if structure varies?
+		// Assuming standard structure for now.
+		c.JSON(http.StatusNotFound, gin.H{"error": "ConfigDirRef not found in RepoWatch spec"})
+		return
+	}
+
+	cd, err := s.K8sManager.GetConfigDir(c.Request.Context(), namespace, configDirRef)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get ConfigDir", "details": err.Error()})
+		return
+	}
+
+	files, found, err := unstructured.NestedSlice(cd.Object, "spec", "files")
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to read files from ConfigDir", "details": err.Error()})
+		return
+	}
+
+	var current, draft string
+	if found {
+		for _, f := range files {
+			fileMap, ok := f.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			path, _, _ := unstructured.NestedString(fileMap, "path")
+			content, _, _ := unstructured.NestedString(fileMap, "source", "inline")
+
+			if path == ".gemini/user-instructions.json" {
+				current = content
+			} else if path == ".gemini/user-instructions.draft.json" {
+				draft = content
+			}
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"current": current,
+		"draft":   draft,
+	})
+}
+
+func (s *Server) updateInstructions(c *gin.Context) {
+	repoName := c.Param("repo")
+	user := s.Auth.GetUserFromContext(c)
+	namespace := user
+	if user == "" {
+		namespace = "default"
+	}
+
+	var req struct {
+		Current string `json:"current"`
+		Draft   string `json:"draft"`
+		Action  string `json:"action"` // "save_draft", "publish", "discard_draft"
+	}
+
+	if err := c.BindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+
+	rw, err := s.K8sManager.GetRepoWatch(c.Request.Context(), namespace, repoName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get RepoWatch", "details": err.Error()})
+		return
+	}
+
+	configDirRef, found, err := unstructured.NestedString(rw.Object, "spec", "review", "llm", "configdirRef")
+	if err != nil || !found {
+		c.JSON(http.StatusNotFound, gin.H{"error": "ConfigDirRef not found in RepoWatch spec"})
+		return
+	}
+
+	switch req.Action {
+	case "save_draft":
+		if err := s.K8sManager.UpdateConfigDirFile(c.Request.Context(), namespace, configDirRef, ".gemini/user-instructions.draft.json", req.Draft); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save draft", "details": err.Error()})
+			return
+		}
+	case "discard_draft":
+		if err := s.K8sManager.UpdateConfigDirFile(c.Request.Context(), namespace, configDirRef, ".gemini/user-instructions.draft.json", ""); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to discard draft", "details": err.Error()})
+			return
+		}
+	case "publish":
+		// Update current
+		if err := s.K8sManager.UpdateConfigDirFile(c.Request.Context(), namespace, configDirRef, ".gemini/user-instructions.json", req.Current); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update current instructions", "details": err.Error()})
+			return
+		}
+		// Remove draft
+		if err := s.K8sManager.UpdateConfigDirFile(c.Request.Context(), namespace, configDirRef, ".gemini/user-instructions.draft.json", ""); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to remove draft", "details": err.Error()})
+			return
+		}
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid action"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": "success"})
 }

--- a/repo-agent/review-ui/review-api/pkg/auth/auth.go
+++ b/repo-agent/review-ui/review-api/pkg/auth/auth.go
@@ -275,3 +275,14 @@ func (a *Authenticator) Middleware() gin.HandlerFunc {
 		c.Next()
 	}
 }
+
+func (a *Authenticator) GetUserFromContext(c *gin.Context) string {
+	val, exists := c.Get(UserKey)
+	if !exists {
+		return ""
+	}
+	if user, ok := val.(string); ok {
+		return user
+	}
+	return ""
+}

--- a/repo-agent/review-ui/review-api/pkg/k8s/k8s.go
+++ b/repo-agent/review-ui/review-api/pkg/k8s/k8s.go
@@ -28,6 +28,14 @@ const (
 	ManualPATKey     = "manual_pat"
 )
 
+var (
+	ConfigDirGVR = schema.GroupVersionResource{
+		Group:    "configdir.gke.io",
+		Version:  "v1alpha1",
+		Resource: "configdirs",
+	}
+)
+
 type Manager struct {
 	Client    dynamic.Interface
 	Clientset *kubernetes.Clientset
@@ -36,6 +44,71 @@ type Manager struct {
 
 func NewManager(client dynamic.Interface, clientset *kubernetes.Clientset, rdb *redis.Client) *Manager {
 	return &Manager{Client: client, Clientset: clientset, Redis: rdb}
+}
+
+func (m *Manager) GetConfigDir(ctx context.Context, namespace, name string) (*unstructured.Unstructured, error) {
+	return m.Client.Resource(ConfigDirGVR).Namespace(namespace).Get(ctx, name, v1.GetOptions{})
+}
+
+func (m *Manager) UpdateConfigDirFile(ctx context.Context, namespace, name, filePath, content string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		cd, err := m.GetConfigDir(ctx, namespace, name)
+		if err != nil {
+			return err
+		}
+
+		files, found, err := unstructured.NestedSlice(cd.Object, "spec", "files")
+		if err != nil {
+			return err
+		}
+		if !found {
+			files = make([]interface{}, 0)
+		}
+
+		newFiles := make([]interface{}, 0, len(files))
+		updated := false
+
+		for _, f := range files {
+			fileMap, ok := f.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			path, _, _ := unstructured.NestedString(fileMap, "path")
+			if path == filePath {
+				if content == "" {
+					// Delete file
+					updated = true
+					continue
+				}
+				// Update file
+				if err := unstructured.SetNestedField(fileMap, content, "source", "inline"); err != nil {
+					return err
+				}
+				newFiles = append(newFiles, fileMap)
+				updated = true
+				continue
+			}
+			newFiles = append(newFiles, fileMap)
+		}
+
+		if !updated && content != "" {
+			// Add new file
+			newFile := map[string]interface{}{
+				"path": filePath,
+				"source": map[string]interface{}{
+					"inline": content,
+				},
+			}
+			newFiles = append(newFiles, newFile)
+		}
+
+		if err := unstructured.SetNestedSlice(cd.Object, newFiles, "spec", "files"); err != nil {
+			return err
+		}
+
+		_, err = m.Client.Resource(ConfigDirGVR).Namespace(namespace).Update(ctx, cd, v1.UpdateOptions{})
+		return err
+	})
 }
 
 func (m *Manager) BootstrapNamespace(ctx context.Context, targetNS string) error {

--- a/repo-agent/review-ui/ui/src/App.js
+++ b/repo-agent/review-ui/ui/src/App.js
@@ -36,6 +36,7 @@ function App() {
   const [reviewViewModes, setReviewViewModes] = useState({});
   const [yamlDrafts, setYamlDrafts] = useState({});
   const [lastUpdated, setLastUpdated] = useState(null);
+  const [hasInstructionDraft, setHasInstructionDraft] = useState(false);
 
   useEffect(() => {
     document.body.className = theme === 'dark' ? 'dark-mode' : '';
@@ -66,6 +67,25 @@ function App() {
       })
       .catch(err => console.error("Failed to fetch auth providers:", err));
   }, []);
+
+  useEffect(() => {
+    if (activeRepo && (isAuthenticated || isGuest)) {
+        fetch(`/api/repos/${activeRepo.name}/instructions`)
+            .then(res => {
+                if (res.ok) return res.json();
+                throw new Error("Failed to fetch instructions");
+            })
+            .then(data => {
+                setHasInstructionDraft(!!data.draft);
+            })
+            .catch(err => {
+                console.error("Failed to check instructions draft:", err);
+                setHasInstructionDraft(false);
+            });
+    } else {
+        setHasInstructionDraft(false);
+    }
+  }, [activeRepo, isAuthenticated, isGuest]);
 
   const handleGithubConfigSubmit = (e) => {
     e.preventDefault();
@@ -925,7 +945,10 @@ function App() {
             <div className="repo-controls">
                 <button className="btn btn-refresh-lg" onClick={() => refreshData(true)} title="Refresh now">↻</button>
                 {lastUpdated && <span className={`last-updated ${Date.now() - lastUpdated > 60000 ? 'stale' : ''}`}>Updated {lastUpdated.toLocaleTimeString()}</span>}
-                <button className="btn" onClick={() => setView('update_repo')} style={{marginLeft: '10px', marginRight: '10px'}}>Update Repo</button>
+                <button className="btn" onClick={() => setView('update_repo')} style={{marginLeft: '10px', marginRight: '10px'}}>
+                    Update Repo
+                    {hasInstructionDraft && <span style={{marginLeft: '5px', color: '#ffcc00', fontWeight: 'bold'}}>●</span>}
+                </button>
                 <DeleteRepo repo={activeRepo} onRepoDeleted={handleRepoDeleted} />
             </div>
         </div>

--- a/repo-agent/review-ui/ui/src/UpdateRepo.js
+++ b/repo-agent/review-ui/ui/src/UpdateRepo.js
@@ -1,11 +1,20 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import yaml from 'js-yaml';
 
 function UpdateRepo({ repo, onCancel, onRepoUpdated }) {
+    const [activeTab, setActiveTab] = useState('config'); // 'config' or 'instructions'
     const [yamlContent, setYamlContent] = useState('');
     const [originalYamlContent, setOriginalYamlContent] = useState('');
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState('');
+
+    // Instructions state
+    const [currentInstructions, setCurrentInstructions] = useState('');
+    const [draftInstructions, setDraftInstructions] = useState('');
+    const [originalDraftInstructions, setOriginalDraftInstructions] = useState('');
+    const [hasDraft, setHasDraft] = useState(false);
+    const [instructionsError, setInstructionsError] = useState('');
+    const [isInstructionsLoading, setIsInstructionsLoading] = useState(false);
 
     useEffect(() => {
         setIsLoading(true);
@@ -17,7 +26,7 @@ function UpdateRepo({ repo, onCancel, onRepoUpdated }) {
             .then(data => {
                 if (data.yaml) {
                     setYamlContent(data.yaml);
-                    setOriginalYamlContent(data.yaml); // Store original YAML content
+                    setOriginalYamlContent(data.yaml);
                 }
                 setIsLoading(false);
             })
@@ -28,18 +37,42 @@ function UpdateRepo({ repo, onCancel, onRepoUpdated }) {
             });
     }, [repo.name]);
 
-    const handleSubmit = async (e) => {
+    const fetchInstructions = useCallback(() => {
+        setIsInstructionsLoading(true);
+        fetch(`/api/repos/${repo.name}/instructions`)
+            .then(res => {
+                if (!res.ok) throw new Error("Failed to fetch instructions");
+                return res.json();
+            })
+            .then(data => {
+                setCurrentInstructions(data.current || '');
+                setDraftInstructions(data.draft || '');
+                setOriginalDraftInstructions(data.draft || '');
+                setHasDraft(!!data.draft);
+                setIsInstructionsLoading(false);
+            })
+            .catch(err => {
+                console.error(err);
+                setInstructionsError(err.message);
+                setIsInstructionsLoading(false);
+            });
+    }, [repo.name]);
+
+    useEffect(() => {
+        if (activeTab === 'instructions') {
+            fetchInstructions();
+        }
+    }, [activeTab, fetchInstructions]);
+
+    const handleConfigSubmit = async (e) => {
         e.preventDefault();
         setError('');
         setIsLoading(true);
 
         try {
-            // Validate YAML
             const parsed = yaml.load(yamlContent);
             if (!parsed) throw new Error("YAML is empty or invalid");
 
-            // Extract repoURL from current and original YAML for comparison
-            // Note: The YAML content here is the Spec, so repoURL is at the root.
             const currentRepoURL = parsed?.repoURL;
             const originalParsed = yaml.load(originalYamlContent);
             const originalRepoURL = originalParsed?.repoURL;
@@ -49,7 +82,6 @@ function UpdateRepo({ repo, onCancel, onRepoUpdated }) {
                 setIsLoading(false);
                 return;
             }
-
         } catch (e) {
             setError('Invalid YAML content: ' + e.message);
             setIsLoading(false);
@@ -86,35 +118,188 @@ function UpdateRepo({ repo, onCancel, onRepoUpdated }) {
         });
     };
 
+    const handleInstructionAction = (action) => {
+        setInstructionsError('');
+        setIsInstructionsLoading(true);
+
+        const body = {
+            current: currentInstructions,
+            draft: draftInstructions,
+            action: action
+        };
+
+        fetch(`/api/repos/${repo.name}/instructions`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body)
+        })
+        .then(async (res) => {
+            if (!res.ok) {
+                const data = await res.json();
+                throw new Error(data.error || 'Failed to update instructions');
+            }
+            return res;
+        })
+        .then(() => {
+            if (action === 'publish' || action === 'discard_draft') {
+                 // Refresh to clear draft or update current
+                 fetchInstructions();
+            } else if (action === 'save_draft') {
+                 setHasDraft(true);
+                 setOriginalDraftInstructions(draftInstructions);
+                 setIsInstructionsLoading(false);
+            }
+        })
+        .catch(err => {
+            console.error(err);
+            setInstructionsError(err.message);
+            setIsInstructionsLoading(false);
+        });
+    };
+
     return (
-        <div className="add-repo-container"> {/* Reusing add-repo styles */}
+        <div className="add-repo-container" style={{maxWidth: '1000px'}}>
             <h2>Update Repository: {repo.name}</h2>
             
-            {error && <div className="message error">{error}</div>}
+            <div className="repo-tabs" style={{justifyContent: 'flex-start', marginBottom: '20px'}}>
+                <button 
+                    className={`tab-btn ${activeTab === 'config' ? 'active' : ''}`}
+                    onClick={() => setActiveTab('config')}
+                >
+                    Configuration
+                </button>
+                <button 
+                    className={`tab-btn ${activeTab === 'instructions' ? 'active' : ''}`}
+                    onClick={() => setActiveTab('instructions')}
+                >
+                    User Instructions
+                    {hasDraft && <span style={{marginLeft: '5px', color: '#orange'}}>●</span>} 
+                </button>
+            </div>
 
-            <form onSubmit={handleSubmit} className="add-repo-form">
-                <div className="form-group">
-                    <label htmlFor="repoYaml">RepoWatch Spec (YAML):</label>
-                    <textarea
-                        id="repoYaml"
-                        value={yamlContent}
-                        onChange={(e) => setYamlContent(e.target.value)}
-                        className="yaml-editor"
-                        rows={20}
-                        disabled={isLoading}
-                        style={{fontFamily: 'monospace', width: '100%', whiteSpace: 'pre'}}
-                    />
-                </div>
+            {activeTab === 'config' && (
+                <>
+                    {error && <div className="message error">{error}</div>}
+                    <form onSubmit={handleConfigSubmit} className="add-repo-form">
+                        <div className="form-group">
+                            <label htmlFor="repoYaml">RepoWatch Spec (YAML):</label>
+                            <textarea
+                                id="repoYaml"
+                                value={yamlContent}
+                                onChange={(e) => setYamlContent(e.target.value)}
+                                className="yaml-editor"
+                                rows={20}
+                                disabled={isLoading}
+                                style={{fontFamily: 'monospace', width: '100%', whiteSpace: 'pre'}}
+                            />
+                        </div>
+                        <div className="form-actions">
+                            <button type="submit" className="btn btn-submit" disabled={isLoading}>
+                                {isLoading ? 'Updating...' : 'Update Repo'}
+                            </button>
+                            <button type="button" className="btn" onClick={onCancel} disabled={isLoading}>
+                                Cancel
+                            </button>
+                        </div>
+                    </form>
+                </>
+            )}
 
-                <div className="form-actions">
-                    <button type="submit" className="btn btn-submit" disabled={isLoading}>
-                        {isLoading ? 'Updating...' : 'Update Repo'}
-                    </button>
-                    <button type="button" className="btn" onClick={onCancel} disabled={isLoading}>
-                        Cancel
-                    </button>
+            {activeTab === 'instructions' && (
+                <div className="instructions-container">
+                    {instructionsError && <div className="message error">{instructionsError}</div>}
+                    
+                    <div style={{display: 'flex', gap: '20px', flexDirection: 'column'}}>
+                        <div style={{flex: 1}}>
+                            <h3>Current Instructions</h3>
+                            <textarea
+                                value={currentInstructions}
+                                onChange={(e) => setCurrentInstructions(e.target.value)}
+                                className="yaml-editor"
+                                rows={20}
+                                disabled={isInstructionsLoading}
+                                style={{fontFamily: 'monospace', width: '100%', whiteSpace: 'pre'}}
+                                placeholder="No user instructions defined."
+                            />
+                             <div className="form-actions" style={{marginTop: '10px'}}>
+                                <button 
+                                    className="btn btn-submit" 
+                                    onClick={() => handleInstructionAction('publish')}
+                                    disabled={isInstructionsLoading || (hasDraft && !window.confirm("This will overwrite current instructions with the content in this box and DISCARD the draft. Are you sure?"))}
+                                    title="Save changes to current instructions directly"
+                                >
+                                    Update Current
+                                </button>
+                            </div>
+                        </div>
+
+                        {hasDraft && (
+                            <div style={{flex: 1, borderTop: '1px solid #eee', paddingTop: '20px'}}>
+                                <h3 style={{color: '#d9534f'}}>Proposed Draft</h3>
+                                <textarea
+                                    value={draftInstructions}
+                                    onChange={(e) => setDraftInstructions(e.target.value)}
+                                    className="yaml-editor"
+                                    rows={20}
+                                    disabled={isInstructionsLoading}
+                                    style={{fontFamily: 'monospace', width: '100%', whiteSpace: 'pre', border: '1px solid #d9534f'}}
+                                />
+                                <div className="form-actions" style={{marginTop: '10px', display: 'flex', gap: '10px', flexWrap: 'wrap'}}>
+                                    <button 
+                                        className="btn btn-submit" 
+                                        style={{backgroundColor: '#5cb85c'}}
+                                        onClick={() => {
+                                            // Copy draft to current then publish
+                                            setCurrentInstructions(draftInstructions);
+                                            // We need to wait for state update? No, we pass values to API.
+                                            // But handleInstructionAction uses state 'currentInstructions'.
+                                            // So we should construct a special call.
+                                            setInstructionsError('');
+                                            setIsInstructionsLoading(true);
+                                            fetch(`/api/repos/${repo.name}/instructions`, {
+                                                method: 'POST',
+                                                headers: { 'Content-Type': 'application/json' },
+                                                body: JSON.stringify({ current: draftInstructions, draft: '', action: 'publish' })
+                                            }).then(() => {
+                                                fetchInstructions();
+                                            }).catch(e => {
+                                                setInstructionsError(e.message);
+                                                setIsInstructionsLoading(false);
+                                            });
+                                        }}
+                                        disabled={isInstructionsLoading}
+                                    >
+                                        Approve & Publish
+                                    </button>
+                                    <button 
+                                        className="btn" 
+                                        onClick={() => handleInstructionAction('save_draft')}
+                                        disabled={isInstructionsLoading || draftInstructions === originalDraftInstructions}
+                                    >
+                                        Save Draft
+                                    </button>
+                                    <button 
+                                        className="btn btn-delete" 
+                                        onClick={() => {
+                                            if (window.confirm("Are you sure you want to discard this draft?")) {
+                                                handleInstructionAction('discard_draft');
+                                            }
+                                        }}
+                                        disabled={isInstructionsLoading}
+                                    >
+                                        Reject / Discard
+                                    </button>
+                                </div>
+                            </div>
+                        )}
+                    </div>
+                     <div className="form-actions" style={{marginTop: '20px', borderTop: '1px solid #eee', paddingTop: '20px'}}>
+                        <button type="button" className="btn" onClick={onCancel} disabled={isInstructionsLoading}>
+                            Back / Cancel
+                        </button>
+                    </div>
                 </div>
-            </form>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
Requires #241 to be merged first.

1. Backend (`review-ui/review-api`):
  * Updated pkg/k8s/k8s.go to include the ConfigDir GVR and added methods GetConfigDir and UpdateConfigDirFile to read and modify ConfigDir resources.
  * Updated pkg/api/server.go to expose two new endpoints:
    * GET /api/repos/:repo/instructions: Fetches current and draft user instructions.
    * POST /api/repos/:repo/instructions: Updates instructions with actions save_draft, publish (approve draft/update current), and discard_draft.

2. Frontend (`review-ui/ui/src`):
  * Refactored UpdateRepo.js to support tabs. It now includes a "User Instructions" tab where users can:
    * View and edit current instructions.
    * View and edit draft instructions (if present).
    * Approve drafts (promotes to current).
    * Discard drafts.
    * Update current instructions directly.
  * Updated App.js to check for the presence of draft instructions for the active repository and display a notification indicator (●) on the "Update Repo" button.


Indicator for showing a draft available for review:

<img width="988" height="444" alt="image" src="https://github.com/user-attachments/assets/805a9465-4b13-454d-b2cc-268b7d82b885" />


Showing current and draft: 
Update current
approve/reject draft.

<img width="1662" height="1788" alt="image" src="https://github.com/user-attachments/assets/cae5760f-8212-489a-be21-49781fb205c9" />


Update current without tooling provided draft:

<img width="1262" height="1372" alt="image" src="https://github.com/user-attachments/assets/15864a74-b6da-45ba-aacf-1f01d63c69e7" />
