### PR TITLE
refactor: common pkg to create dev-sandbox

### DIFF
--- a/repo-agent/images/dev-sandbox/Dockerfile
+++ b/repo-agent/images/dev-sandbox/Dockerfile
@@ -13,9 +13,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -v k8s.io/klog/v2 golang.
 
 
 # Copy the llm directory
-COPY pkg/llm/ ./pkg/llm/
-COPY pkg/sshd/ ./pkg/sshd/
-COPY pkg/commands/ ./pkg/commands/
+COPY pkg/ pkg/
 
 COPY dev-sandbox/ dev-sandbox/
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -v -o /dev-sandbox ./dev-sandbox

--- a/repo-agent/images/repowatch-controller/Dockerfile
+++ b/repo-agent/images/repowatch-controller/Dockerfile
@@ -10,6 +10,7 @@ COPY go.sum go.sum
 RUN go mod download
 
 # Copy the go source
+COPY pkg/ pkg/
 COPY repowatch/cmd/repowatch-controller/main.go repowatch/cmd/repowatch-controller/main.go
 COPY repowatch/api/ repowatch/api/
 COPY repowatch/controllers/ repowatch/controllers/

--- a/repo-agent/pkg/commands/create.go
+++ b/repo-agent/pkg/commands/create.go
@@ -7,16 +7,22 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/sandbox"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 )
 
 // CreateOptions holds options for the Create command.
 type CreateOptions struct {
-	Name     string
-	Repo     string
-	Branch   string
-	Dotfiles string
+	Name                  string
+	Repo                  string
+	Branch                string
+	Dotfiles              string
+	Namespace             string
+	LLMProvider           string
+	LLMSecret             string
+	DevcontainerConfigRef string
+	GithubLogin           string
 }
 
 // InitDefaults initializes default values for CreateOptions.
@@ -41,46 +47,109 @@ func BuildCreateCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opt.Repo, "repo", "", "URL of the repository")
 	cmd.Flags().StringVar(&opt.Branch, "branch", "", "Branch to checkout")
 	cmd.Flags().StringVar(&opt.Dotfiles, "dotfiles", "", "URL of the dotfiles repository")
-	_ = cmd.MarkFlagRequired("repo")
+	cmd.Flags().StringVar(&opt.Namespace, "namespace", "default", "Namespace to create the sandbox in")
+	cmd.Flags().StringVar(&opt.LLMProvider, "llm-provider", "gemini-cli", "LLM provider to use")
+	cmd.Flags().StringVar(&opt.LLMSecret, "llm-secret", "", "LLM k8s secret to use")
+	cmd.Flags().StringVar(&opt.DevcontainerConfigRef, "devcontainer-config-ref", "devcontainer-json", "Devcontainer config ref to use")
+	cmd.Flags().StringVar(&opt.GithubLogin, "github-login", "", "GitHub login to use")
+
+	// Mark required flags using : _ = cmd.MarkFlagRequired("branch")
 
 	return cmd
 }
 
-// RunCreate executes the create logic.
-func RunCreate(ctx context.Context, opt CreateOptions) error {
-	htmlURL := strings.TrimSuffix(opt.Repo, ".git")
+// From CreateOptions, return the HTML URL, clone URL, and origin URL
+func urls(opt CreateOptions) (string, string, string) {
+	repo := opt.Repo
+	if repo == "" {
+		// Try this command "git config --get remote.origin.url"
+		out, err := exec.Command("git", "config", "--get", "remote.origin.url").Output()
+		if err != nil {
+			panic("repo URL must be provided")
+		}
+		repo = strings.TrimSpace(string(out))
+	}
+
+	htmlURL := strings.TrimSuffix(repo, ".git")
 	cloneURL := htmlURL + ".git"
 	if opt.Branch != "" {
 		cloneURL += "#refs/heads/" + opt.Branch
 	}
+	originURL := htmlURL + ".git"
+	return htmlURL, cloneURL, originURL
+}
 
-	sandbox := DevSandbox{
-		APIVersion: "custom.agents.x-k8s.io/v1alpha1",
-		Kind:       "DevSandbox",
-		Metadata: DevSandboxMeta{
-			Name:      opt.Name,
-			Namespace: "default",
+func userInfo(opt CreateOptions) (string, string, string) {
+	// Try to get user info from git config
+	nameOut, err := exec.Command("git", "config", "--get", "user.name").Output()
+	if err != nil {
+		panic("user name must be set in git config")
+	}
+	name := strings.TrimSpace(string(nameOut))
+
+	emailOut, err := exec.Command("git", "config", "--get", "user.email").Output()
+	if err != nil {
+		panic("user email must be set in git config")
+	}
+	email := strings.TrimSpace(string(emailOut))
+
+	return name, email, opt.GithubLogin
+}
+
+// RunCreate executes the create logic.
+func RunCreate(ctx context.Context, opt CreateOptions) error {
+	htmlURL, cloneURL, originURL := urls(opt)
+	userName, userEmail, userLogin := userInfo(opt)
+
+	secretName := opt.LLMSecret
+	if secretName == "" {
+		if opt.LLMProvider == "gemini-cli" {
+			secretName = "gemini-vscode-tokens"
+		} else if opt.LLMProvider == "claude" {
+			secretName = "anthropic-api-key"
+		} else {
+			return fmt.Errorf("llm-secret must be provided for llm-provider %q", opt.LLMProvider)
+		}
+	}
+
+	sandboxOpt := sandbox.DevSandboxOptions{
+		Name:      opt.Name,
+		Namespace: opt.Namespace,
+		Labels: map[string]string{
+			"createdBy": "dev-sandbox-cli",
 		},
-		Spec: DevSandboxSpec{
-			Source: DevSandboxSource{
-				CloneURL: cloneURL,
-				HTMLURL:  htmlURL,
-			},
-			ServiceAccountName: "issue-sandbox",
-			Destination: DevSandboxDest{
-				Branch: "master",
-			},
-		},
+		CloneURL: cloneURL,
+		HTMLURL:  htmlURL,
+		Branch:   opt.Branch,
+		// Default service account for CLI created sandboxes
+		ServiceAccountName: "issue-sandbox",
+		DotFilesRepo:       opt.Dotfiles,
+
+		Origin:      originURL,
+		PushEnabled: true,
+
+		UserLogin: userLogin,
+		UserName:  userName,
+		UserEmail: userEmail,
+
+		LLMProvider: opt.LLMProvider,
+		// TODO: LLMConfigdirRef:     repoWatch.Spec.Dev.LLM.ConfigdirRef,
+		LLMAPIKeySecretName: secretName,
+
+		GithubSecretName:      "github-pat",
+		DevcontainerConfigRef: opt.DevcontainerConfigRef,
+
+		HTTPEnabled: true,
+		Replicas:    1,
 	}
 
 	if opt.Branch != "" {
-		sandbox.Spec.Destination.Branch = opt.Branch
-	}
-	if opt.Dotfiles != "" {
-		sandbox.Spec.User.DotFilesRepo = opt.Dotfiles
+		sandboxOpt.Branch = opt.Branch
 	}
 
-	data, err := yaml.Marshal(sandbox)
+	sb := sandbox.NewDevSandbox(sandboxOpt)
+
+	data, err := yaml.Marshal(sb.Object)
 	if err != nil {
 		return fmt.Errorf("marshalling yaml: %w", err)
 	}
@@ -96,36 +165,4 @@ func RunCreate(ctx context.Context, opt CreateOptions) error {
 
 	fmt.Printf("DevSandbox %q created\n", opt.Name)
 	return nil
-}
-
-type DevSandbox struct {
-	APIVersion string         `json:"apiVersion"`
-	Kind       string         `json:"kind"`
-	Metadata   DevSandboxMeta `json:"metadata"`
-	Spec       DevSandboxSpec `json:"spec"`
-}
-
-type DevSandboxMeta struct {
-	Name      string `json:"name"`
-	Namespace string `json:"namespace,omitempty"`
-}
-
-type DevSandboxSpec struct {
-	User               DevSandboxUser   `json:"user,omitempty"`
-	ServiceAccountName string           `json:"serviceAccountName,omitempty"`
-	Source             DevSandboxSource `json:"source,omitempty"`
-	Destination        DevSandboxDest   `json:"destination,omitempty"`
-}
-
-type DevSandboxUser struct {
-	DotFilesRepo string `json:"dotFilesRepo,omitempty"`
-}
-
-type DevSandboxSource struct {
-	CloneURL string `json:"cloneURL,omitempty"`
-	HTMLURL  string `json:"htmlURL,omitempty"`
-}
-
-type DevSandboxDest struct {
-	Branch string `json:"branch,omitempty"`
 }

--- a/repo-agent/pkg/sandbox/dev_sandbox.go
+++ b/repo-agent/pkg/sandbox/dev_sandbox.go
@@ -1,0 +1,148 @@
+package sandbox
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// DevSandboxOptions holds options for creating a DevSandbox.
+type DevSandboxOptions struct {
+	Name        string
+	Namespace   string
+	Labels      map[string]string
+	Annotations map[string]string
+
+	// Source
+	CloneURL string
+	HTMLURL  string
+
+	// Destination
+	Branch      string
+	Origin      string
+	PushEnabled bool
+	UserLogin   string
+	UserName    string
+	UserEmail   string
+
+	// User Config
+	DotFilesRepo string
+
+	// LLM
+	LLMProvider         string
+	LLMConfigdirRef     string
+	LLMAPIKeySecretName string
+
+	// Infra
+	ServiceAccountName    string
+	GithubSecretName      string
+	DevcontainerConfigRef string
+
+	// Gateway
+	HTTPEnabled bool
+
+	// Scaling
+	Replicas int64
+}
+
+// NewDevSandbox creates a new DevSandbox unstructured object.
+func NewDevSandbox(opt DevSandboxOptions) *unstructured.Unstructured {
+	spec := map[string]interface{}{
+		"source": map[string]interface{}{
+			"cloneURL": opt.CloneURL,
+			"htmlURL":  opt.HTMLURL,
+		},
+		"destination": map[string]interface{}{
+			"branch": opt.Branch,
+		},
+	}
+
+	if opt.Replicas > 0 {
+		spec["replicas"] = opt.Replicas
+	}
+
+	// Destination details
+	dest := spec["destination"].(map[string]interface{})
+	if opt.Origin != "" {
+		dest["origin"] = opt.Origin
+	}
+	if opt.PushEnabled {
+		dest["pushEnabled"] = true
+	}
+	if opt.UserLogin != "" || opt.UserName != "" || opt.UserEmail != "" {
+		userMap := map[string]interface{}{}
+		if opt.UserLogin != "" {
+			userMap["login"] = opt.UserLogin
+		}
+		if opt.UserName != "" {
+			userMap["name"] = opt.UserName
+		}
+		if opt.UserEmail != "" {
+			userMap["email"] = opt.UserEmail
+		}
+		dest["user"] = userMap
+	}
+
+	// User Config (Dotfiles)
+	if opt.DotFilesRepo != "" {
+		spec["user"] = map[string]interface{}{
+			"dotFilesRepo": opt.DotFilesRepo,
+		}
+	}
+
+	// LLM
+	if opt.LLMProvider != "" {
+		spec["llmBackend"] = map[string]interface{}{
+			"name": opt.LLMProvider,
+		}
+	}
+	if opt.LLMConfigdirRef != "" || opt.LLMAPIKeySecretName != "" {
+		llmMap := map[string]interface{}{}
+		if opt.LLMConfigdirRef != "" {
+			llmMap["configdirRef"] = opt.LLMConfigdirRef
+		}
+		if opt.LLMAPIKeySecretName != "" {
+			llmMap["apiKeySecretName"] = opt.LLMAPIKeySecretName
+		}
+		spec["llm"] = llmMap
+	}
+
+	// Infra
+	if opt.ServiceAccountName != "" {
+		spec["serviceAccountName"] = opt.ServiceAccountName
+	}
+	if opt.GithubSecretName != "" {
+		spec["githubSecretName"] = opt.GithubSecretName
+	}
+	if opt.DevcontainerConfigRef != "" {
+		spec["devcontainerConfigRef"] = opt.DevcontainerConfigRef
+	}
+
+	// Gateway
+	if opt.HTTPEnabled {
+		spec["gateway"] = map[string]interface{}{
+			"httpEnabled": true,
+		}
+	}
+
+	u := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "custom.agents.x-k8s.io/v1alpha1",
+			"kind":       "DevSandbox",
+			"metadata": map[string]interface{}{
+				"name": opt.Name,
+			},
+			"spec": spec,
+		},
+	}
+
+	if opt.Namespace != "" {
+		u.SetNamespace(opt.Namespace)
+	}
+	if len(opt.Labels) > 0 {
+		u.SetLabels(opt.Labels)
+	}
+	if len(opt.Annotations) > 0 {
+		u.SetAnnotations(opt.Annotations)
+	}
+
+	return u
+}

--- a/repo-agent/repowatch/controllers/repowatch_controller.go
+++ b/repo-agent/repowatch/controllers/repowatch_controller.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/sandbox"
 	reviewv1alpha1 "github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/repowatch/api/v1alpha1"
 )
 
@@ -1282,60 +1283,40 @@ func (r *RepoWatchReconciler) createDevSandbox(ctx context.Context, user *github
 	cloneURL := fmt.Sprintf("https://github.com/%s/%s.git", forkOwner, forkRepo)
 	originURL := fmt.Sprintf("github.com/%s/%s", forkOwner, forkRepo)
 
-	sandbox := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "custom.agents.x-k8s.io/v1alpha1",
-			"kind":       "DevSandbox",
-			"metadata": map[string]interface{}{
-				"name":      sandboxName,
-				"namespace": repoWatch.Namespace,
-				"labels": map[string]interface{}{
-					"review.gemini.google.com/repowatch": repoWatch.Name,
-				},
-			},
-			"spec": map[string]interface{}{
-				"replicas": int64(1),
-				"source": map[string]interface{}{
-					"cloneURL": cloneURL,
-					// "htmlURL":  fmt.Sprintf("https://github.com/%s/%s/tree/%s", forkOwner, forkRepo, branchName),
-					"htmlURL": fmt.Sprintf("https://github.com/%s/%s", forkOwner, forkRepo),
-				},
-				"llmBackend": map[string]interface{}{
-					"name": repoWatch.Spec.Dev.LLM.Provider,
-				},
-				"llm": map[string]interface{}{
-					"configdirRef":     repoWatch.Spec.Dev.LLM.ConfigdirRef,
-					"apiKeySecretName": repoWatch.Spec.Dev.LLM.APIKeySecretRef,
-				},
-				"destination": map[string]interface{}{
-					"pushEnabled": true,
-					"branch":      branchName,
-					"origin":      originURL,
-					"user": map[string]interface{}{
-						"login": user.GetLogin(),
-						"name":  user.GetName(),
-						"email": user.GetEmail(),
-					},
-				},
-				"gateway": map[string]interface{}{
-					"httpEnabled": true,
-				},
-				"githubSecretName": repoWatch.Spec.GithubSecretName,
-			},
+	opts := sandbox.DevSandboxOptions{
+		Name:      sandboxName,
+		Namespace: repoWatch.Namespace,
+		Labels: map[string]string{
+			"review.gemini.google.com/repowatch": repoWatch.Name,
 		},
+		CloneURL: cloneURL,
+		HTMLURL:  fmt.Sprintf("https://github.com/%s/%s", forkOwner, forkRepo),
+
+		Branch:      branchName,
+		Origin:      originURL,
+		PushEnabled: true,
+		UserLogin:   user.GetLogin(),
+		UserName:    user.GetName(),
+		UserEmail:   user.GetEmail(),
+
+		LLMProvider:         repoWatch.Spec.Dev.LLM.Provider,
+		LLMConfigdirRef:     repoWatch.Spec.Dev.LLM.ConfigdirRef,
+		LLMAPIKeySecretName: repoWatch.Spec.Dev.LLM.APIKeySecretRef,
+
+		GithubSecretName:      repoWatch.Spec.GithubSecretName,
+		DevcontainerConfigRef: repoWatch.Spec.Dev.DevcontainerConfigRef,
+
+		HTTPEnabled: true,
+		Replicas:    1,
 	}
 
-	if repoWatch.Spec.Dev.DevcontainerConfigRef != "" {
-		if err := unstructured.SetNestedField(sandbox.Object, repoWatch.Spec.Dev.DevcontainerConfigRef, "spec", "devcontainerConfigRef"); err != nil {
-			return err
-		}
-	}
+	sb := sandbox.NewDevSandbox(opts)
 
-	if err := controllerutil.SetControllerReference(repoWatch, sandbox, r.Scheme); err != nil {
+	if err := controllerutil.SetControllerReference(repoWatch, sb, r.Scheme); err != nil {
 		return err
 	}
 
-	return r.Create(ctx, sandbox)
+	return r.Create(ctx, sb)
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
1. Created `pkg/sandbox/dev_sandbox.go`: This file defines DevSandboxOptions and the NewDevSandbox function, which constructs and returns an unstructured DevSandbox object. This centralizes the logic for creating these resources.
2. Refactored `pkg/commands/create.go`: The CLI command for creating a dev sandbox now uses sandbox.NewDevSandbox. I removed the local DevSandbox struct definitions and updated the RunCreate function to populate the options and generate the resource.
3. Refactored `repowatch/controllers/repowatch_controller.go`: The createDevSandbox method in the controller now also uses sandbox.NewDevSandbox. I updated the method to map the controller's available data (like user info, LLM config, etc.) to DevSandboxOptions and ensured the controller reference is still correctly set.


### Usage example:

```
# bootstrapped default namespace first using #246 

 % ./bin/dev-sandbox bootstrap --namespace default 
Namespace "default" bootstrapped successfully
```

```
# Create dev-sandbox using current repo 
 % ./bin/dev-sandbox create barrz
devsandbox.custom.agents.x-k8s.io/barrz created
DevSandbox "barrz" created

 % kubectl get devsandbox barrz -o yaml       
apiVersion: custom.agents.x-k8s.io/v1alpha1
kind: DevSandbox
metadata:
  annotations:
    applyset.kubernetes.io/additional-namespaces: default
    applyset.kubernetes.io/contains-group-kinds: Sandbox.agents.x-k8s.io,Service
    applyset.kubernetes.io/tooling: kro/v0.5.1+dirty
  creationTimestamp: "2025-12-28T08:03:01Z"
  finalizers:
  - kro.run/finalizer
  generation: 1
  labels:
    applyset.kubernetes.io/id: applyset-6V-TG5mYknikuSSoZbjeHqq6lKMMtWRHEFeA5G_e3HA-v1
    createdBy: dev-sandbox-cli
    kro.run/kro-version: v0.5.1-dirty
    kro.run/owned: "true"
    kro.run/resource-graph-definition-id: dedc4d0e-ecf8-4e96-9787-c170d1d831b5
    kro.run/resource-graph-definition-name: dev-sandbox
  name: barrz
  namespace: default
  resourceVersion: "464196"
  uid: 3d62646a-0008-4e1a-906b-344adc2ec916
spec:
  destination:
    branch: ""
    origin: https://github.com/barney-s/gemini-for-kubernetes-development.git
    pushEnabled: true
    user:
      email: ba...com
      name: B...man
  devcontainerConfigRef: devcontainer-json
  gateway:
    httpEnabled: true
    ref: repo-agent-gateway
  githubSecretName: github-pat
  llm:
    apiKeySecretName: gemini-vscode-tokens
    configdirRef: ""
  llmBackend:
    name: gemini-cli
  replicas: 1
  resources:
    ephemeralStorage: 6Gi
  serviceAccountName: issue-sandbox
  source:
    cloneURL: https://github.com/barney-s/gemini-for-kubernetes-development.git
    htmlURL: https://github.com/barney-s/gemini-for-kubernetes-development
  user:
    dotFilesRepo: ""
status:
  agentDraft: devc-barrz
  conditions:
  - lastTransitionTime: "2025-12-28T08:03:10Z"
    message: Instance reconciled successfully
    observedGeneration: 1
    reason: ReconciliationSucceeded
    status: "True"
    type: InstanceSynced
  fqdn: devc-barrz-lb
  sandboxConditions:
  - lastTransitionTime: "2025-12-28T08:03:08Z"
    message: Pod is Ready; Service Exists
    observedGeneration: 1
    reason: DependenciesReady
    status: "True"
    type: Ready
  state: ACTIVE


 % kubectl get pods  devc-barrz     
NAME         READY   STATUS    RESTARTS   AGE
devc-barrz   1/1     Running   0          3m8s
```