### PR TITLE
dev-sandbox: simple support for reading gemini-cli chats

### DIFF
--- a/repo-agent/dev-sandbox/main.go
+++ b/repo-agent/dev-sandbox/main.go
@@ -65,6 +65,8 @@ func run(ctx context.Context) error {
 	rootCommand.AddCommand(commands.NewCodeCommand())
 	rootCommand.AddCommand(commands.NewTmuxCommand())
 
+	rootCommand.AddCommand(commands.NewThreadsCommand())
+
 	return rootCommand.ExecuteContext(ctx)
 }
 

--- a/repo-agent/pkg/commands/threads.go
+++ b/repo-agent/pkg/commands/threads.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// NewThreadsCommand creates a new "parent" cobra command for threads/chats in the dev sandbox.
+func NewThreadsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "threads",
+		Short: "Manage threads/chats in the dev sandbox",
+	}
+
+	cmd.AddCommand(NewThreadsListCommand())
+	cmd.AddCommand(NewThreadsGetCommand())
+
+	// The agent is added as a hidden command.
+	cmd.AddCommand(NewThreadsAgentCommand())
+
+	return cmd
+}
+
+type ThreadInfo struct {
+	SessionID   string `json:"sessionId,omitempty"`
+	ProjectHash string `json:"projectHash,omitempty"`
+
+	StartTime time.Time `json:"startTime,omitempty"`
+
+	TotalTokens int `json:"tokens,omitempty"`
+
+	Messages []ThreadMessage `json:"messages,omitempty"`
+}
+
+type ThreadMessage struct {
+	ID        string    `json:"id,omitempty"`
+	Timestamp time.Time `json:"timestamp,omitempty"`
+	Type      string    `json:"type,omitempty"`
+	Content   string    `json:"content,omitempty"`
+	Model     string    `json:"model,omitempty"`
+
+	ToolCalls []ToolCall `json:"toolCalls,omitempty"`
+}
+
+type ToolCall struct {
+	ID        string         `json:"id,omitempty"`
+	Name      string         `json:"name,omitempty"`
+	Arguments map[string]any `json:"arguments,omitempty"`
+}

--- a/repo-agent/pkg/commands/threads_agent.go
+++ b/repo-agent/pkg/commands/threads_agent.go
@@ -1,0 +1,199 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+)
+
+// ThreadsAgentOptions holds options for the ThreadsAgent function.
+type ThreadsAgentOptions struct {
+	SandboxName string
+
+	FilterThreadID string
+
+	IncludeMessages bool
+}
+
+// NewThreadsAgentCommand creates a new cobra command for managing LLM threads/chats in the dev sandbox.
+func NewThreadsAgentCommand() *cobra.Command {
+	var opt ThreadsAgentOptions
+
+	cmd := &cobra.Command{
+		Use:   "agent [sandbox-name]",
+		Short: "Manage LLM threads/chats in the dev sandbox",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return fmt.Errorf("threads agent command does not take any arguments")
+			}
+			return RunThreadsAgent(cmd.Context(), opt)
+		},
+	}
+	cmd.Hidden = true
+
+	cmd.Flags().StringVar(&opt.FilterThreadID, "thread-id", "", "If specified, filter only for the given thread ID")
+	cmd.Flags().BoolVar(&opt.IncludeMessages, "include-messages", false, "If specified, include messages in the output")
+
+	return cmd
+}
+
+// RunThreadsAgent runs the threads agent in the specified dev sandbox.
+func RunThreadsAgent(ctx context.Context, opt ThreadsAgentOptions) error {
+	agent := &threadsAgent{}
+
+	threads, err := agent.listThreads(ctx, opt)
+	if err != nil {
+		return fmt.Errorf("failed to list threads: %w", err)
+	}
+
+	b, err := json.Marshal(threads)
+	if err != nil {
+		return fmt.Errorf("failed to marshal threads to JSON: %w", err)
+	}
+	if _, err := os.Stdout.Write(b); err != nil {
+		return fmt.Errorf("failed to write threads to stdout: %w", err)
+	}
+	return nil
+}
+
+type threadsAgent struct {
+}
+
+type geminiSessionInfo struct {
+	SessionID   string `json:"sessionId"`
+	ProjectHash string `json:"projectHash"`
+
+	StartTime   string `json:"startTime"`
+	LastUpdated string `json:"lastUpdated"`
+
+	Messages []geminiSessionMessage `json:"messages"`
+}
+
+type geminiSessionMessage struct {
+	ID        string              `json:"id"`
+	Timestamp time.Time           `json:"timestamp"`
+	Type      string              `json:"type"`
+	Content   string              `json:"content"`
+	Thoughts  []json.RawMessage   `json:"thoughts"`
+	Tokens    geminiSessionTokens `json:"tokens"`
+	Model     string              `json:"model"`
+	ToolCalls []geminiToolCall    `json:"toolCalls"`
+}
+
+type geminiSessionTokens struct {
+	Input    int `json:"input"`
+	Output   int `json:"output"`
+	Cached   int `json:"cached"`
+	Thoughts int `json:"thoughts"`
+	Tool     int `json:"tool"`
+	Total    int `json:"total"`
+}
+
+type geminiToolCall struct {
+	ID                     string          `json:"id"`
+	Name                   string          `json:"name"`
+	Args                   map[string]any  `json:"args"`
+	Result                 json.RawMessage `json:"result"`
+	Status                 string          `json:"status"`
+	Timestamp              string          `json:"timestamp"`
+	ResultDisplay          string          `json:"resultDisplay"`
+	DisplayName            string          `json:"displayName"`
+	Description            string          `json:"description"`
+	RenderOutputAsMarkdown bool            `json:"renderOutputAsMarkdown"`
+}
+
+func (a *threadsAgent) listThreads(ctx context.Context, opt ThreadsAgentOptions) ([]ThreadInfo, error) {
+	log := klog.FromContext(ctx)
+
+	var out []ThreadInfo
+
+	// gemini --list-sessions only does one directory (the cwd), and doesn't output structured information.
+
+	// TODO: Fix identity in dev-sandbox (it will likely trigger some alarms if we keep using root)
+	geminiDir := "/root/.gemini/tmp"
+
+	parseGeminiSessionFile := func(path string) error {
+		if filepath.Base(path) == "logs.json" {
+			// ignore
+			return nil
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read gemini session file %q: %w", path, err)
+		}
+		var session geminiSessionInfo
+		if err := json.Unmarshal(b, &session); err != nil {
+			return fmt.Errorf("failed to unmarshal gemini session file %q: %w", path, err)
+		}
+
+		if opt.FilterThreadID != "" && session.SessionID != opt.FilterThreadID {
+			return nil
+		}
+
+		thread := ThreadInfo{
+			SessionID:   session.SessionID,
+			ProjectHash: session.ProjectHash,
+		}
+		if t, err := time.Parse(time.RFC3339, session.StartTime); err != nil {
+			log.Error(err, "failed to parse start time", "startTime", session.StartTime, "path", path)
+		} else {
+			thread.StartTime = t
+		}
+
+		for _, msg := range session.Messages {
+			thread.TotalTokens += msg.Tokens.Total
+		}
+
+		if opt.IncludeMessages {
+			for _, msg := range session.Messages {
+				msgOut := ThreadMessage{
+					ID:        msg.ID,
+					Timestamp: msg.Timestamp,
+					Type:      msg.Type,
+					Content:   msg.Content,
+					Model:     msg.Model,
+				}
+				for _, toolCall := range msg.ToolCalls {
+					toolCallOut := ToolCall{
+						ID:        toolCall.ID,
+						Name:      toolCall.Name,
+						Arguments: toolCall.Args,
+					}
+					msgOut.ToolCalls = append(msgOut.ToolCalls, toolCallOut)
+				}
+
+				thread.Messages = append(thread.Messages, msgOut)
+			}
+		}
+
+		out = append(out, thread)
+		return nil
+	}
+	if err := filepath.WalkDir(geminiDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if filepath.Ext(name) != ".json" {
+			return nil
+		}
+		if err := parseGeminiSessionFile(path); err != nil {
+			log.Error(err, "failed to parse gemini session file", "path", path)
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to walk gemini dir %q: %w", geminiDir, err)
+	}
+
+	return out, nil
+}

--- a/repo-agent/pkg/commands/threads_get.go
+++ b/repo-agent/pkg/commands/threads_get.go
@@ -1,0 +1,91 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// GetThreadsOptions holds options for the GetThreads function.
+type GetThreadsOptions struct {
+	SandboxName string
+	ThreadID    string
+}
+
+// NewThreadsGetCommand creates a new cobra command for getting LLM threads/chats in the dev sandbox.
+func NewThreadsGetCommand() *cobra.Command {
+	var opt GetThreadsOptions
+
+	cmd := &cobra.Command{
+		Use:   "get [sandbox-name] [thread-id]",
+		Short: "Get LLM thread/chat in the dev sandbox",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 2 {
+				return fmt.Errorf("threads get command requires exactly two arguments: the sandbox name and the thread ID")
+			}
+			opt.SandboxName = args[0]
+			opt.ThreadID = args[1]
+
+			return RunGetThreads(cmd.Context(), opt)
+		},
+	}
+	return cmd
+}
+
+// RunGetThreads gets LLM thread/chat in the specified dev sandbox.
+func RunGetThreads(ctx context.Context, opt GetThreadsOptions) error {
+	// 1. Find the pod
+	podID, err := findSandboxPod(ctx, opt.SandboxName)
+	if err != nil {
+		return err
+	}
+
+	thread, err := getThread(ctx, *podID, opt.ThreadID)
+	if err != nil {
+		return fmt.Errorf("failed to get thread: %w", err)
+	}
+
+	for _, msg := range thread.Messages {
+		fmt.Printf("%v\t%v\t%v\n", msg.Type, msg.Content, msg.Timestamp)
+		for _, toolCall := range msg.ToolCalls {
+			fmt.Printf("\tTool Call: %v\n", toolCall.Name)
+		}
+	}
+
+	return nil
+}
+
+// getThread runs the agent to get a thread in the given dev sandbox pod.
+func getThread(ctx context.Context, podID types.NamespacedName, threadID string) (*ThreadInfo, error) {
+	args := []string{
+		"kubectl", "exec", "--namespace", podID.Namespace, podID.Name, "--", "/repo-agent/dev-sandbox", "threads", "agent",
+	}
+	args = append(args, "--include-messages=true")
+	args = append(args, fmt.Sprintf("--thread-id=%s", threadID))
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("failed to launch dev-sandbox agent via kubectl: %w", err)
+	}
+
+	var threads []ThreadInfo
+	if err := json.Unmarshal(stdout.Bytes(), &threads); err != nil {
+		return nil, fmt.Errorf("failed to parse threads agent output: %w", err)
+	}
+
+	if len(threads) == 0 {
+		return nil, fmt.Errorf("thread with ID %q not found", threadID)
+	}
+
+	thread := threads[0]
+	return &thread, nil
+}

--- a/repo-agent/pkg/commands/threads_list.go
+++ b/repo-agent/pkg/commands/threads_list.go
@@ -1,0 +1,75 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// ListThreadsOptions holds options for the ListThreads function.
+type ListThreadsOptions struct {
+	SandboxName string
+}
+
+// NewThreadsListCommand creates a new cobra command for listing LLM threads/chats in the dev sandbox.
+func NewThreadsListCommand() *cobra.Command {
+	var opt ListThreadsOptions
+
+	cmd := &cobra.Command{
+		Use:   "list [sandbox-name]",
+		Short: "List LLM threads/chats in the dev sandbox",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return fmt.Errorf("threads list command requires exactly one argument: the sandbox name")
+			}
+			opt.SandboxName = args[0]
+
+			return RunListThreads(cmd.Context(), opt)
+		},
+	}
+	return cmd
+}
+
+// RunListThreads lists LLM threads/chats in the specified dev sandbox.
+func RunListThreads(ctx context.Context, opt ListThreadsOptions) error {
+	// 1. Find the pod
+	podID, err := findSandboxPod(ctx, opt.SandboxName)
+	if err != nil {
+		return err
+	}
+
+	threads, err := listThreads(ctx, *podID)
+	if err != nil {
+		return fmt.Errorf("failed to list threads: %w", err)
+	}
+
+	for _, thread := range threads {
+		fmt.Fprintf(os.Stdout, "%v\t%v\t%v\t%v\n", thread.SessionID, thread.ProjectHash, thread.StartTime, thread.TotalTokens)
+	}
+
+	return nil
+}
+
+// listThreads runs the agent to list threads in the given dev sandbox pod.
+func listThreads(ctx context.Context, podID types.NamespacedName) ([]ThreadInfo, error) {
+	cmd := exec.CommandContext(ctx, "kubectl", "exec", "--namespace", podID.Namespace, podID.Name, "--", "/repo-agent/dev-sandbox", "threads", "agent")
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("failed to launch dev-sandbox agent via kubectl: %w", err)
+	}
+
+	var threads []ThreadInfo
+	if err := json.Unmarshal(stdout.Bytes(), &threads); err != nil {
+		return nil, fmt.Errorf("failed to parse threads agent output: %w", err)
+	}
+	return threads, nil
+}


### PR DESCRIPTION
Because --list-sessions does not produce structured output,
we instead add a new hidden "threads agent" command that outputs JSON
from the raw session logs.

We add two new user-facing commands:

  threads list <sandbox>  - list all threads in the given sandbox
  threads get <sandbox> <thread-id> - get details of a specific thread
