### PR TITLE
feat: dev-sandbox bootstrap --namespace to use dev-sandboxes

### DIFF
--- a/repo-agent/dev-sandbox/main.go
+++ b/repo-agent/dev-sandbox/main.go
@@ -61,6 +61,7 @@ func run(ctx context.Context) error {
 	rootCommand.AddCommand(sshdCommand)
 
 	rootCommand.AddCommand(commands.BuildCreateCommand())
+	rootCommand.AddCommand(commands.BuildBootstrapCommand())
 	rootCommand.AddCommand(commands.NewCodeCommand())
 	rootCommand.AddCommand(commands.NewTmuxCommand())
 

--- a/repo-agent/images/dev-sandbox/Dockerfile
+++ b/repo-agent/images/dev-sandbox/Dockerfile
@@ -13,9 +13,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -v k8s.io/klog/v2 golang.
 
 
 # Copy the llm directory
-COPY pkg/llm/ ./pkg/llm/
-COPY pkg/sshd/ ./pkg/sshd/
-COPY pkg/commands/ ./pkg/commands/
+COPY pkg/ pkg/
 
 COPY dev-sandbox/ dev-sandbox/
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -v -o /dev-sandbox ./dev-sandbox

--- a/repo-agent/images/review-api/Dockerfile
+++ b/repo-agent/images/review-api/Dockerfile
@@ -9,6 +9,7 @@ COPY go.sum go.sum
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
+COPY pkg/ pkg/
 COPY review-ui/review-api/ review-ui/review-api/
 RUN CGO_ENABLED=0 GOOS=linux go build -o /review-api review-ui/review-api/main.go
 

--- a/repo-agent/pkg/commands/bootstrap.go
+++ b/repo-agent/pkg/commands/bootstrap.go
@@ -1,0 +1,49 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/k8s"
+	"github.com/spf13/cobra"
+)
+
+// BootstrapOptions holds options for the Bootstrap command.
+type BootstrapOptions struct {
+	Namespace string
+}
+
+// BuildBootstrapCommand builds the cobra command for bootstrapping a namespace.
+func BuildBootstrapCommand() *cobra.Command {
+	var opt BootstrapOptions
+
+	cmd := &cobra.Command{
+		Use:   "bootstrap",
+		Short: "Bootstrap a namespace for development",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if opt.Namespace == "" {
+				return fmt.Errorf("namespace is required")
+			}
+			return RunBootstrap(cmd.Context(), opt)
+		},
+	}
+	cmd.Flags().StringVar(&opt.Namespace, "namespace", "", "Namespace to bootstrap")
+	_ = cmd.MarkFlagRequired("namespace")
+
+	return cmd
+}
+
+// RunBootstrap executes the bootstrap logic.
+func RunBootstrap(ctx context.Context, opt BootstrapOptions) error {
+	clientset, _, err := GetClientset()
+	if err != nil {
+		return err
+	}
+
+	if err := k8s.BootstrapNamespace(ctx, clientset, opt.Namespace); err != nil {
+		return fmt.Errorf("bootstrapping namespace %q: %w", opt.Namespace, err)
+	}
+
+	fmt.Printf("Namespace %q bootstrapped successfully\n", opt.Namespace)
+	return nil
+}

--- a/repo-agent/pkg/commands/helpers.go
+++ b/repo-agent/pkg/commands/helpers.go
@@ -14,25 +14,34 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// findSandboxPod finds the pod for the given sandbox name.
-func findSandboxPod(ctx context.Context, sandboxName string) (*types.NamespacedName, error) {
+// GetClientset returns a new Kubernetes clientset.
+func GetClientset() (*kubernetes.Clientset, string, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	configOverrides := &clientcmd.ConfigOverrides{}
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 
 	config, err := kubeConfig.ClientConfig()
 	if err != nil {
-		return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
+		return nil, "", fmt.Errorf("failed to load kubeconfig: %w", err)
 	}
 
 	namespace, _, err := kubeConfig.Namespace()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get namespace: %w", err)
+		return nil, "", fmt.Errorf("failed to get namespace: %w", err)
 	}
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
+		return nil, "", fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+	return clientset, namespace, nil
+}
+
+// findSandboxPod finds the pod for the given sandbox name.
+func findSandboxPod(ctx context.Context, sandboxName string) (*types.NamespacedName, error) {
+	clientset, namespace, err := GetClientset()
+	if err != nil {
+		return nil, err
 	}
 
 	// The sandbox name in the RGD is devc-<name>

--- a/repo-agent/pkg/k8s/bootstrap.go
+++ b/repo-agent/pkg/k8s/bootstrap.go
@@ -1,0 +1,214 @@
+package k8s
+
+import (
+	"context"
+	"log"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+)
+
+const (
+	SystemNamespace  = "repo-agent-system"
+	GithubSecretName = "github-pat"
+	GeminiSecretName = "gemini-vscode-tokens"
+	ClaudeSecretName = "anthropic-api-key"
+	DevContainerCM   = "devcontainer-json"
+)
+
+// BootstrapNamespace bootstraps the target namespace with necessary secrets and service accounts.
+func BootstrapNamespace(ctx context.Context, clientset kubernetes.Interface, targetNS string) error {
+	_, err := clientset.CoreV1().Namespaces().Get(ctx, targetNS, v1.GetOptions{})
+	if errors.IsNotFound(err) {
+		log.Printf("Creating namespace %s", targetNS)
+		ns := &corev1.Namespace{
+			ObjectMeta: v1.ObjectMeta{
+				Name:   targetNS,
+				Labels: map[string]string{"app.kubernetes.io/managed-by": "repo-agent", "review.gemini.google.com/tenant": targetNS},
+			},
+		}
+		if _, err := clientset.CoreV1().Namespaces().Create(ctx, ns, v1.CreateOptions{}); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+
+	// Copy default secrets/configs from system namespace if they don't exist in user namespace
+	if err := CopySecret(ctx, clientset, SystemNamespace, GithubSecretName, targetNS, GithubSecretName); err != nil {
+		log.Printf("Warning: failed to copy default github secret: %v", err)
+	}
+	if err := CopySecret(ctx, clientset, SystemNamespace, GeminiSecretName, targetNS, GeminiSecretName); err != nil {
+		log.Printf("Warning: failed to copy default gemini secret: %v", err)
+	}
+	if err := CopySecret(ctx, clientset, SystemNamespace, ClaudeSecretName, targetNS, ClaudeSecretName); err != nil {
+		log.Printf("Warning: failed to copy default claude secret: %v", err)
+	}
+	if err := CopyConfigMap(ctx, clientset, SystemNamespace, DevContainerCM, targetNS, DevContainerCM); err != nil {
+		log.Printf("Debug: failed to copy %s: %v", DevContainerCM, err)
+	}
+
+	if err := SetupServiceAccounts(ctx, clientset, targetNS); err != nil {
+		log.Printf("Warning: failed to setup service accounts: %v", err)
+	}
+
+	return nil
+}
+
+// CopySecret copies a secret from source namespace to destination namespace.
+func CopySecret(ctx context.Context, clientset kubernetes.Interface, srcNS, srcName, dstNS, dstName string) error {
+	src, err := clientset.CoreV1().Secrets(srcNS).Get(ctx, srcName, v1.GetOptions{})
+	if err != nil {
+		log.Printf("Error reading secret %s/%s: %v", srcNS, srcName, err)
+		return err
+	}
+	dst := &corev1.Secret{ObjectMeta: v1.ObjectMeta{Name: dstName, Namespace: dstNS}, Data: src.Data, Type: src.Type}
+	_, err = clientset.CoreV1().Secrets(dstNS).Create(ctx, dst, v1.CreateOptions{})
+	return ignoreAlreadyExists(err)
+}
+
+// CopyConfigMap copies a configmap from source namespace to destination namespace.
+func CopyConfigMap(ctx context.Context, clientset kubernetes.Interface, srcNS, srcName, dstNS, dstName string) error {
+	src, err := clientset.CoreV1().ConfigMaps(srcNS).Get(ctx, srcName, v1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	dst := &corev1.ConfigMap{ObjectMeta: v1.ObjectMeta{Name: dstName, Namespace: dstNS}, Data: src.Data, BinaryData: src.BinaryData}
+	_, err = clientset.CoreV1().ConfigMaps(dstNS).Create(ctx, dst, v1.CreateOptions{})
+	return ignoreAlreadyExists(err)
+}
+
+// SetupServiceAccounts sets up the necessary service accounts and role bindings in the namespace.
+func SetupServiceAccounts(ctx context.Context, clientset kubernetes.Interface, ns string) error {
+	// --- Review Sandbox ---
+	saReview := &corev1.ServiceAccount{ObjectMeta: v1.ObjectMeta{Name: "review-sandbox", Namespace: ns}}
+	_, err := clientset.CoreV1().ServiceAccounts(ns).Create(ctx, saReview, v1.CreateOptions{})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+
+	// Bind to review-sandbox cluster role (base permissions)
+	rbReview := &rbacv1.RoleBinding{
+		ObjectMeta: v1.ObjectMeta{Name: "review-sandbox-binding", Namespace: ns},
+		Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "review-sandbox", Namespace: ns}},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "review-sandbox", APIGroup: "rbac.authorization.k8s.io"},
+	}
+	_, err = clientset.RbacV1().RoleBindings(ns).Create(ctx, rbReview, v1.CreateOptions{})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+
+	// Add to review-sandbox cluster role binding (to match make apply-common-for-examples)
+	if err := ensureClusterRoleBindingSubject(ctx, clientset, "review-sandbox", rbacv1.Subject{Kind: "ServiceAccount", Name: "review-sandbox", Namespace: ns}); err != nil {
+		log.Printf("Warning: failed to update review-sandbox cluster role binding: %v", err)
+	}
+
+	// Bind to configdir-controller cluster role (needed for init container)
+	rbReviewConfigDir := &rbacv1.RoleBinding{
+		ObjectMeta: v1.ObjectMeta{Name: "review-sandbox-configdir-binding", Namespace: ns},
+		Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "review-sandbox", Namespace: ns}},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "configdir-controller", APIGroup: "rbac.authorization.k8s.io"},
+	}
+	_, err = clientset.RbacV1().RoleBindings(ns).Create(ctx, rbReviewConfigDir, v1.CreateOptions{})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+
+	// --- Dev Sandbox ---
+	saDev := &corev1.ServiceAccount{ObjectMeta: v1.ObjectMeta{Name: "dev-sandbox", Namespace: ns}}
+	_, err = clientset.CoreV1().ServiceAccounts(ns).Create(ctx, saDev, v1.CreateOptions{})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+
+	// Bind to dev-sandbox cluster role (base permissions)
+	rbDev := &rbacv1.RoleBinding{
+		ObjectMeta: v1.ObjectMeta{Name: "dev-sandbox-binding", Namespace: ns},
+		Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "dev-sandbox", Namespace: ns}},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "dev-sandbox", APIGroup: "rbac.authorization.k8s.io"},
+	}
+	_, err = clientset.RbacV1().RoleBindings(ns).Create(ctx, rbDev, v1.CreateOptions{})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+
+	// Add to dev-sandbox cluster role binding (to match make apply-common-for-examples)
+	if err := ensureClusterRoleBindingSubject(ctx, clientset, "dev-sandbox", rbacv1.Subject{Kind: "ServiceAccount", Name: "dev-sandbox", Namespace: ns}); err != nil {
+		log.Printf("Warning: failed to update dev-sandbox cluster role binding: %v", err)
+	}
+
+	// Bind to configdir-controller cluster role (needed for init container)
+	rbDevConfigDir := &rbacv1.RoleBinding{
+		ObjectMeta: v1.ObjectMeta{Name: "dev-sandbox-configdir-binding", Namespace: ns},
+		Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "dev-sandbox", Namespace: ns}},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "configdir-controller", APIGroup: "rbac.authorization.k8s.io"},
+	}
+	_, err = clientset.RbacV1().RoleBindings(ns).Create(ctx, rbDevConfigDir, v1.CreateOptions{})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+
+	// --- Issue Sandbox ---
+	saIssue := &corev1.ServiceAccount{ObjectMeta: v1.ObjectMeta{Name: "issue-sandbox", Namespace: ns}}
+	_, err = clientset.CoreV1().ServiceAccounts(ns).Create(ctx, saIssue, v1.CreateOptions{})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+
+	// Bind to issue-sandbox cluster role (base permissions)
+	rbIssue := &rbacv1.RoleBinding{
+		ObjectMeta: v1.ObjectMeta{Name: "issue-sandbox-binding", Namespace: ns},
+		Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "issue-sandbox", Namespace: ns}},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "issue-sandbox", APIGroup: "rbac.authorization.k8s.io"},
+	}
+	_, err = clientset.RbacV1().RoleBindings(ns).Create(ctx, rbIssue, v1.CreateOptions{})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+
+	// Add to issue-sandbox cluster role binding (to match make apply-common-for-examples)
+	if err := ensureClusterRoleBindingSubject(ctx, clientset, "issue-sandbox", rbacv1.Subject{Kind: "ServiceAccount", Name: "issue-sandbox", Namespace: ns}); err != nil {
+		log.Printf("Warning: failed to update issue-sandbox cluster role binding: %v", err)
+	}
+
+	// Bind to configdir-controller cluster role (needed for init container)
+	rbIssueConfigDir := &rbacv1.RoleBinding{
+		ObjectMeta: v1.ObjectMeta{Name: "issue-sandbox-configdir-binding", Namespace: ns},
+		Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "issue-sandbox", Namespace: ns}},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "configdir-controller", APIGroup: "rbac.authorization.k8s.io"},
+	}
+	_, err = clientset.RbacV1().RoleBindings(ns).Create(ctx, rbIssueConfigDir, v1.CreateOptions{})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+
+	return nil
+}
+
+func ensureClusterRoleBindingSubject(ctx context.Context, clientset kubernetes.Interface, bindingName string, subject rbacv1.Subject) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		binding, err := clientset.RbacV1().ClusterRoleBindings().Get(ctx, bindingName, v1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		for _, s := range binding.Subjects {
+			if s.Kind == subject.Kind && s.Name == subject.Name && s.Namespace == subject.Namespace {
+				return nil // Already exists
+			}
+		}
+		binding.Subjects = append(binding.Subjects, subject)
+		_, err = clientset.RbacV1().ClusterRoleBindings().Update(ctx, binding, v1.UpdateOptions{})
+		return err
+	})
+}
+
+func ignoreAlreadyExists(err error) error {
+	if errors.IsAlreadyExists(err) {
+		return nil
+	}
+	return err
+}

--- a/repo-agent/review-ui/review-api/pkg/api/handlers_settings.go
+++ b/repo-agent/review-ui/review-api/pkg/api/handlers_settings.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	pkgk8s "github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/k8s"
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/review-ui/review-api/pkg/auth"
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/review-ui/review-api/pkg/k8s"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,7 +20,7 @@ func (s *Server) getSettings(c *gin.Context) {
 		"github_pat_set":     false, // Legacy field for UI compatibility
 	}
 
-	if sec, err := s.K8sManager.Clientset.CoreV1().Secrets(namespace).Get(c.Request.Context(), k8s.GithubSecretName, v1.GetOptions{}); err == nil {
+	if sec, err := s.K8sManager.Clientset.CoreV1().Secrets(namespace).Get(c.Request.Context(), pkgk8s.GithubSecretName, v1.GetOptions{}); err == nil {
 		if _, ok := sec.Data[k8s.ManualPATKey]; ok {
 			settings["manual_pat_set"] = true
 			settings["github_pat_set"] = true
@@ -37,7 +38,7 @@ func (s *Server) getSettings(c *gin.Context) {
 			}
 		}
 	}
-	if sec, err := s.K8sManager.Clientset.CoreV1().Secrets(namespace).Get(c.Request.Context(), k8s.GeminiSecretName, v1.GetOptions{}); err == nil {
+	if sec, err := s.K8sManager.Clientset.CoreV1().Secrets(namespace).Get(c.Request.Context(), pkgk8s.GeminiSecretName, v1.GetOptions{}); err == nil {
 		if _, ok := sec.Data["gemini"]; ok {
 			settings["gemini_api_key_set"] = true
 		}
@@ -63,7 +64,7 @@ func (s *Server) updateSettings(c *gin.Context) {
 			data := map[string][]byte{
 				k8s.ManualPATKey: nil,
 			}
-			err := s.K8sManager.UpdateSecret(c.Request.Context(), namespace, k8s.GithubSecretName, data, nil)
+			err := s.K8sManager.UpdateSecret(c.Request.Context(), namespace, pkgk8s.GithubSecretName, data, nil)
 			if err != nil {
 				log.Printf("Failed to clear GitHub PAT: %v", err)
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to clear GitHub PAT"})
@@ -76,7 +77,7 @@ func (s *Server) updateSettings(c *gin.Context) {
 				"refresh_token":  nil,
 				"expiry":         nil,
 			}
-			err := s.K8sManager.UpdateSecret(c.Request.Context(), namespace, k8s.GithubSecretName, data, nil)
+			err := s.K8sManager.UpdateSecret(c.Request.Context(), namespace, pkgk8s.GithubSecretName, data, nil)
 			if err != nil {
 				log.Printf("Failed to update GitHub PAT: %v", err)
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update GitHub PAT"})
@@ -86,7 +87,7 @@ func (s *Server) updateSettings(c *gin.Context) {
 	}
 
 	if payload.GeminiAPIKey != "" {
-		err := s.K8sManager.UpdateSecret(c.Request.Context(), namespace, k8s.GeminiSecretName, map[string][]byte{"gemini": []byte(payload.GeminiAPIKey)}, nil)
+		err := s.K8sManager.UpdateSecret(c.Request.Context(), namespace, pkgk8s.GeminiSecretName, map[string][]byte{"gemini": []byte(payload.GeminiAPIKey)}, nil)
 		if err != nil {
 			log.Printf("Failed to update Gemini API Key: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update Gemini API Key"})

--- a/repo-agent/review-ui/review-api/pkg/auth/auth.go
+++ b/repo-agent/review-ui/review-api/pkg/auth/auth.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
+	pkgk8s "github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/k8s"
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/review-ui/review-api/pkg/k8s"
 	"github.com/google/go-github/v39/github"
 	"golang.org/x/oauth2"
@@ -131,7 +132,7 @@ func (a *Authenticator) Callback(c *gin.Context) {
 		return
 	}
 
-	if err := a.K8sManager.BootstrapNamespace(c.Request.Context(), ghUser); err != nil {
+	if err := pkgk8s.BootstrapNamespace(c.Request.Context(), a.K8sManager.Clientset, ghUser); err != nil {
 		log.Printf("Failed to bootstrap namespace %s: %v", ghUser, err)
 	}
 
@@ -169,7 +170,7 @@ func (a *Authenticator) updateUserSecret(ctx context.Context, namespace string, 
 	if user.Email != nil {
 		data["email"] = []byte(*user.Email)
 	}
-	return a.K8sManager.UpdateSecret(ctx, namespace, k8s.GithubSecretName, data, nil)
+	return a.K8sManager.UpdateSecret(ctx, namespace, pkgk8s.GithubSecretName, data, nil)
 }
 
 func (a *Authenticator) Status(c *gin.Context) {
@@ -214,7 +215,7 @@ func (a *Authenticator) UpdateGithubConfig(c *gin.Context) {
 
 	// Update Secret in repo-agent-system
 	// We need to get the existing secret to preserve the PAT
-	secret, err := a.K8sManager.Clientset.CoreV1().Secrets(k8s.SystemNamespace).Get(c.Request.Context(), k8s.GithubSecretName, v1.GetOptions{})
+	secret, err := a.K8sManager.Clientset.CoreV1().Secrets(pkgk8s.SystemNamespace).Get(c.Request.Context(), pkgk8s.GithubSecretName, v1.GetOptions{})
 	if err != nil {
 		log.Printf("Failed to get github secret: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get github secret"})
@@ -227,7 +228,7 @@ func (a *Authenticator) UpdateGithubConfig(c *gin.Context) {
 	secret.Data["github-client-id"] = []byte(payload.ClientID)
 	secret.Data["github-client-secret"] = []byte(payload.ClientSecret)
 
-	_, err = a.K8sManager.Clientset.CoreV1().Secrets(k8s.SystemNamespace).Update(c.Request.Context(), secret, v1.UpdateOptions{})
+	_, err = a.K8sManager.Clientset.CoreV1().Secrets(pkgk8s.SystemNamespace).Update(c.Request.Context(), secret, v1.UpdateOptions{})
 	if err != nil {
 		log.Printf("Failed to update github secret: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update github secret"})
@@ -264,7 +265,7 @@ func (a *Authenticator) Middleware() gin.HandlerFunc {
 		// dramatically reduce latency and eliminate the 502/504 errors caused by client-side throttling, allowing the VS Code UI to load correctly
 		if _, ok := a.bootstrappedUsers.Load(user); !ok {
 			// Lazy bootstrap checks if namespace exists, creating it if needed.
-			if err := a.K8sManager.BootstrapNamespace(c.Request.Context(), user); err != nil {
+			if err := pkgk8s.BootstrapNamespace(c.Request.Context(), a.K8sManager.Clientset, user); err != nil {
 				log.Printf("Lazy bootstrap failed for user %s: %v", user, err)
 			} else {
 				a.bootstrappedUsers.Store(user, true)

--- a/repo-agent/review-ui/review-api/pkg/k8s/k8s.go
+++ b/repo-agent/review-ui/review-api/pkg/k8s/k8s.go
@@ -8,7 +8,6 @@ import (
 
 	redis "github.com/go-redis/redis/v8"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -19,13 +18,8 @@ import (
 )
 
 const (
-	SystemNamespace  = "repo-agent-system"
-	GithubSecretName = "github-pat"
-	GeminiSecretName = "gemini-vscode-tokens"
-	ClaudeSecretName = "anthropic-api-key"
-	DevContainerCM   = "devcontainer-json"
-	OAuthPATKey      = "oauth_pat"
-	ManualPATKey     = "manual_pat"
+	OAuthPATKey  = "oauth_pat"
+	ManualPATKey = "manual_pat"
 )
 
 var (
@@ -109,195 +103,6 @@ func (m *Manager) UpdateConfigDirFile(ctx context.Context, namespace, name, file
 		_, err = m.Client.Resource(ConfigDirGVR).Namespace(namespace).Update(ctx, cd, v1.UpdateOptions{})
 		return err
 	})
-}
-
-func (m *Manager) BootstrapNamespace(ctx context.Context, targetNS string) error {
-	_, err := m.Clientset.CoreV1().Namespaces().Get(ctx, targetNS, v1.GetOptions{})
-	if errors.IsNotFound(err) {
-		log.Printf("Creating namespace %s", targetNS)
-		ns := &corev1.Namespace{
-			ObjectMeta: v1.ObjectMeta{
-				Name:   targetNS,
-				Labels: map[string]string{"app.kubernetes.io/managed-by": "repo-agent", "review.gemini.google.com/tenant": targetNS},
-			},
-		}
-		if _, err := m.Clientset.CoreV1().Namespaces().Create(ctx, ns, v1.CreateOptions{}); err != nil {
-			return err
-		}
-	} else if err != nil {
-		return err
-	}
-
-	// Copy default secrets/configs from system namespace if they don't exist in user namespace
-	if err := m.CopySecret(ctx, SystemNamespace, GithubSecretName, targetNS, GithubSecretName); err != nil {
-		log.Printf("Warning: failed to copy default github secret: %v", err)
-	}
-	if err := m.CopySecret(ctx, SystemNamespace, GeminiSecretName, targetNS, GeminiSecretName); err != nil {
-		log.Printf("Warning: failed to copy default gemini secret: %v", err)
-	}
-	if err := m.CopySecret(ctx, SystemNamespace, ClaudeSecretName, targetNS, ClaudeSecretName); err != nil {
-		log.Printf("Warning: failed to copy default claude secret: %v", err)
-	}
-	if err := m.CopyConfigMap(ctx, SystemNamespace, DevContainerCM, targetNS, DevContainerCM); err != nil {
-		log.Printf("Debug: failed to copy %s: %v", DevContainerCM, err)
-	}
-
-	if err := m.SetupServiceAccounts(ctx, targetNS); err != nil {
-		log.Printf("Warning: failed to setup service accounts: %v", err)
-	}
-
-	return nil
-}
-
-func (m *Manager) CopySecret(ctx context.Context, srcNS, srcName, dstNS, dstName string) error {
-	src, err := m.Clientset.CoreV1().Secrets(srcNS).Get(ctx, srcName, v1.GetOptions{})
-	if err != nil {
-		log.Printf("Error reading secret %s/%s: %v", srcNS, srcName, err)
-		return err
-	}
-	dst := &corev1.Secret{ObjectMeta: v1.ObjectMeta{Name: dstName, Namespace: dstNS}, Data: src.Data, Type: src.Type}
-	_, err = m.Clientset.CoreV1().Secrets(dstNS).Create(ctx, dst, v1.CreateOptions{})
-	return ignoreAlreadyExists(err)
-}
-
-func (m *Manager) CopyConfigMap(ctx context.Context, srcNS, srcName, dstNS, dstName string) error {
-	src, err := m.Clientset.CoreV1().ConfigMaps(srcNS).Get(ctx, srcName, v1.GetOptions{})
-	if err != nil {
-		return err
-	}
-	dst := &corev1.ConfigMap{ObjectMeta: v1.ObjectMeta{Name: dstName, Namespace: dstNS}, Data: src.Data, BinaryData: src.BinaryData}
-	_, err = m.Clientset.CoreV1().ConfigMaps(dstNS).Create(ctx, dst, v1.CreateOptions{})
-	return ignoreAlreadyExists(err)
-}
-
-func (m *Manager) SetupServiceAccounts(ctx context.Context, ns string) error {
-	// --- Review Sandbox ---
-	saReview := &corev1.ServiceAccount{ObjectMeta: v1.ObjectMeta{Name: "review-sandbox", Namespace: ns}}
-	_, err := m.Clientset.CoreV1().ServiceAccounts(ns).Create(ctx, saReview, v1.CreateOptions{})
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return err
-	}
-
-	// Bind to review-sandbox cluster role (base permissions)
-	rbReview := &rbacv1.RoleBinding{
-		ObjectMeta: v1.ObjectMeta{Name: "review-sandbox-binding", Namespace: ns},
-		Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "review-sandbox", Namespace: ns}},
-		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "review-sandbox", APIGroup: "rbac.authorization.k8s.io"},
-	}
-	_, err = m.Clientset.RbacV1().RoleBindings(ns).Create(ctx, rbReview, v1.CreateOptions{})
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return err
-	}
-
-	// Add to review-sandbox cluster role binding (to match make apply-common-for-examples)
-	if err := m.ensureClusterRoleBindingSubject(ctx, "review-sandbox", rbacv1.Subject{Kind: "ServiceAccount", Name: "review-sandbox", Namespace: ns}); err != nil {
-		log.Printf("Warning: failed to update review-sandbox cluster role binding: %v", err)
-	}
-
-	// Bind to configdir-controller cluster role (needed for init container)
-	rbReviewConfigDir := &rbacv1.RoleBinding{
-		ObjectMeta: v1.ObjectMeta{Name: "review-sandbox-configdir-binding", Namespace: ns},
-		Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "review-sandbox", Namespace: ns}},
-		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "configdir-controller", APIGroup: "rbac.authorization.k8s.io"},
-	}
-	_, err = m.Clientset.RbacV1().RoleBindings(ns).Create(ctx, rbReviewConfigDir, v1.CreateOptions{})
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return err
-	}
-
-	// --- Dev Sandbox ---
-	saDev := &corev1.ServiceAccount{ObjectMeta: v1.ObjectMeta{Name: "dev-sandbox", Namespace: ns}}
-	_, err = m.Clientset.CoreV1().ServiceAccounts(ns).Create(ctx, saDev, v1.CreateOptions{})
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return err
-	}
-
-	// Bind to dev-sandbox cluster role (base permissions)
-	rbDev := &rbacv1.RoleBinding{
-		ObjectMeta: v1.ObjectMeta{Name: "dev-sandbox-binding", Namespace: ns},
-		Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "dev-sandbox", Namespace: ns}},
-		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "dev-sandbox", APIGroup: "rbac.authorization.k8s.io"},
-	}
-	_, err = m.Clientset.RbacV1().RoleBindings(ns).Create(ctx, rbDev, v1.CreateOptions{})
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return err
-	}
-
-	// Add to dev-sandbox cluster role binding (to match make apply-common-for-examples)
-	if err := m.ensureClusterRoleBindingSubject(ctx, "dev-sandbox", rbacv1.Subject{Kind: "ServiceAccount", Name: "dev-sandbox", Namespace: ns}); err != nil {
-		log.Printf("Warning: failed to update dev-sandbox cluster role binding: %v", err)
-	}
-
-	// Bind to configdir-controller cluster role (needed for init container)
-	rbDevConfigDir := &rbacv1.RoleBinding{
-		ObjectMeta: v1.ObjectMeta{Name: "dev-sandbox-configdir-binding", Namespace: ns},
-		Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "dev-sandbox", Namespace: ns}},
-		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "configdir-controller", APIGroup: "rbac.authorization.k8s.io"},
-	}
-	_, err = m.Clientset.RbacV1().RoleBindings(ns).Create(ctx, rbDevConfigDir, v1.CreateOptions{})
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return err
-	}
-
-	// --- Issue Sandbox ---
-	saIssue := &corev1.ServiceAccount{ObjectMeta: v1.ObjectMeta{Name: "issue-sandbox", Namespace: ns}}
-	_, err = m.Clientset.CoreV1().ServiceAccounts(ns).Create(ctx, saIssue, v1.CreateOptions{})
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return err
-	}
-
-	// Bind to issue-sandbox cluster role (base permissions)
-	rbIssue := &rbacv1.RoleBinding{
-		ObjectMeta: v1.ObjectMeta{Name: "issue-sandbox-binding", Namespace: ns},
-		Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "issue-sandbox", Namespace: ns}},
-		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "issue-sandbox", APIGroup: "rbac.authorization.k8s.io"},
-	}
-	_, err = m.Clientset.RbacV1().RoleBindings(ns).Create(ctx, rbIssue, v1.CreateOptions{})
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return err
-	}
-
-	// Add to issue-sandbox cluster role binding (to match make apply-common-for-examples)
-	if err := m.ensureClusterRoleBindingSubject(ctx, "issue-sandbox", rbacv1.Subject{Kind: "ServiceAccount", Name: "issue-sandbox", Namespace: ns}); err != nil {
-		log.Printf("Warning: failed to update issue-sandbox cluster role binding: %v", err)
-	}
-
-	// Bind to configdir-controller cluster role (needed for init container)
-	rbIssueConfigDir := &rbacv1.RoleBinding{
-		ObjectMeta: v1.ObjectMeta{Name: "issue-sandbox-configdir-binding", Namespace: ns},
-		Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "issue-sandbox", Namespace: ns}},
-		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "configdir-controller", APIGroup: "rbac.authorization.k8s.io"},
-	}
-	_, err = m.Clientset.RbacV1().RoleBindings(ns).Create(ctx, rbIssueConfigDir, v1.CreateOptions{})
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return err
-	}
-
-	return nil
-}
-
-func (m *Manager) ensureClusterRoleBindingSubject(ctx context.Context, bindingName string, subject rbacv1.Subject) error {
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		binding, err := m.Clientset.RbacV1().ClusterRoleBindings().Get(ctx, bindingName, v1.GetOptions{})
-		if err != nil {
-			return err
-		}
-		for _, s := range binding.Subjects {
-			if s.Kind == subject.Kind && s.Name == subject.Name && s.Namespace == subject.Namespace {
-				return nil // Already exists
-			}
-		}
-		binding.Subjects = append(binding.Subjects, subject)
-		_, err = m.Clientset.RbacV1().ClusterRoleBindings().Update(ctx, binding, v1.UpdateOptions{})
-		return err
-	})
-}
-
-func ignoreAlreadyExists(err error) error {
-	if errors.IsAlreadyExists(err) {
-		return nil
-	}
-	return err
 }
 
 func (m *Manager) UpdateSecret(ctx context.Context, namespace, name string, data map[string][]byte, annotations map[string]string) error {


### PR DESCRIPTION
1. Created `pkg/k8s/bootstrap.go`: Extracted the BootstrapNamespace function and its dependencies (CopySecret, CopyConfigMap, SetupServiceAccounts) from review-ui into a shared package pkg/k8s to make it reusable.
2. Refactored `review-ui/review-api/pkg/k8s/k8s.go`: Removed the moved code and constants to avoid duplication.
3. Updated `pkg/commands/helpers.go`: Refactored findSandboxPod to expose a new GetClientset helper function for creating Kubernetes clients.
4. Created `pkg/commands/bootstrap.go`: Implemented the new bootstrap command which uses the shared pkg/k8s logic and GetClientset.
5. Updated `dev-sandbox/main.go`: Registered the new bootstrap command in the root command.
6. Fixed `review-ui` references: Updated review-ui/review-api/pkg/auth/auth.go and review-ui/review-api/pkg/api/handlers_settings.go to import pkg/k8s and use the moved functions and constants.

You can now use the bootstrap command as follows:
dev-sandbox bootstrap --namespace <namespace>


### Usage example:

```
 % ./bin/dev-sandbox bootstrap --namespace default 
Namespace "default" bootstrapped successfully

 % kubectl get secret 
NAME                   TYPE     DATA   AGE
anthropic-api-key      Opaque   1      6s
gemini-vscode-tokens   Opaque   1      6s
github-pat             Opaque   3      6s

 % kubectl get configmap 
NAME                DATA   AGE
devcontainer-json   1      12s
kube-root-ca.crt    1      46h
```