### PR TITLE
Implement per-user Gemini API Key BYOK with Post-Login Enforcement

### DIFF
--- a/repo-agent/Makefile
+++ b/repo-agent/Makefile
@@ -17,8 +17,10 @@ KIND_CLUSTER_ARG=
 endif
 
 # Check pre-reqs
-ifndef GEMINI_API_KEY
-$(error GEMINI_API_KEY is not set. Please set it before running make.)
+ifndef GITHUB_CLIENT_ID
+  ifndef GEMINI_API_KEY
+    $(error GEMINI_API_KEY is not set. It is required for single-user mode. Please set it or GITHUB_CLIENT_ID before running make.)
+  endif
 endif
 
 ifndef GITHUB_PAT

--- a/repo-agent/installer.sh
+++ b/repo-agent/installer.sh
@@ -12,10 +12,9 @@ if [ "$INSTALL_MODE" != "single-user" ] && [ "$INSTALL_MODE" != "multi-user" ]; 
 fi
 
 # Required environment variables
-: "${GEMINI_API_KEY:?Error: GEMINI_API_KEY is not set. Please set it before running this script.}"
-
 if [ "$INSTALL_MODE" = "single-user" ]; then
-: "${GITHUB_PAT:?Error: GITHUB_PAT is not set. Please set it before running this script.}"
+: "${GEMINI_API_KEY:?Error: GEMINI_API_KEY is not set. It is required for 'single-user' installation mode.}"
+: "${GITHUB_PAT:?Error: GITHUB_PAT is not set. It is required for 'single-user' installation mode.}"
 else
 # GITHUB_PAT is optional for multi-user mode if OAuth flow is used
 : "${GITHUB_CLIENT_ID:?Error: GITHUB_CLIENT_ID is not set. Is is required for 'multi-user' installation mode.}" 
@@ -62,7 +61,7 @@ kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/downl
 
 echo "Install repo agent"
 kubectl apply -f https://github.com/gke-labs/gemini-for-kubernetes-development/releases/download/${REPO_AGENT_VERSION}/manifest.yaml
-kubectl create secret -n repo-agent-system generic gemini-vscode-tokens --from-literal=gemini=${GEMINI_API_KEY} --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret -n repo-agent-system generic gemini-vscode-tokens --from-literal=gemini="${GEMINI_API_KEY:-}" --dry-run=client -o yaml | kubectl apply -f -
 if [ ! -z "${ANTHROPIC_API_KEY:-}" ]; then
   echo "Creating Anthropic API key secret"
   kubectl create secret -n repo-agent-system generic anthropic-api-key --from-literal=claude=${ANTHROPIC_API_KEY} --dry-run=client -o yaml | kubectl apply -f -

--- a/repo-agent/review-ui/review-api/pkg/api/handlers_common.go
+++ b/repo-agent/review-ui/review-api/pkg/api/handlers_common.go
@@ -3,10 +3,14 @@ package api
 import (
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	pkgk8s "github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/k8s"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // --- Health Check ---
@@ -41,4 +45,24 @@ func (s *Server) proxy(c *gin.Context) {
 	}
 
 	c.String(resp.StatusCode, string(body))
+}
+
+func (s *Server) ensureGeminiKeySet(c *gin.Context, namespace string) bool {
+	sec, err := s.K8sManager.Clientset.CoreV1().Secrets(namespace).Get(c.Request.Context(), pkgk8s.GeminiSecretName, v1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Gemini API Key is not configured. Please set it in Settings."})
+		} else {
+			log.Printf("Error getting Gemini secret: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to check Gemini API Key configuration"})
+		}
+		return false
+	}
+
+	if val, ok := sec.Data["gemini"]; !ok || len(val) == 0 {
+		c.JSON(http.StatusForbidden, gin.H{"error": "Gemini API Key is empty. Please set it in Settings."})
+		return false
+	}
+
+	return true
 }

--- a/repo-agent/review-ui/review-api/pkg/api/handlers_repo.go
+++ b/repo-agent/review-ui/review-api/pkg/api/handlers_repo.go
@@ -23,6 +23,11 @@ import (
 
 func (s *Server) createRepoWatch(c *gin.Context) {
 	namespace := c.MustGet(auth.UserKey).(string)
+
+	if !s.ensureGeminiKeySet(c, namespace) {
+		return
+	}
+
 	var payload struct {
 		YAML string `json:"yaml"`
 	}

--- a/repo-agent/review-ui/review-api/pkg/api/handlers_settings.go
+++ b/repo-agent/review-ui/review-api/pkg/api/handlers_settings.go
@@ -39,7 +39,7 @@ func (s *Server) getSettings(c *gin.Context) {
 		}
 	}
 	if sec, err := s.K8sManager.Clientset.CoreV1().Secrets(namespace).Get(c.Request.Context(), pkgk8s.GeminiSecretName, v1.GetOptions{}); err == nil {
-		if _, ok := sec.Data["gemini"]; ok {
+		if val, ok := sec.Data["gemini"]; ok && len(val) > 0 {
 			settings["gemini_api_key_set"] = true
 		}
 	}

--- a/repo-agent/review-ui/ui/src/App.js
+++ b/repo-agent/review-ui/ui/src/App.js
@@ -19,11 +19,13 @@ function App() {
   const [showGithubConfig, setShowGithubConfig] = useState(false);
   const [githubClientId, setGithubClientId] = useState('');
   const [githubClientSecret, setGithubClientSecret] = useState('');
+  const [isGeminiKeySet, setIsGeminiKeySet] = useState(true); // Default to true to avoid flash of warning
   const [configError, setConfigError] = useState('');
 
   const [repos, setRepos] = useState([]);
   const [activeRepo, setActiveRepo] = useState(null);
   const activeRepoRef = useRef(activeRepo);
+  const hasRedirectedMissingKey = useRef(false);
   useEffect(() => { activeRepoRef.current = activeRepo; }, [activeRepo]);
 
   const [activeSubTab, setActiveSubTab] = useState({ repo: '', name: '' });
@@ -67,6 +69,21 @@ function App() {
       })
       .catch(err => console.error("Failed to fetch auth providers:", err));
   }, []);
+
+  useEffect(() => {
+    if (isAuthenticated || isGuest) {
+      fetch('/api/settings')
+        .then(res => res.json())
+        .then(data => {
+          setIsGeminiKeySet(data.gemini_api_key_set);
+          if (!data.gemini_api_key_set && !hasRedirectedMissingKey.current && isAuthenticated) {
+            hasRedirectedMissingKey.current = true;
+            setView('settings');
+          }
+        })
+        .catch(err => console.error("Failed to fetch settings:", err));
+    }
+  }, [isAuthenticated, isGuest]);
 
   useEffect(() => {
     if (activeRepo && (isAuthenticated || isGuest)) {
@@ -911,7 +928,14 @@ function App() {
             {repo.name}
           </button>
         ))}
-        <button className="tab-btn add-repo-btn" onClick={() => setView('add_repo')} title="Watch new repository">+</button>
+        <button className="tab-btn add-repo-btn" onClick={() => {
+          if (!isGeminiKeySet && !isGuest) {
+            alert("Please set your Gemini API Key in Settings before adding a repository.");
+            setView('settings');
+          } else {
+            setView('add_repo');
+          }
+        }} title="Watch new repository">+</button>
       </nav>
       {activeRepo && (
         <div className="active-repo-container">
@@ -1000,6 +1024,12 @@ function App() {
           </div>
         </div>
       </header>
+      
+      {(isAuthenticated || isGuest) && !isGeminiKeySet && (
+        <div className="warning-banner" style={{ backgroundColor: '#fff3cd', color: '#856404', padding: '10px', textAlign: 'center', borderBottom: '1px solid #ffeeba' }}>
+          <strong>⚠️ Gemini API Key Missing:</strong> Please configure your Gemini API Key in <a href="#" onClick={(e) => { e.preventDefault(); setView('settings'); }}>Settings</a> to enable code reviews and issue handling.
+        </div>
+      )}
       
       {view === 'dashboard' && renderDashboard()}
       {view === 'settings' && <Settings onBack={() => setView('dashboard')} />}


### PR DESCRIPTION
### Summary

    - Single-user mode continues to use the global GEMINI_API_KEY for the guest account.
    - Multi-tenant users are now notified via a dashboard banner if their Gemini API key is missing.
    - Authenticated users are automatically redirected to Settings on first login if the key is missing.
    - Enforcement: Sandbox creation (Add Repo) is blocked at both UI and API levels until a key is configured.
    - Streamlined secret management: Always copy Gemini secret during bootstrapping; empty keys are handled downstream.
    - Tooling: Updated installer.sh and Makefile to make GEMINI_API_KEY optional in multi-tenant mode.
    
 ### Rationale
  In multi-tenant environments, individual API keys are essential for quota management and security. This implementation ensures that sandbox operations (which consume Gemini API units) only proceed when a valid, non empty key is configured in the user's specific namespace.

  Key Changes

  1. UI: Proactive Notification & Guardrails
   - Missing Key Detection: The UI now checks the Gemini API key status for both Authenticated and Guest users.
   - Warning Banner: A persistent alert banner appears at the top of the dashboard if the Gemini API key is missing or empty.
   - Automatic Redirect: Upon first login, authenticated users are automatically redirected to the Settings page if their key is not yet configured.
   - Action Gating: The "Add Repository" button is guarded; it will alert the user and redirect them to Settings if clicked without a valid key.

  2. Backend: Robust Enforcement
   - Empty Key Validation: Updated the settings handler and enforcement helpers to distinguish between a "set" secret and a secret containing an empty string. A key is now only considered "configured" if it has a non-zero length.
   - API Security: Added ensureGeminiKeySet to the repository handlers. Any attempt to create a new RepoWatch via the API will return a 403 Forbidden if the Gemini key is missing or empty.
   - Unified Logic: Verification is now applied consistently across all namespaces (including default), ensuring guest users also provide a key if the system default is not set.

  3. Streamlined Infrastructure
   - Namespace Bootstrapping: BootstrapNamespace always copies the system-wide Gemini secret to new user namespaces. This ensures
     the secret object exists, while the application logic handles the enforcement based on the value of the key.
   - Tooling (Makefile & Installer): Made the GEMINI_API_KEY environment variable optional for multi-user/multi-tenant
     installations. This allows for "Zero-Key" deployments where users are expected to provide their own credentials after the initial setup.

  Technical Choices
   - Post-Login Check: By moving the check inside the application, we avoid interrupting the GitHub OAuth flow and provide a better UX for returning users who already have a key configured.
   - Session-Aware Redirect: Used a React useRef to ensure the automatic "Missing Key" redirect to Settings only happens once per session, preventing navigation loops.

  Manual Testing
   1. Initial Setup: Deploy the agent with GitHub OAuth enabled but leave GEMINI_API_KEY empty/unset.
   2. Login: Log in as a GitHub user.
      - Verify you are automatically redirected to the Settings page on the first landing.
      - Verify the yellow Warning Banner is visible on the dashboard.
   3. Attempt Action: Navigate to the dashboard and click the "+" (Add Repo) button.
      - Verify an alert appears and you are redirected to Settings.
   4. Configure Key: Enter a valid key in Settings and save.
      - Verify the Warning Banner disappears.
      - Verify you can now successfully add a repository.
   5. Guest Mode: Log out and use Guest mode.
      - Verify that guest users also see the warning banner if no global key was provided during installation.


<img width="2115" height="1015" alt="image" src="https://github.com/user-attachments/assets/7bc62d91-0327-47dd-84cb-0aacbbc82a43" />


NOTE: this is after forcibly going to home page after not setting GEMINI_API_KEY after first redirect, user is actually auto-redirected to "Settings"<img width="2132" height="1141" alt="image" src="https://github.com/user-attachments/assets/cb845e90-8f43-4f9b-a9a0-a9d5ef86b312" />