### PR TITLE
fix: cleanup stale sandbox entries in review-api store

### DIFF
--- a/repo-agent/review-ui/review-api/pkg/api/handlers_dev.go
+++ b/repo-agent/review-ui/review-api/pkg/api/handlers_dev.go
@@ -194,7 +194,10 @@ func (s *Server) fetchAndPopulateDevSandboxes(ctx context.Context, namespace, re
 	}
 
 	log.Printf("Populating DevSandboxes: Found %d devsandboxes for Repo: %s", len(list.Items), repo)
+
+	activeSandboxes := make(map[string]bool)
 	for _, item := range list.Items {
+		activeSandboxes[item.GetName()] = true
 		replicas, found, err := unstructured.NestedInt64(item.Object, "spec", "replicas")
 		if err != nil || !found {
 			log.Printf("Replicas (.spec.replicas) not found in DevSandbox %s", item.GetName())
@@ -252,6 +255,22 @@ func (s *Server) fetchAndPopulateDevSandboxes(ctx context.Context, namespace, re
 			}
 			if err := s.Store.SaveDevSandbox(ctx, namespace, repo, sandbox); err != nil {
 				log.Printf("Failed to cache DevSandbox %s: %v", item.GetName(), err)
+			}
+		}
+	}
+
+	// Cleanup stale entries
+	storedSandboxes, err := s.Store.ListDevSandboxes(ctx, namespace, repo)
+	if err != nil {
+		log.Printf("Failed to list dev sandboxes for cleanup: %v", err)
+		return
+	}
+
+	for _, sb := range storedSandboxes {
+		if !activeSandboxes[sb.Name] {
+			log.Printf("Removing stale DevSandbox from store: %s", sb.Name)
+			if err := s.Store.DeleteDevSandbox(ctx, namespace, repo, sb.Name); err != nil {
+				log.Printf("Failed to delete stale DevSandbox %s: %v", sb.Name, err)
 			}
 		}
 	}

--- a/repo-agent/review-ui/review-api/pkg/api/handlers_issue.go
+++ b/repo-agent/review-ui/review-api/pkg/api/handlers_issue.go
@@ -51,6 +51,8 @@ func (s *Server) fetchAndPopulateIssues(ctx context.Context, namespace, repo, ha
 	}
 
 	log.Printf("Populating Issues: Found %d issuesandboxes for Repo: %s Handler: %s", len(list.Items), repo, handler)
+
+	activeIssues := make(map[string]bool)
 	for _, item := range list.Items {
 		log.Printf("Creating Issue entry for IssueSandbox: %s/%s", item.GetNamespace(), item.GetName())
 		replicas, found, err := unstructured.NestedInt64(item.Object, "spec", "replicas")
@@ -70,6 +72,9 @@ func (s *Server) fetchAndPopulateIssues(ctx context.Context, namespace, repo, ha
 			log.Printf("Title (.spec.source.title) not found in IssueSandbox %s", item.GetName())
 			continue
 		}
+
+		activeIssues[issueID] = true
+
 		htmlurl, found, err := unstructured.NestedString(item.Object, "spec", "source", "htmlURL")
 		if err != nil || !found {
 			log.Printf("htmlURL (.spec.source.htmlURL) not found in IssueSandbox %s", item.GetName())
@@ -146,6 +151,22 @@ func (s *Server) fetchAndPopulateIssues(ctx context.Context, namespace, repo, ha
 		}
 		if err := s.Store.SaveIssue(ctx, namespace, repo, handler, issue); err != nil {
 			log.Printf("Failed to cache Issue %s for repo %s handler %s: %v", issueID, repo, handler, err)
+		}
+	}
+
+	// Cleanup stale entries
+	storedIssues, err := s.Store.ListIssues(ctx, namespace, repo, handler)
+	if err != nil {
+		log.Printf("Failed to list issues for cleanup: %v", err)
+		return
+	}
+
+	for _, issue := range storedIssues {
+		if !activeIssues[issue.ID] {
+			log.Printf("Removing stale Issue from store: %s", issue.ID)
+			if err := s.Store.DeleteIssue(ctx, namespace, repo, handler, issue.ID); err != nil {
+				log.Printf("Failed to delete stale Issue %s: %v", issue.ID, err)
+			}
 		}
 	}
 }

--- a/repo-agent/review-ui/review-api/pkg/api/handlers_pr.go
+++ b/repo-agent/review-ui/review-api/pkg/api/handlers_pr.go
@@ -50,6 +50,8 @@ func (s *Server) fetchAndPopulatePRs(ctx context.Context, namespace, repo string
 	}
 
 	log.Printf("Populating PRs: Found %d reviewsandboxes for Repo: %s", len(list.Items), repo)
+
+	activePRs := make(map[string]bool)
 	for _, item := range list.Items {
 		log.Printf("Creating PR entry for ReviewSandbox: %s/%s", item.GetNamespace(), item.GetName())
 		// Get replicas and if it scaled down skip
@@ -75,6 +77,9 @@ func (s *Server) fetchAndPopulatePRs(ctx context.Context, namespace, repo string
 			log.Printf("Title (.spec.source.title) not found in ReviewSandbox  %s", item.GetName())
 			continue
 		}
+
+		activePRs[prID] = true
+
 		htmlurl, found, err := unstructured.NestedString(item.Object, "spec", "source", "htmlURL")
 		if err != nil || !found {
 			log.Printf("Title (.spec.source.htmlURL) not found in ReviewSandbox  %s", item.GetName())
@@ -128,6 +133,22 @@ func (s *Server) fetchAndPopulatePRs(ctx context.Context, namespace, repo string
 
 		if err := s.Store.SavePR(ctx, namespace, repo, pr); err != nil {
 			log.Printf("Failed to cache PR %s for repo %s: %v", pr.ID, repo, err)
+		}
+	}
+
+	// Cleanup stale entries
+	storedPRs, err := s.Store.ListPRs(ctx, namespace, repo)
+	if err != nil {
+		log.Printf("Failed to list PRs for cleanup: %v", err)
+		return
+	}
+
+	for _, pr := range storedPRs {
+		if !activePRs[pr.ID] {
+			log.Printf("Removing stale PR from store: %s", pr.ID)
+			if err := s.Store.DeletePR(ctx, namespace, repo, pr.ID); err != nil {
+				log.Printf("Failed to delete stale PR %s: %v", pr.ID, err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Updated `fetchAndPopulate` handlers for Dev, PR, and Issue sandboxes to track active resources found in the Kubernetes cluster. Added logic to compare active resources against stored entries and remove any stale sandboxes (e.g., those that have been deleted) from the Redis store, ensuring the API reflects the current state of the cluster.