### PR TITLE
feat: error out if too many files were changed in a review

### DIFF
--- a/repo-agent/k8s/crds/review.gemini.google.com_repowatches.yaml
+++ b/repo-agent/k8s/crds/review.gemini.google.com_repowatches.yaml
@@ -162,6 +162,9 @@ spec:
                     type: object
                   maxActiveSandboxes:
                     type: integer
+                  maxReviewFiles:
+                    default: 30
+                    type: integer
                   maxSandboxes:
                     type: integer
                   pullRequests:

--- a/repo-agent/k8s/review-sandbox-rgd.yaml
+++ b/repo-agent/k8s/review-sandbox-rgd.yaml
@@ -10,6 +10,7 @@ spec:
     spec:
       # Spec fields that users can provide.
       replicas: integer | default=1
+      maxReviewFiles: integer | default=30
       llmBackend:
         name: string | default="gemini-cli"
       llm:
@@ -89,6 +90,8 @@ spec:
                       value: ${schema.spec.source.repo}
                     - name: PRID
                       value: ${schema.spec.source.pr}
+                    - name: MAX_REVIEW_FILES
+                      value: ${string(schema.spec.maxReviewFiles)}
                     # URL to the repository where the .devcontainer folder we want to load is located
                     - name: AGENT_PROMPT
                       value: ${schema.spec.llm.prompt}

--- a/repo-agent/repowatch/api/v1alpha1/repowatch_types.go
+++ b/repo-agent/repowatch/api/v1alpha1/repowatch_types.go
@@ -71,6 +71,11 @@ type PRReviewSpec struct {
 	// +kubebuilder:validation:Optional
 	MaxSandboxes int `json:"maxSandboxes,omitempty"`
 
+	// The maximum number of files to review in a PR.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=30
+	MaxReviewFiles int `json:"maxReviewFiles,omitempty"`
+
 	// The time in minutes after which a review sandbox will be scaled down to 0 replicas.
 	// +kubebuilder:validation:Optional
 	ReviewShutdownAfterMinutes int `json:"reviewShutdownAfterMinutes,omitempty"`

--- a/repo-agent/repowatch/controllers/repowatch_controller.go
+++ b/repo-agent/repowatch/controllers/repowatch_controller.go
@@ -979,7 +979,8 @@ func (r *RepoWatchReconciler) createReviewSandboxForPR(ctx context.Context, repo
 				"gateway": map[string]interface{}{
 					"httpEnabled": true,
 				},
-				"replicas": int64(1),
+				"maxReviewFiles": int64(repoWatch.Spec.Review.MaxReviewFiles),
+				"replicas":       int64(1),
 			},
 		},
 	}

--- a/repo-agent/review-sandbox/main.go
+++ b/repo-agent/review-sandbox/main.go
@@ -37,6 +37,8 @@ var (
 	}
 )
 
+const DefaultMaxReviewFiles = 30
+
 func main() {
 	go agentoutput.Run("review", gvr)
 
@@ -54,7 +56,11 @@ func main() {
 	_ = agentoutput.SetAgentState(gvr, "reviewing", "")
 	err = runReview()
 	if err != nil {
-		_ = agentoutput.SetAgentState(gvr, "error", err.Error())
+		if strings.Contains(err.Error(), "Too many files") {
+			_ = agentoutput.SetAgentState(gvr, "Error: Too many files", err.Error())
+		} else {
+			_ = agentoutput.SetAgentState(gvr, "error", err.Error())
+		}
 		log.Fatalf("failed reviewing: %v", err)
 	}
 	_ = agentoutput.SetAgentState(gvr, "review ready", "")
@@ -70,6 +76,8 @@ func main() {
 func runReview() error {
 	agentName := os.Getenv("AGENT_NAME")
 	log.Printf("Review with AGENT_NAME: %s", agentName)
+
+	maxReviewFiles := getMaxReviewFiles()
 
 	// save the incoming prompt
 	if err := os.WriteFile("../agent-prompt.txt", []byte(os.Getenv("AGENT_PROMPT")), 0644); err != nil {
@@ -90,6 +98,11 @@ func runReview() error {
 		if err != nil {
 			return fmt.Errorf("failed to parse diff from URL: %v", err)
 		}
+
+		if len(diffFiles) > maxReviewFiles {
+			return fmt.Errorf("Too many files to review: %d (max %d)", len(diffFiles), maxReviewFiles)
+		}
+
 		diffSize := getDiffSize(diffFiles)
 		expectedComments = sizeToComments[diffSize]
 		log.Printf("Diff size categorized as %s, expecting up to %d comments.", diffSize, expectedComments)
@@ -446,4 +459,18 @@ func dedupeAndCombineText(provider llm.Provider, text string) (string, error) {
 	}
 
 	return string(output), nil
+}
+
+func getMaxReviewFiles() int {
+	maxReviewFilesStr := os.Getenv("MAX_REVIEW_FILES")
+	maxReviewFiles := DefaultMaxReviewFiles
+	if maxReviewFilesStr != "" {
+		val, err := strconv.Atoi(maxReviewFilesStr)
+		if err != nil {
+			log.Printf("Invalid MAX_REVIEW_FILES value '%s', using default %d: %v", maxReviewFilesStr, DefaultMaxReviewFiles, err)
+		} else {
+			maxReviewFiles = val
+		}
+	}
+	return maxReviewFiles
 }

--- a/repo-agent/review-sandbox/main_test.go
+++ b/repo-agent/review-sandbox/main_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetMaxReviewFiles(t *testing.T) {
+	// Test default value
+	os.Unsetenv("MAX_REVIEW_FILES")
+	if val := getMaxReviewFiles(); val != DefaultMaxReviewFiles {
+		t.Errorf("Expected default %d, got %d", DefaultMaxReviewFiles, val)
+	}
+
+	// Test valid value
+	os.Setenv("MAX_REVIEW_FILES", "50")
+	if val := getMaxReviewFiles(); val != 50 {
+		t.Errorf("Expected 50, got %d", val)
+	}
+
+	// Test invalid value (should fallback to default)
+	os.Setenv("MAX_REVIEW_FILES", "invalid")
+	if val := getMaxReviewFiles(); val != DefaultMaxReviewFiles {
+		t.Errorf("Expected fallback to default %d, got %d", DefaultMaxReviewFiles, val)
+	}
+
+	// Cleanup
+	os.Unsetenv("MAX_REVIEW_FILES")
+}

--- a/repo-agent/review-sandbox/review-sandbox-rgd.yaml
+++ b/repo-agent/review-sandbox/review-sandbox-rgd.yaml
@@ -10,6 +10,7 @@ spec:
     spec:
       # Spec fields that users can provide.
       replicas: integer | default=1
+      maxReviewFiles: integer | default=30
       llmBackend:
         name: string | default="gemini-cli"
       llm:
@@ -89,6 +90,8 @@ spec:
                       value: ${schema.spec.source.repo}
                     - name: PRID
                       value: ${schema.spec.source.pr}
+                    - name: MAX_REVIEW_FILES
+                      value: ${string(schema.spec.maxReviewFiles)}
                     # URL to the repository where the .devcontainer folder we want to load is located
                     - name: AGENT_PROMPT
                       value: ${schema.spec.llm.prompt}


### PR DESCRIPTION

* default is 30
* can be changed by specifying repowatch `.spec.review.maxReviewFiles`

<img width="3292" height="756" alt="image" src="https://github.com/user-attachments/assets/a9d08656-5a79-4462-8f29-430d319f1b23" />

<img width="830" height="250" alt="image" src="https://github.com/user-attachments/assets/cf2ef6a9-4727-4401-924b-3a69028221ff" />

With custom no of files 77

<img width="830" height="250" alt="image" src="https://github.com/user-attachments/assets/a7d709d1-67e2-444f-97ba-3136f7a5f464" />
