### PR TITLE
refactor: move from log to klog

### DIFF
--- a/repo-agent/configdir/cmd/configdir-cli/main.go
+++ b/repo-agent/configdir/cmd/configdir-cli/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -33,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
@@ -52,45 +52,46 @@ func main() {
 
 	cfg, err := config.GetConfig()
 	if err != nil {
-		log.Fatalf("unable to get kubeconfig: %v", err)
+		klog.Fatalf("unable to get kubeconfig: %v", err)
 	}
 
 	if err := configdirv1alpha1.AddToScheme(scheme.Scheme); err != nil {
-		log.Fatalf("unable to add scheme: %v", err)
+		klog.Fatalf("unable to add scheme: %v", err)
 	}
 
 	cli, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	if err != nil {
-		log.Fatalf("unable to create kubernetes client: %v", err)
+		klog.Fatalf("unable to create kubernetes client: %v", err)
 	}
 
 	ctx := context.Background()
+
 	if directory == "" {
-		log.Fatalf("--directory is required when --sync-to-cluster is set.")
+		klog.Fatalf("--directory is required when --sync-to-cluster is set.")
 	}
 	if name == "" {
-		log.Print("--name is not set, using directory name as ConfigDir name")
+		klog.Info("--name is not set, using directory name as ConfigDir name")
 		name = filepath.Base(directory)
 	}
 	if syncToCluster {
 		if err := syncConfigDataToCluster(ctx, cli, directory, includeFolderName, name, namespace); err != nil {
-			log.Fatalf("failed: %v", err)
+			klog.Fatalf("failed: %v", err)
 		}
-		log.Print("successfully synced to cluster")
+		klog.Info("successfully synced to cluster")
 		return
 	}
 
 	if err := os.MkdirAll(directory, 0755); err != nil {
-		log.Fatalf("unable to create target directory: %v", err)
+		klog.Fatalf("unable to create target directory: %v", err)
 	}
 
 	configDir := &configdirv1alpha1.ConfigDir{}
 	if err := cli.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, configDir); err != nil {
 		if client.IgnoreNotFound(err) == nil && ignoreNotFoundError {
-			log.Printf("ConfigDir %s not found in namespace %s, but ignoring not found error as requested.", name, namespace)
+			klog.Info("ConfigDir not found, but ignoring not found error as requested.", "name", name, "namespace", namespace)
 			return
 		}
-		log.Fatalf("unable to fetch ConfigDir: %v", err)
+		klog.Fatalf("unable to fetch ConfigDir: %v", err)
 	}
 
 	for _, file := range configDir.Spec.Files {
@@ -104,45 +105,46 @@ func main() {
 		case source.ConfigMapRef != nil:
 			cm := &corev1.ConfigMap{}
 			if err := cli.Get(ctx, types.NamespacedName{Name: source.ConfigMapRef.Name, Namespace: namespace}, cm); err != nil {
-				log.Printf("unable to fetch ConfigMap %s: %v", source.ConfigMapRef.Name, err)
+				klog.Info("unable to fetch ConfigMap", "name", source.ConfigMapRef.Name, "err", err)
 				continue
 			}
 			content = []byte(cm.Data[source.ConfigMapRef.Key])
 		case source.SecretRef != nil:
 			secret := &corev1.Secret{}
 			if err := cli.Get(ctx, types.NamespacedName{Name: source.SecretRef.Name, Namespace: namespace}, secret); err != nil {
-				log.Printf("unable to fetch Secret %s: %v", source.SecretRef.Name, err)
+				klog.Info("unable to fetch Secret", "name", source.SecretRef.Name, "err", err)
 				continue
 			}
 			content = secret.Data[source.SecretRef.Key]
 		case source.URL != nil:
 			content, err = fetchURL(ctx, cli, namespace, source.URL)
 			if err != nil {
-				log.Printf("unable to fetch URL %s: %v", source.URL.Location, err)
+				klog.Info("unable to fetch URL", "location", source.URL.Location, "err", err)
 				continue
 			}
 		case source.FileContentKey != "":
 			content, err = findFileContent(ctx, cli, namespace, configDir.Spec.FileContentSelector, source.FileContentKey)
 			if err != nil {
-				log.Printf("unable to find file content key %s: %v", source.FileContentKey, err)
+				klog.Info("unable to find file content key", "key", source.FileContentKey, "err", err)
 				continue
 			}
 		}
 
 		filePath := filepath.Join(directory, file.Path)
 		if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
-			log.Printf("unable to create directory for %s: %v", filePath, err)
+			klog.Info("unable to create directory", "path", filePath, "err", err)
 			continue
 		}
 		if err := os.WriteFile(filePath, content, 0644); err != nil {
-			log.Printf("unable to write file: %s: %v", filePath, err)
+			klog.Info("unable to write file", "path", filePath, "err", err)
 			continue
 		}
-		log.Printf("synced file: %s", filePath)
+		klog.Info("synced file", "path", filePath)
 	}
 }
 
 func syncConfigDataToCluster(ctx context.Context, cli client.Client, sourceDir string, includeFolderName bool, configDirName, namespace string) error {
+	log := klog.FromContext(ctx)
 	type fileInfo struct {
 		path    string // relative path
 		content []byte
@@ -179,7 +181,7 @@ func syncConfigDataToCluster(ctx context.Context, cli client.Client, sourceDir s
 		return fmt.Errorf("failed to walk directory: %w", err)
 	}
 
-	log.Printf("found files. count: %d, totalSize: %d", len(files), totalSize)
+	log.Info("found files", "count", len(files), "totalSize", totalSize)
 
 	configDir := &configdirv1alpha1.ConfigDir{
 		ObjectMeta: metav1.ObjectMeta{
@@ -191,7 +193,7 @@ func syncConfigDataToCluster(ctx context.Context, cli client.Client, sourceDir s
 
 	const oneMB = 1 * 1024 * 1024
 	if totalSize < oneMB {
-		log.Print("total size is less than 1MB, using inline files")
+		log.Info("total size is less than 1MB, using inline files")
 		for _, f := range files {
 			configDir.Spec.Files = append(configDir.Spec.Files, configdirv1alpha1.FileItem{
 				Path: f.path,
@@ -201,7 +203,7 @@ func syncConfigDataToCluster(ctx context.Context, cli client.Client, sourceDir s
 			})
 		}
 	} else {
-		log.Print("total size is >= 1MB, using ConfigMaps for files")
+		log.Info("total size is >= 1MB, using ConfigMaps for files")
 		for _, f := range files {
 			if f.size > oneMB {
 				return fmt.Errorf("file %s is larger than 1MB and cannot be stored in a ConfigMap", f.path)
@@ -227,13 +229,13 @@ func syncConfigDataToCluster(ctx context.Context, cli client.Client, sourceDir s
 				if err := cli.Create(ctx, cm); err != nil {
 					return fmt.Errorf("failed to create configmap %s: %w", cmName, err)
 				}
-				log.Printf("created configmap %s", cmName)
+				log.Info("created configmap", "name", cmName)
 			} else {
 				existingCm.Data = cm.Data
 				if err := cli.Update(ctx, &existingCm); err != nil {
 					return fmt.Errorf("failed to update configmap %s: %w", cmName, err)
 				}
-				log.Printf("updated configmap %s", cmName)
+				log.Info("updated configmap", "name", cmName)
 			}
 
 			configDir.Spec.Files = append(configDir.Spec.Files, configdirv1alpha1.FileItem{
@@ -259,13 +261,13 @@ func syncConfigDataToCluster(ctx context.Context, cli client.Client, sourceDir s
 		if err := cli.Create(ctx, configDir); err != nil {
 			return fmt.Errorf("failed to create configdir %s: %w", configDirName, err)
 		}
-		log.Printf("created configdir %s", configDirName)
+		log.Info("created configdir", "name", configDirName)
 	} else {
 		existingCd.Spec = configDir.Spec
 		if err := cli.Update(ctx, &existingCd); err != nil {
 			return fmt.Errorf("failed to update configdir %s: %w", configDirName, err)
 		}
-		log.Printf("updated configdir %s", configDirName)
+		log.Info("updated configdir", "name", configDirName)
 	}
 
 	return nil

--- a/repo-agent/dev-sandbox/main.go
+++ b/repo-agent/dev-sandbox/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -188,7 +187,8 @@ func InitContainer(ctx context.Context) error {
 }
 
 func startCodeServer(ctx context.Context) (*exec.Cmd, error) {
-	log.Println("starting code-server")
+	log := klog.FromContext(ctx)
+	log.Info("starting code-server")
 	repoURL := os.Getenv("GIT_HTML_URL")
 	parts := strings.Split(strings.TrimPrefix(repoURL, "https://github.com/"), "/")
 	if len(parts) != 2 {
@@ -203,7 +203,7 @@ func startCodeServer(ctx context.Context) (*exec.Cmd, error) {
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("running code-server command failed: %w", err)
 	}
-	log.Printf("Running code-server in subprocess %d\n", cmd.Process.Pid)
+	log.Info("Running code-server in subprocess", "pid", cmd.Process.Pid)
 	return cmd, nil
 }
 

--- a/repo-agent/llm/cmd/claude-test/main.go
+++ b/repo-agent/llm/cmd/claude-test/main.go
@@ -16,9 +16,10 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
+
+	"k8s.io/klog/v2"
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/llm"
 )
@@ -43,25 +44,25 @@ func main() {
 	// The temporary directory and its contents are deleted when the main function exits.
 	tempDir, err := os.MkdirTemp("", "claude-test-")
 	if err != nil {
-		log.Fatalf("failed to create temp dir: %v", err)
+		klog.Fatalf("failed to create temp dir: %v", err)
 	}
 	defer os.RemoveAll(tempDir) // Clean up the temporary directory on exit
 
 	// Retrieve the API key from environment variable
 	apiKey := os.Getenv("ANTHROPIC_API_KEY")
 	if apiKey == "" {
-		log.Fatal("ANTHROPIC_API_KEY environment variable not set")
+		klog.Fatal("ANTHROPIC_API_KEY environment variable not set")
 	}
 	// Write the API key to a file named 'claude' within the temporary directory.
 	// The filename 'claude' is what the Setup function expects by default.
 	if err := os.WriteFile(filepath.Join(tempDir, "claude"), []byte(apiKey), 0600); err != nil {
-		log.Fatalf("failed to write api key file: %v", err)
+		klog.Fatalf("failed to write api key file: %v", err)
 	}
 
 	// Call the Setup function, passing the temporary directory as the tokens directory.
 	// This ensures the file-based API key retrieval path is tested.
 	if err := claude.Setup("", tempDir); err != nil {
-		log.Fatalf("failed to setup claude: %v", err)
+		klog.Fatalf("failed to setup claude: %v", err)
 	}
 
 	prompt := "What is the capital of France?"
@@ -73,7 +74,7 @@ func main() {
 
 	resp, err := claude.Run(prompt)
 	if err != nil {
-		log.Fatalf("failed to run claude: %v", err)
+		klog.Fatalf("failed to run claude: %v", err)
 	}
 
 	fmt.Printf("Response from Claude: %s\n", string(resp))

--- a/repo-agent/pkg/agentoutput/client.go
+++ b/repo-agent/pkg/agentoutput/client.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 )
 
 func getClient() (dynamic.Interface, string, string, error) {
@@ -54,6 +54,7 @@ func getClient() (dynamic.Interface, string, string, error) {
 
 // SetAgentState updates the agentState and agentStateMessage annotations.
 func SetAgentState(ctx context.Context, gvr schema.GroupVersionResource, state string, message string) error {
+	log := klog.FromContext(ctx)
 	dc, name, namespace, err := getClient()
 	if err != nil {
 		return err
@@ -79,10 +80,10 @@ func SetAgentState(ctx context.Context, gvr schema.GroupVersionResource, state s
 		},
 	}
 
-	log.Printf("applying resource %s/%s with state: %s\n", namespace, name, state)
+	log.Info("applying resource with state", "namespace", namespace, "name", name, "state", state)
 	_, err = dc.Resource(gvr).Namespace(namespace).Apply(ctx, name, applyObj, metav1.ApplyOptions{FieldManager: "agent-output-client"})
 	if err != nil {
-		log.Printf("error applying resource %s/%s: %v\n", namespace, name, err)
+		log.Info("error applying resource", "namespace", namespace, "name", name, "err", err)
 		return err
 	}
 	return nil
@@ -119,10 +120,10 @@ func SetAgentLabel(gvr schema.GroupVersionResource, labels []string) error {
 		},
 	}
 
-	log.Printf("applying resource %s/%s labels\n", namespace, name)
+	klog.Infof("applying resource %s/%s labels\n", namespace, name)
 	_, err = dc.Resource(gvr).Namespace(namespace).Apply(context.TODO(), name, applyObj, metav1.ApplyOptions{FieldManager: "agent-output-client"})
 	if err != nil {
-		log.Printf("error applying resource %s/%s: %v\n", namespace, name, err)
+		klog.Infof("error applying resource %s/%s: %v\n", namespace, name, err)
 		return err
 	}
 	return nil
@@ -148,7 +149,7 @@ func AddAgentLabel(gvr schema.GroupVersionResource, newLabels []string) error {
 	var existingLabels []string
 	if val, ok := annotations["agentLabels"]; ok {
 		if err := json.Unmarshal([]byte(val), &existingLabels); err != nil {
-			log.Printf("warning: failed to unmarshal existing agentLabels: %v, resetting", err)
+			klog.Infof("warning: failed to unmarshal existing agentLabels: %v, resetting", err)
 			existingLabels = []string{}
 		}
 	}

--- a/repo-agent/pkg/codeserver/codeserver.go
+++ b/repo-agent/pkg/codeserver/codeserver.go
@@ -2,10 +2,11 @@ package codeserver
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"strings"
+
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -22,7 +23,7 @@ func runDummyCommand() (*exec.Cmd, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("Running dummy command in subprocess %d\n", cmd.Process.Pid)
+	klog.Infof("Running dummy command in subprocess %d\n", cmd.Process.Pid)
 	return cmd, nil
 }
 
@@ -39,13 +40,13 @@ func Start() (*exec.Cmd, error) {
 	if _, err := os.Stat(codeServerPath); err != nil {
 		if os.IsNotExist(err) {
 			// code-server not found.
-			log.Println("code-server not found, running dummy command instead")
+			klog.Info("code-server not found, running dummy command instead")
 			return runDummyCommand()
 		}
 		return nil, err
 	}
 
-	log.Println("starting code-server")
+	klog.Info("starting code-server")
 	args := []string{"--auth=none", fmt.Sprintf("--bind-addr=0.0.0.0:%d", CodeServerPort), WorkspacePath + "/" + repo}
 	cmd := execCommand(codeServerPath, args...)
 	cmd.Stdout = os.Stdout
@@ -53,6 +54,6 @@ func Start() (*exec.Cmd, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("Running code-server in subprocess %d\n", cmd.Process.Pid)
+	klog.Infof("Running code-server in subprocess %d\n", cmd.Process.Pid)
 	return cmd, nil
 }

--- a/repo-agent/pkg/gitcli/gitcli.go
+++ b/repo-agent/pkg/gitcli/gitcli.go
@@ -2,9 +2,10 @@ package gitcli
 
 import (
 	"fmt"
-	"log"
 	"os/exec"
 	"strings"
+
+	"k8s.io/klog/v2"
 )
 
 var execCommand = exec.Command
@@ -16,7 +17,7 @@ func runCommand(args ...string) ([]byte, error) {
 	if len(args) > 3 && args[0] == "remote" && args[1] == "add" {
 		logArgs[3] = "*****"
 	}
-	log.Printf("Running command: %s %v", name, logArgs)
+	klog.Infof("Running command: %s %v", name, logArgs)
 	cmd := execCommand(name, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -65,12 +66,12 @@ func CheckoutOrCreateBranch(branch string) error {
 		return fmt.Errorf("failed to list git branches: %w", err)
 	}
 	if exists {
-		log.Printf("branch %s already exists, checking it out", branch)
+		klog.Infof("branch %s already exists, checking it out", branch)
 		if err := CheckoutBranch(branch); err != nil {
 			return fmt.Errorf("failed to checkout existing branch: %w", err)
 		}
 	} else {
-		log.Printf("branch %s does not exist, creating it", branch)
+		klog.Infof("branch %s does not exist, creating it", branch)
 		if err := CreateAndCheckoutBranch(branch); err != nil {
 			return fmt.Errorf("failed to create issue branch: %w", err)
 		}
@@ -103,7 +104,7 @@ func CommitAllChanges(message string) error {
 		return fmt.Errorf("failed to get git status: %w", err)
 	}
 	if hasChanges {
-		log.Println("Changes detected, committing")
+		klog.Info("Changes detected, committing")
 		if err := AddAll(); err != nil {
 			return fmt.Errorf("failed to git add: %v", err)
 		}

--- a/repo-agent/pkg/gitcli/gitcli_test.go
+++ b/repo-agent/pkg/gitcli/gitcli_test.go
@@ -2,12 +2,15 @@ package gitcli
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
-	"log"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
+
+	"k8s.io/klog/v2"
 )
 
 // TestHelperProcess isn't a real test. It's used as a helper process
@@ -146,10 +149,17 @@ func TestAddRemoteRedaction(t *testing.T) {
 	execCommand = fakeExecCommand
 	defer func() { execCommand = exec.Command }()
 
-	// Capture log output
-	var buf bytes.Buffer
-	log.SetOutput(&buf)
-	defer log.SetOutput(os.Stderr)
+	// Capture stderr
+	r, w, _ := os.Pipe()
+	origStderr := os.Stderr
+	os.Stderr = w
+
+	// Ensure klog logs to stderr
+	_ = flag.Set("logtostderr", "true")
+
+	defer func() {
+		os.Stderr = origStderr
+	}()
 
 	// URL with sensitive info
 	err := AddRemote("origin", "https://user:secret-token@github.com/repo.git")
@@ -157,7 +167,14 @@ func TestAddRemoteRedaction(t *testing.T) {
 		t.Errorf("Expected no error, got %v", err)
 	}
 
+	// Force flush klog
+	klog.Flush()
+	w.Close()
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
 	output := buf.String()
+
 	if strings.Contains(output, "secret-token") {
 		t.Errorf("Log output contains token: %s", output)
 	}

--- a/repo-agent/pkg/k8s/bootstrap.go
+++ b/repo-agent/pkg/k8s/bootstrap.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"context"
-	"log"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -10,6 +9,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -22,9 +22,10 @@ const (
 
 // BootstrapNamespace bootstraps the target namespace with necessary secrets and service accounts.
 func BootstrapNamespace(ctx context.Context, clientset kubernetes.Interface, targetNS string) error {
+	log := klog.FromContext(ctx)
 	_, err := clientset.CoreV1().Namespaces().Get(ctx, targetNS, v1.GetOptions{})
 	if errors.IsNotFound(err) {
-		log.Printf("Creating namespace %s", targetNS)
+		log.Info("Creating namespace", "name", targetNS)
 		ns := &corev1.Namespace{
 			ObjectMeta: v1.ObjectMeta{
 				Name:   targetNS,
@@ -40,20 +41,20 @@ func BootstrapNamespace(ctx context.Context, clientset kubernetes.Interface, tar
 
 	// Copy default secrets/configs from system namespace if they don't exist in user namespace
 	if err := CopySecret(ctx, clientset, SystemNamespace, GithubSecretName, targetNS, GithubSecretName); err != nil {
-		log.Printf("Warning: failed to copy default github secret: %v", err)
+		log.Info("Warning: failed to copy default github secret", "err", err)
 	}
 	if err := CopySecret(ctx, clientset, SystemNamespace, GeminiSecretName, targetNS, GeminiSecretName); err != nil {
-		log.Printf("Warning: failed to copy default gemini secret: %v", err)
+		log.Info("Warning: failed to copy default gemini secret", "err", err)
 	}
 	if err := CopySecret(ctx, clientset, SystemNamespace, ClaudeSecretName, targetNS, ClaudeSecretName); err != nil {
-		log.Printf("Warning: failed to copy default claude secret: %v", err)
+		log.Info("Warning: failed to copy default claude secret", "err", err)
 	}
 	if err := CopyConfigMap(ctx, clientset, SystemNamespace, DevContainerCM, targetNS, DevContainerCM); err != nil {
-		log.Printf("Debug: failed to copy %s: %v", DevContainerCM, err)
+		log.Info("Debug: failed to copy configmap", "name", DevContainerCM, "err", err)
 	}
 
 	if err := SetupServiceAccounts(ctx, clientset, targetNS); err != nil {
-		log.Printf("Warning: failed to setup service accounts: %v", err)
+		log.Info("Warning: failed to setup service accounts", "err", err)
 	}
 
 	return nil
@@ -61,9 +62,10 @@ func BootstrapNamespace(ctx context.Context, clientset kubernetes.Interface, tar
 
 // CopySecret copies a secret from source namespace to destination namespace.
 func CopySecret(ctx context.Context, clientset kubernetes.Interface, srcNS, srcName, dstNS, dstName string) error {
+	log := klog.FromContext(ctx)
 	src, err := clientset.CoreV1().Secrets(srcNS).Get(ctx, srcName, v1.GetOptions{})
 	if err != nil {
-		log.Printf("Error reading secret %s/%s: %v", srcNS, srcName, err)
+		log.Info("Error reading secret", "namespace", srcNS, "name", srcName, "err", err)
 		return err
 	}
 	dst := &corev1.Secret{ObjectMeta: v1.ObjectMeta{Name: dstName, Namespace: dstNS}, Data: src.Data, Type: src.Type}
@@ -84,6 +86,7 @@ func CopyConfigMap(ctx context.Context, clientset kubernetes.Interface, srcNS, s
 
 // SetupServiceAccounts sets up the necessary service accounts and role bindings in the namespace.
 func SetupServiceAccounts(ctx context.Context, clientset kubernetes.Interface, ns string) error {
+	log := klog.FromContext(ctx)
 	// --- Review Sandbox ---
 	saReview := &corev1.ServiceAccount{ObjectMeta: v1.ObjectMeta{Name: "review-sandbox", Namespace: ns}}
 	_, err := clientset.CoreV1().ServiceAccounts(ns).Create(ctx, saReview, v1.CreateOptions{})
@@ -104,7 +107,7 @@ func SetupServiceAccounts(ctx context.Context, clientset kubernetes.Interface, n
 
 	// Add to review-sandbox cluster role binding (to match make apply-common-for-examples)
 	if err := ensureClusterRoleBindingSubject(ctx, clientset, "review-sandbox", rbacv1.Subject{Kind: "ServiceAccount", Name: "review-sandbox", Namespace: ns}); err != nil {
-		log.Printf("Warning: failed to update review-sandbox cluster role binding: %v", err)
+		log.Info("Warning: failed to update review-sandbox cluster role binding", "err", err)
 	}
 
 	// Bind to configdir-controller cluster role (needed for init container)
@@ -138,7 +141,7 @@ func SetupServiceAccounts(ctx context.Context, clientset kubernetes.Interface, n
 
 	// Add to dev-sandbox cluster role binding (to match make apply-common-for-examples)
 	if err := ensureClusterRoleBindingSubject(ctx, clientset, "dev-sandbox", rbacv1.Subject{Kind: "ServiceAccount", Name: "dev-sandbox", Namespace: ns}); err != nil {
-		log.Printf("Warning: failed to update dev-sandbox cluster role binding: %v", err)
+		log.Info("Warning: failed to update dev-sandbox cluster role binding", "err", err)
 	}
 
 	// Bind to configdir-controller cluster role (needed for init container)
@@ -172,7 +175,7 @@ func SetupServiceAccounts(ctx context.Context, clientset kubernetes.Interface, n
 
 	// Add to issue-sandbox cluster role binding (to match make apply-common-for-examples)
 	if err := ensureClusterRoleBindingSubject(ctx, clientset, "issue-sandbox", rbacv1.Subject{Kind: "ServiceAccount", Name: "issue-sandbox", Namespace: ns}); err != nil {
-		log.Printf("Warning: failed to update issue-sandbox cluster role binding: %v", err)
+		log.Info("Warning: failed to update issue-sandbox cluster role binding", "err", err)
 	}
 
 	// Bind to configdir-controller cluster role (needed for init container)

--- a/repo-agent/pkg/llm/claude.go
+++ b/repo-agent/pkg/llm/claude.go
@@ -19,10 +19,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
+
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -62,7 +63,7 @@ func (c *Claude) Setup(_, tokensDir string) error {
 	apiKeyBytes, err := os.ReadFile(apiKeyPath)
 	if err != nil {
 		// If reading from file fails, fall back to checking the environment variable
-		log.Printf("Failed to read API key from %s: %v", apiKeyPath, err)
+		klog.Infof("Failed to read API key from %s: %v", apiKeyPath, err)
 		apiKey, ok := os.LookupEnv(AnthropicAPIKeyEnvVar)
 		if !ok {
 			return fmt.Errorf("API key not found in %s or %s environment variable", apiKeyPath, AnthropicAPIKeyEnvVar)
@@ -83,7 +84,7 @@ func (c *Claude) ExpandPrompt(prompt string) (string, error) {
 }
 
 func (c *Claude) Run(prompt string) ([]byte, error) {
-	log.Printf("Claude provider called with prompt: %s", prompt)
+	klog.Infof("Claude provider called with prompt: %s", prompt)
 
 	requestBody, err := json.Marshal(map[string]interface{}{
 		"model":      defaultClaudeModel,
@@ -128,7 +129,7 @@ func (c *Claude) Run(prompt string) ([]byte, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		log.Printf("Claude API request failed with status %d: %s", resp.StatusCode, string(body))
+		klog.Infof("Claude API request failed with status %d: %s", resp.StatusCode, string(body))
 		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 

--- a/repo-agent/pkg/llm/dummy.go
+++ b/repo-agent/pkg/llm/dummy.go
@@ -2,8 +2,9 @@ package llm
 
 import (
 	"bytes"
-	"log"
 	"strings"
+
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -35,12 +36,12 @@ type Dummy struct {
 }
 
 func (d *Dummy) Setup(_, _ string) error {
-	log.Println("Dummy provider setup")
+	klog.Info("Dummy provider setup")
 	return nil
 }
 
 func (d *Dummy) Cleanup(_ string) error {
-	log.Println("Dummy provider cleanup")
+	klog.Info("Dummy provider cleanup")
 	return nil
 }
 
@@ -61,7 +62,7 @@ func (d *Dummy) response(prompt string) []byte {
 
 func (d *Dummy) Run(prompt string) ([]byte, error) {
 	var err error
-	log.Printf("Dummy provider running with prompt")
+	klog.Infof("Dummy provider running with prompt")
 	output := d.response(prompt)
 	for _, p := range d.processors {
 		output, err = p(output)

--- a/repo-agent/pkg/llm/gemini.go
+++ b/repo-agent/pkg/llm/gemini.go
@@ -17,10 +17,11 @@ package llm
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"k8s.io/klog/v2"
 )
 
 // Gemini is an Provider that uses the gemini-cli.
@@ -41,10 +42,10 @@ func (g *Gemini) Setup(workspacesDir, tokensDir string) error {
 	// if .gemini directory exists in /workspaces copy it to home directory
 	geminiConfigDir := filepath.Join(workspacesDir, ".gemini")
 	if _, err := os.Stat(geminiConfigDir); err == nil {
-		log.Println(".gemini directory exists in /workspaces, copying to repo directory")
+		klog.Info(".gemini directory exists in /workspaces, copying to repo directory")
 		// if desitation .gemini directory exists move it to .gemini.bak
 		if _, err := os.Stat(".gemini"); err == nil {
-			log.Println(".gemini directory exists in repo directory, moving to .gemini.bak")
+			klog.Info(".gemini directory exists in repo directory, moving to .gemini.bak")
 			err := os.Rename(".gemini", ".gemini.bak")
 			if err != nil {
 				return fmt.Errorf("failed to move .gemini to .gemini.bak: %v", err)
@@ -57,19 +58,19 @@ func (g *Gemini) Setup(workspacesDir, tokensDir string) error {
 			return fmt.Errorf("failed to copy .gemini directory: %v", err)
 		}
 	} else {
-		log.Println(".gemini directory does not exist in /workspaces")
+		klog.Info(".gemini directory does not exist in /workspaces")
 	}
 
 	// Ensure root settings.json has previewFeatures
 	if err := ensureSettings(".gemini"); err != nil {
-		log.Printf("Warning: failed to ensure .gemini/settings.json: %v", err)
+		klog.Infof("Warning: failed to ensure .gemini/settings.json: %v", err)
 	}
 
 	// Ensure home directory settings.json has previewFeatures
 	homeDir, err := os.UserHomeDir()
 	if err == nil {
 		if err := ensureSettings(filepath.Join(homeDir, ".gemini")); err != nil {
-			log.Printf("Warning: failed to ensure ~/.gemini/settings.json: %v", err)
+			klog.Infof("Warning: failed to ensure ~/.gemini/settings.json: %v", err)
 		}
 	}
 
@@ -93,7 +94,7 @@ func ensureSettings(geminiDir string) error {
 		data, err := os.ReadFile(settingsPath)
 		if err == nil {
 			if err := json.Unmarshal(data, &settings); err != nil {
-				log.Printf("Warning: failed to unmarshal existing settings.json: %v", err)
+				klog.Infof("Warning: failed to unmarshal existing settings.json: %v", err)
 			}
 		}
 	}
@@ -128,9 +129,9 @@ func ensureSettings(geminiDir string) error {
 func (g *Gemini) Cleanup(workspacesDir string) error {
 	geminiBackupDir := filepath.Join(workspacesDir, ".gemini.bak")
 	if _, err := os.Stat(geminiBackupDir); err == nil {
-		log.Println("moving .gemini.bak -> .gemini")
+		klog.Info("moving .gemini.bak -> .gemini")
 		if err := os.RemoveAll(geminiBackupDir); err != nil {
-			log.Printf("failed to remove .gemini directory: %v", err)
+			klog.Infof("failed to remove .gemini directory: %v", err)
 		}
 		if err := os.Rename(".gemini.bak", ".gemini"); err != nil {
 			return fmt.Errorf("failed to move .gemini.bak to .gemini: %w", err)
@@ -144,11 +145,11 @@ func (g *Gemini) ExpandPrompt(prompt string) (string, error) {
 }
 
 func (g *Gemini) Run(agentPrompt string) ([]byte, error) {
-	log.Println("running gemini")
+	klog.Info("running gemini")
 
 	output, err := g.Executor.Run("gemini", "-y", "-p", agentPrompt)
 	if err != nil {
-		log.Printf("gemini command failed: %v. Output: %s", err, string(output))
+		klog.Infof("gemini command failed: %v. Output: %s", err, string(output))
 		return nil, err
 	}
 

--- a/repo-agent/pkg/sandbox/workflow.go
+++ b/repo-agent/pkg/sandbox/workflow.go
@@ -3,10 +3,10 @@ package sandbox
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/agentoutput"
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/gitcli"
@@ -38,7 +38,7 @@ func PrepareGitBranch(cfg Config) (string, error) {
 	// Typically origin would be the upstream repo and not the user's fork
 	// Removing origin to prevent accidental pushes to upstream
 	if err := gitcli.RemoveRemote("origin"); err != nil {
-		log.Printf("could not remove origin, probably because it does not exist: %v", err)
+		klog.Infof("could not remove origin, probably because it does not exist: %v", err)
 	}
 
 	if cfg.PushEnabled && cfg.GithubUserOrigin != "" {
@@ -73,7 +73,8 @@ func PrepareGitBranch(cfg Config) (string, error) {
 }
 
 func RunAgent(ctx context.Context, cfg Config) error {
-	log.Printf("Starting agent with AGENT_NAME: %s", cfg.AgentName)
+	log := klog.FromContext(ctx)
+	log.Info("Starting agent", "agentName", cfg.AgentName)
 
 	provider, err := llm.NewLLMProvider(cfg.AgentName)
 	if err != nil {
@@ -99,7 +100,7 @@ func RunAgent(ctx context.Context, cfg Config) error {
 
 	output, err := provider.Run(cfg.AgentPrompt)
 	if err != nil {
-		log.Printf("Agent run failed: %v, output: %s", err, string(output))
+		log.Info("Agent run failed", "err", err, "output", string(output))
 	}
 	if err := os.WriteFile("../agent-output.txt", output, 0644); err != nil {
 		return fmt.Errorf("failed to write agent-output.txt: %w", err)
@@ -114,6 +115,7 @@ func RunAgent(ctx context.Context, cfg Config) error {
 }
 
 func ProcessGitChanges(ctx context.Context, cfg Config, oldCommitID string, commitMessage string) error {
+	log := klog.FromContext(ctx)
 	// Commit and push
 	if cfg.GithubUserEmail != "" {
 		if err := gitcli.CommitAllChanges(commitMessage); err != nil {
@@ -127,7 +129,7 @@ func ProcessGitChanges(ctx context.Context, cfg Config, oldCommitID string, comm
 	}
 
 	if newCommitID != oldCommitID {
-		log.Println("New changes being committed")
+		log.Info("New changes being committed")
 		if cfg.PushEnabled {
 			if cfg.ReportStatus {
 				_ = agentoutput.SetAgentState(ctx, cfg.GVR, "pushing changes", "")
@@ -135,9 +137,9 @@ func ProcessGitChanges(ctx context.Context, cfg Config, oldCommitID string, comm
 			if err := gitcli.Push("origin", cfg.BranchName, true); err != nil {
 				return fmt.Errorf("failed to push changes: %w", err)
 			}
-			log.Println("New changes pushed")
+			log.Info("New changes pushed")
 		} else {
-			log.Println("New changes not pushed. Git push not enabled")
+			log.Info("New changes not pushed. Git push not enabled")
 		}
 	}
 	return nil

--- a/repo-agent/review-ui/review-api/main.go
+++ b/repo-agent/review-ui/review-api/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
-	"log"
 	"os"
 	"strings"
 
@@ -21,6 +20,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -38,7 +38,7 @@ func main() {
 	// Ping redis to ensure connection
 	_, err := rdb.Ping(context.Background()).Result()
 	if err != nil {
-		log.Fatalf("Failed to connect to Redis: %v", err)
+		klog.Fatalf("Failed to connect to Redis: %v", err)
 	}
 
 	// Pre-populate mock data in Redis
@@ -47,23 +47,23 @@ func main() {
 	// Kubernetes client
 	config, err := rest.InClusterConfig()
 	if err != nil {
-		log.Printf("Failed to get in-cluster config, trying local config: %v", err)
+		klog.Infof("Failed to get in-cluster config, trying local config: %v", err)
 		kubeconfig := os.Getenv("KUBECONFIG")
 		if kubeconfig == "" {
 			kubeconfig = os.Getenv("HOME") + "/.kube/config"
 		}
 		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
 		if err != nil {
-			log.Fatalf("Failed to get local kubeconfig: %v", err)
+			klog.Fatalf("Failed to get local kubeconfig: %v", err)
 		}
 	}
 	k8sClient, err := dynamic.NewForConfig(config)
 	if err != nil {
-		log.Fatalf("Failed to create kubernetes client: %v", err)
+		klog.Fatalf("Failed to create kubernetes client: %v", err)
 	}
 	k8sClientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		log.Fatalf("Failed to create clientset: %v", err)
+		klog.Fatalf("Failed to create clientset: %v", err)
 	}
 
 	// K8s Manager
@@ -73,9 +73,9 @@ func main() {
 	var allowedUsers []string
 	if allowedUsersStr := os.Getenv("GITHUB_ALLOWED_USERS"); allowedUsersStr != "" {
 		allowedUsers = strings.Split(allowedUsersStr, ",")
-		log.Printf("GitHub authentication restricted to users: %v", allowedUsers)
+		klog.Infof("GitHub authentication restricted to users: %v", allowedUsers)
 	} else {
-		log.Println("No GITHUB_ALLOWED_USERS environment variable set. All GitHub users allowed to authenticate.")
+		klog.Info("No GITHUB_ALLOWED_USERS environment variable set. All GitHub users allowed to authenticate.")
 	}
 
 	// Authenticator
@@ -94,7 +94,7 @@ func main() {
 		// Generate a random secret if not provided
 		b := make([]byte, 32)
 		if _, err := rand.Read(b); err != nil {
-			log.Fatalf("Failed to generate random session secret: %v", err)
+			klog.Fatalf("Failed to generate random session secret: %v", err)
 		}
 		sessionSecret = base64.StdEncoding.EncodeToString(b)
 	}
@@ -106,6 +106,6 @@ func main() {
 
 	err = router.Run(":8080")
 	if err != nil {
-		log.Fatalf("Failed to start router: %v", err)
+		klog.Fatalf("Failed to start router: %v", err)
 	}
 }

--- a/repo-agent/review-ui/review-api/pkg/api/handlers_common.go
+++ b/repo-agent/review-ui/review-api/pkg/api/handlers_common.go
@@ -3,7 +3,6 @@ package api
 import (
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"strings"
 
@@ -11,6 +10,7 @@ import (
 	pkgk8s "github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/k8s"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 )
 
 // --- Health Check ---
@@ -53,7 +53,7 @@ func (s *Server) ensureGeminiKeySet(c *gin.Context, namespace string) bool {
 		if errors.IsNotFound(err) {
 			c.JSON(http.StatusForbidden, gin.H{"error": "Gemini API Key is not configured. Please set it in Settings."})
 		} else {
-			log.Printf("Error getting Gemini secret: %v", err)
+			klog.Infof("Error getting Gemini secret: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to check Gemini API Key configuration"})
 		}
 		return false

--- a/repo-agent/review-ui/review-api/pkg/api/handlers_dev.go
+++ b/repo-agent/review-ui/review-api/pkg/api/handlers_dev.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
-	"log"
 	"net/http"
 	"strings"
 
@@ -17,16 +16,18 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 )
 
 func (s *Server) getDevSandboxes(c *gin.Context) {
+	log := klog.FromContext(c.Request.Context())
 	namespace := c.MustGet(auth.UserKey).(string)
 	repo := c.Param("repo")
 	s.fetchAndPopulateDevSandboxes(c.Request.Context(), namespace, repo)
 
 	sandboxes, err := s.Store.ListDevSandboxes(c.Request.Context(), namespace, repo)
 	if err != nil {
-		log.Printf("Error listing dev sandboxes: %v", err)
+		log.Info("Error listing dev sandboxes", "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list dev sandboxes"})
 		return
 	}
@@ -35,6 +36,7 @@ func (s *Server) getDevSandboxes(c *gin.Context) {
 }
 
 func (s *Server) createDevSandbox(c *gin.Context) {
+	log := klog.FromContext(c.Request.Context())
 	namespace := c.MustGet(auth.UserKey).(string)
 	repo := c.Param("repo")
 
@@ -88,7 +90,7 @@ func (s *Server) createDevSandbox(c *gin.Context) {
 			userEmail = string(email)
 		}
 	} else {
-		log.Printf("Failed to get github secret for user %s: %v", namespace, err)
+		log.Info("Failed to get github secret for user", "user", namespace, "err", err)
 	}
 
 	// Sanitize branch name for K8s resource name to match controller logic
@@ -118,7 +120,7 @@ func (s *Server) createDevSandbox(c *gin.Context) {
 
 		if changed {
 			if err := unstructured.SetNestedStringSlice(rw.Object, newExclude, "spec", "dev", "excludeBranches"); err != nil {
-				log.Printf("Failed to update excludeBranches in local object: %v", err)
+				log.Info("Failed to update excludeBranches in local object", "err", err)
 			} else {
 				// Update RepoWatch in K8s
 				_, updateErr := s.K8sManager.Client.Resource(schema.GroupVersionResource{
@@ -127,7 +129,7 @@ func (s *Server) createDevSandbox(c *gin.Context) {
 					Resource: "repowatches",
 				}).Namespace(namespace).Update(c.Request.Context(), rw, v1.UpdateOptions{})
 				if updateErr != nil {
-					log.Printf("Failed to update RepoWatch to remove excluded branch: %v", updateErr)
+					log.Info("Failed to update RepoWatch to remove excluded branch", "err", updateErr)
 				}
 			}
 		}
@@ -170,7 +172,7 @@ func (s *Server) createDevSandbox(c *gin.Context) {
 
 	_, err = s.K8sManager.Client.Resource(gvr).Namespace(namespace).Create(c.Request.Context(), sb, v1.CreateOptions{})
 	if err != nil {
-		log.Printf("Failed to create DevSandbox: %v", err)
+		log.Info("Failed to create DevSandbox", "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create DevSandbox", "details": err.Error()})
 		return
 	}
@@ -179,6 +181,7 @@ func (s *Server) createDevSandbox(c *gin.Context) {
 }
 
 func (s *Server) fetchAndPopulateDevSandboxes(ctx context.Context, namespace, repo string) {
+	log := klog.FromContext(ctx)
 	gvr := schema.GroupVersionResource{
 		Group:    "custom.agents.x-k8s.io",
 		Version:  "v1alpha1",
@@ -189,30 +192,30 @@ func (s *Server) fetchAndPopulateDevSandboxes(ctx context.Context, namespace, re
 			LabelSelector: fmt.Sprintf("review.gemini.google.com/repowatch=%s", repo),
 		})
 	if err != nil {
-		log.Printf("Failed to list DevSandbox CRs: %v.", err)
+		log.Info("Failed to list DevSandbox CRs", "err", err)
 		return
 	}
 
-	log.Printf("Populating DevSandboxes: Found %d devsandboxes for Repo: %s", len(list.Items), repo)
+	log.Info("Populating DevSandboxes", "devsandbox_count", len(list.Items), "repo", repo)
 
 	activeSandboxes := make(map[string]bool)
 	for _, item := range list.Items {
 		activeSandboxes[item.GetName()] = true
 		replicas, found, err := unstructured.NestedInt64(item.Object, "spec", "replicas")
 		if err != nil || !found {
-			log.Printf("Replicas (.spec.replicas) not found in DevSandbox %s", item.GetName())
+			log.Info("Replicas (.spec.replicas) not found in DevSandbox", "name", item.GetName())
 			continue
 		}
 
 		branch, found, err := unstructured.NestedString(item.Object, "spec", "destination", "branch")
 		if err != nil || !found {
-			log.Printf("Branch (.spec.destination.branch) not found in DevSandbox %s", item.GetName())
+			log.Info("Branch (.spec.destination.branch) not found in DevSandbox", "name", item.GetName())
 			branch = "nobranch" // fallback
 		}
 
 		cloneURL, found, err := unstructured.NestedString(item.Object, "spec", "source", "cloneURL")
 		if err != nil || !found {
-			log.Printf("cloneURL (.spec.source.cloneURL) not found in DevSandbox %s", item.GetName())
+			log.Info("cloneURL (.spec.source.cloneURL) not found in DevSandbox", "name", item.GetName())
 			cloneURL = "https://github.com/noorg/norepo.git"
 		}
 		repoParts := strings.Split(strings.TrimSuffix(cloneURL, ".git"), "/")
@@ -254,7 +257,7 @@ func (s *Server) fetchAndPopulateDevSandboxes(ctx context.Context, namespace, re
 				Labels:            labels,
 			}
 			if err := s.Store.SaveDevSandbox(ctx, namespace, repo, sandbox); err != nil {
-				log.Printf("Failed to cache DevSandbox %s: %v", item.GetName(), err)
+				log.Info("Failed to cache DevSandbox", "name", item.GetName(), "err", err)
 			}
 		}
 	}
@@ -262,21 +265,22 @@ func (s *Server) fetchAndPopulateDevSandboxes(ctx context.Context, namespace, re
 	// Cleanup stale entries
 	storedSandboxes, err := s.Store.ListDevSandboxes(ctx, namespace, repo)
 	if err != nil {
-		log.Printf("Failed to list dev sandboxes for cleanup: %v", err)
+		log.Info("Failed to list dev sandboxes for cleanup", "err", err)
 		return
 	}
 
 	for _, sb := range storedSandboxes {
 		if !activeSandboxes[sb.Name] {
-			log.Printf("Removing stale DevSandbox from store: %s", sb.Name)
+			log.Info("Removing stale DevSandbox from store", "name", sb.Name)
 			if err := s.Store.DeleteDevSandbox(ctx, namespace, repo, sb.Name); err != nil {
-				log.Printf("Failed to delete stale DevSandbox %s: %v", sb.Name, err)
+				log.Info("Failed to delete stale DevSandbox", "name", sb.Name, "err", err)
 			}
 		}
 	}
 }
 
 func (s *Server) deleteDevSandbox(c *gin.Context) {
+	log := klog.FromContext(c.Request.Context())
 	namespace := c.MustGet(auth.UserKey).(string)
 	repo := c.Param("repo")
 	name := c.Param("name") // This is the sandbox name
@@ -288,7 +292,7 @@ func (s *Server) deleteDevSandbox(c *gin.Context) {
 	}
 
 	if err := s.Store.DeleteDevSandbox(c.Request.Context(), namespace, repo, name); err != nil {
-		log.Printf("Failed to DEL DevSandbox data from Redis: %v", err)
+		log.Info("Failed to DEL DevSandbox data from Redis", "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to DEL DevSandbox data from Redis"})
 		return
 	}
@@ -297,11 +301,12 @@ func (s *Server) deleteDevSandbox(c *gin.Context) {
 }
 
 func (s *Server) scaleUpDevSandbox(c *gin.Context) {
+	log := klog.FromContext(c.Request.Context())
 	namespace := c.MustGet(auth.UserKey).(string)
 	name := c.Param("name")
 
 	if err := s.K8sManager.ScaleupDevSandboxHelper(c.Request.Context(), namespace, name); err != nil {
-		log.Printf("Failed to scale up dev sandbox %s: %v", name, err)
+		log.Info("Failed to scale up dev sandbox", "name", name, "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to scale up dev sandbox"})
 		return
 	}
@@ -310,6 +315,7 @@ func (s *Server) scaleUpDevSandbox(c *gin.Context) {
 }
 
 func (s *Server) scaleDownDevSandbox(c *gin.Context) {
+	log := klog.FromContext(c.Request.Context())
 	namespace := c.MustGet(auth.UserKey).(string)
 	name := c.Param("name")
 	if err := s.K8sManager.ScaledownDevSandboxHelper(c.Request.Context(), namespace, name); err != nil {
@@ -318,7 +324,7 @@ func (s *Server) scaleDownDevSandbox(c *gin.Context) {
 	}
 
 	if err := s.K8sManager.UpdateDevSandboxAnnotation(c.Request.Context(), namespace, name, "agentState", "sandbox paused"); err != nil {
-		log.Printf("Failed to update dev sandbox annotation: %v", err)
+		log.Info("Failed to update dev sandbox annotation", "err", err)
 	}
 
 	c.Status(http.StatusOK)

--- a/repo-agent/review-ui/review-api/pkg/api/handlers_issue.go
+++ b/repo-agent/review-ui/review-api/pkg/api/handlers_issue.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -17,9 +16,11 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 )
 
 func (s *Server) getIssues(c *gin.Context) {
+	log := klog.FromContext(c.Request.Context())
 	namespace := c.MustGet(auth.UserKey).(string)
 	repo := c.Param("repo")
 	handler := c.Param("handler")
@@ -27,7 +28,7 @@ func (s *Server) getIssues(c *gin.Context) {
 
 	issues, err := s.Store.ListIssues(c.Request.Context(), namespace, repo, handler)
 	if err != nil {
-		log.Printf("Error listing issues: %v", err)
+		log.Info("Error listing issues", "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list issues"})
 		return
 	}
@@ -36,6 +37,7 @@ func (s *Server) getIssues(c *gin.Context) {
 }
 
 func (s *Server) fetchAndPopulateIssues(ctx context.Context, namespace, repo, handler string) {
+	log := klog.FromContext(ctx)
 	gvr := schema.GroupVersionResource{
 		Group:    "custom.agents.x-k8s.io",
 		Version:  "v1alpha1",
@@ -46,30 +48,30 @@ func (s *Server) fetchAndPopulateIssues(ctx context.Context, namespace, repo, ha
 			LabelSelector: fmt.Sprintf("review.gemini.google.com/repowatch=%s,review.gemini.google.com/handler=%s", repo, handler),
 		})
 	if err != nil {
-		log.Printf("Failed to list IssueSandbox CRs: %v.", err)
+		log.Info("Failed to list IssueSandbox CRs", "err", err)
 		return
 	}
 
-	log.Printf("Populating Issues: Found %d issuesandboxes for Repo: %s Handler: %s", len(list.Items), repo, handler)
+	log.Info("Populating Issues", "issuesandbox_count", len(list.Items), "repo", repo, "handler", handler)
 
 	activeIssues := make(map[string]bool)
 	for _, item := range list.Items {
-		log.Printf("Creating Issue entry for IssueSandbox: %s/%s", item.GetNamespace(), item.GetName())
+		log.Info("Creating Issue entry for IssueSandbox", "namespace", item.GetNamespace(), "name", item.GetName())
 		replicas, found, err := unstructured.NestedInt64(item.Object, "spec", "replicas")
 		if err != nil || !found {
-			log.Printf("Replicas (.spec.replicas) not found in IssueSandbox %s", item.GetName())
+			log.Info("Replicas (.spec.replicas) not found in IssueSandbox", "name", item.GetName())
 			continue
 		}
 
 		issueID, found, err := unstructured.NestedString(item.Object, "spec", "source", "issue")
 		if err != nil || !found {
-			log.Printf("Issue ID (.spec.source.issue) not found in IssueSandbox %s", item.GetName())
+			log.Info("Issue ID (.spec.source.issue) not found in IssueSandbox", "name", item.GetName())
 			continue
 		}
 
 		title, found, err := unstructured.NestedString(item.Object, "spec", "source", "title")
 		if err != nil || !found {
-			log.Printf("Title (.spec.source.title) not found in IssueSandbox %s", item.GetName())
+			log.Info("Title (.spec.source.title) not found in IssueSandbox", "name", item.GetName())
 			continue
 		}
 
@@ -77,7 +79,7 @@ func (s *Server) fetchAndPopulateIssues(ctx context.Context, namespace, repo, ha
 
 		htmlurl, found, err := unstructured.NestedString(item.Object, "spec", "source", "htmlURL")
 		if err != nil || !found {
-			log.Printf("htmlURL (.spec.source.htmlURL) not found in IssueSandbox %s", item.GetName())
+			log.Info("htmlURL (.spec.source.htmlURL) not found in IssueSandbox", "name", item.GetName())
 		}
 
 		// https://github.com/barney-s/kro/tree/issue-753-bugfix
@@ -87,17 +89,17 @@ func (s *Server) fetchAndPopulateIssues(ctx context.Context, namespace, repo, ha
 
 		cloneURL, found, err := unstructured.NestedString(item.Object, "spec", "source", "cloneURL")
 		if err != nil || !found {
-			log.Printf("branchURL (.spec.source.cloneURL) not found in IssueSandbox %s", item.GetName())
+			log.Info("branchURL (.spec.source.cloneURL) not found in IssueSandbox", "name", item.GetName())
 			cloneURL = "https://github.com/noorg/norepo.git"
 		}
 		login, found, err := unstructured.NestedString(item.Object, "spec", "destination", "user", "login")
 		if err != nil || !found {
-			log.Printf("branchURL (.spec.destination.user.login) not found in IssueSandbox %s", item.GetName())
+			log.Info("branchURL (.spec.destination.user.login) not found in IssueSandbox", "name", item.GetName())
 			login = "nouser"
 		}
 		branch, found, err := unstructured.NestedString(item.Object, "spec", "destination", "branch")
 		if err != nil || !found {
-			log.Printf("branchURL (.spec.destination.branch) not found in IssueSandbox %s", item.GetName())
+			log.Info("branchURL (.spec.destination.branch) not found in IssueSandbox", "name", item.GetName())
 			branch = "nobranch"
 		}
 
@@ -108,7 +110,7 @@ func (s *Server) fetchAndPopulateIssues(ctx context.Context, namespace, repo, ha
 
 		pushBranch, found, err := unstructured.NestedBool(item.Object, "spec", "destination", "pushEnabled")
 		if err != nil || !found {
-			log.Printf("pushBranch (.spec.source.pushBranch) not found in IssueSandbox %s", item.GetName())
+			log.Info("pushBranch (.spec.source.pushBranch) not found in IssueSandbox", "name", item.GetName())
 		}
 
 		// get draft from annotation[agentDraft]
@@ -118,12 +120,12 @@ func (s *Server) fetchAndPopulateIssues(ctx context.Context, namespace, repo, ha
 		var labels []string
 		annotations := item.GetAnnotations()
 		if annotations == nil {
-			log.Printf("annotations (annotations=nil) not found in IssueSandbox %s", item.GetName())
+			log.Info("annotations (annotations=nil) not found in IssueSandbox", "name", item.GetName())
 		} else {
 			if val, ok := annotations["agentDraft"]; ok {
 				draft = val
 			} else {
-				log.Printf("agentDraft (annotations[agentDraft]) not found in IssueSandbox %s", item.GetName())
+				log.Info("agentDraft (annotations[agentDraft]) not found in IssueSandbox", "name", item.GetName())
 			}
 			if val, ok := annotations["agentState"]; ok {
 				agentState = val
@@ -150,22 +152,22 @@ func (s *Server) fetchAndPopulateIssues(ctx context.Context, namespace, repo, ha
 			Labels:            labels,
 		}
 		if err := s.Store.SaveIssue(ctx, namespace, repo, handler, issue); err != nil {
-			log.Printf("Failed to cache Issue %s for repo %s handler %s: %v", issueID, repo, handler, err)
+			log.Info("Failed to cache Issue", "issueID", issueID, "repo", repo, "handler", handler, "err", err)
 		}
 	}
 
 	// Cleanup stale entries
 	storedIssues, err := s.Store.ListIssues(ctx, namespace, repo, handler)
 	if err != nil {
-		log.Printf("Failed to list issues for cleanup: %v", err)
+		log.Info("Failed to list issues for cleanup", "err", err)
 		return
 	}
 
 	for _, issue := range storedIssues {
 		if !activeIssues[issue.ID] {
-			log.Printf("Removing stale Issue from store: %s", issue.ID)
+			log.Info("Removing stale Issue from store", "issueID", issue.ID)
 			if err := s.Store.DeleteIssue(ctx, namespace, repo, handler, issue.ID); err != nil {
-				log.Printf("Failed to delete stale Issue %s: %v", issue.ID, err)
+				log.Info("Failed to delete stale Issue", "issueID", issue.ID, "err", err)
 			}
 		}
 	}
@@ -194,6 +196,7 @@ func (s *Server) saveIssueDraft(c *gin.Context) {
 }
 
 func (s *Server) submitIssueComment(c *gin.Context) {
+	log := klog.FromContext(c.Request.Context())
 	namespace := c.MustGet(auth.UserKey).(string)
 	repo := c.Param("repo")
 	issueID := c.Param("issue_id")
@@ -207,11 +210,11 @@ func (s *Server) submitIssueComment(c *gin.Context) {
 	}
 
 	ctx := c.Request.Context()
-	log.Printf("Submitting comment for Issue %s in repo %s with comment: %s", issueID, repo, payload.Comment)
+	log.Info("Submitting comment for Issue", "issueID", issueID, "repo", repo, "comment", payload.Comment)
 
 	issue, err := s.Store.GetIssue(ctx, namespace, repo, handler, issueID)
 	if err != nil {
-		log.Printf("Failed to get Issue %s from Store for repo %s handler %s: %v", issueID, repo, handler, err)
+		log.Info("Failed to get Issue from Store for repo", "issueID", issueID, "repo", repo, "handler", handler, "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get Issue data from Store"})
 		return
 	}
@@ -221,7 +224,7 @@ func (s *Server) submitIssueComment(c *gin.Context) {
 
 	repoWatch, err := s.K8sManager.GetRepoWatch(ctx, namespace, repo)
 	if err != nil {
-		log.Printf("Failed to get repowatch %s: %v", repo, err)
+		log.Info("Failed to get repowatch", "repo", repo, "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get repowatch config"})
 		return
 	}
@@ -251,14 +254,14 @@ func (s *Server) submitIssueComment(c *gin.Context) {
 		owner, _, _ := parseRepoURL(repoURL)
 
 		if err := s.Store.SaveIssueFeedback(ctx, owner, repo, handler, issueID, draft, agentDraft, prompt, configdir); err != nil {
-			log.Printf("Failed to store feedback for Issue %s in repo %s: %v", issueID, repo, err)
+			log.Info("Failed to store feedback for Issue", "issueID", issueID, "repo", repo, "err", err)
 			// Continue without failing the comment submission
 		}
 	}
 
 	token, err := s.K8sManager.GetGitHubToken(ctx, repoWatch)
 	if err != nil {
-		log.Printf("Failed to get github token for repo %s: %v", repo, err)
+		log.Info("Failed to get github token for repo", "repo", repo, "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get github token"})
 		return
 	}
@@ -269,20 +272,20 @@ func (s *Server) submitIssueComment(c *gin.Context) {
 
 	repoURL, found, err := unstructured.NestedString(repoWatch.Object, "spec", "repoURL")
 	if err != nil || !found {
-		log.Printf("repoURL not found in RepoWatch CR %s", repoWatch.GetName())
+		log.Info("repoURL not found in RepoWatch CR", "name", repoWatch.GetName())
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "repoURL not found in RepoWatch CR"})
 		return
 	}
 	owner, repoName, err := parseRepoURL(repoURL)
 	if err != nil {
-		log.Printf("Failed to parse repo url %s: %v", repoURL, err)
+		log.Info("Failed to parse repo url", "url", repoURL, "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to parse repo url"})
 		return
 	}
 
 	issueNumber, err := strconv.Atoi(issueID)
 	if err != nil {
-		log.Printf("Failed to parse issueID %s: %v", issueID, err)
+		log.Info("Failed to parse issueID", "issueID", issueID, "err", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid issue id"})
 		return
 	}
@@ -290,7 +293,7 @@ func (s *Server) submitIssueComment(c *gin.Context) {
 	comment := &github.IssueComment{Body: &payload.Comment}
 	_, _, err = client.Issues.CreateComment(ctx, owner, repoName, issueNumber, comment)
 	if err != nil {
-		log.Printf("Failed to create comment on Issue %d: %v", issueNumber, err)
+		log.Info("Failed to create comment on Issue", "issueNumber", issueNumber, "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create comment on github"})
 		return
 	}
@@ -311,6 +314,7 @@ func (s *Server) submitIssueComment(c *gin.Context) {
 }
 
 func (s *Server) deleteIssue(c *gin.Context) {
+	log := klog.FromContext(c.Request.Context())
 	namespace := c.MustGet(auth.UserKey).(string)
 	repo := c.Param("repo")
 	issueID := c.Param("issue_id")
@@ -323,7 +327,7 @@ func (s *Server) deleteIssue(c *gin.Context) {
 	}
 
 	if err := s.Store.DeleteIssue(c.Request.Context(), namespace, repo, handler, issueID); err != nil {
-		log.Printf("Failed to DEL Issue data from Store: %v", err)
+		log.Info("Failed to DEL Issue data from Store", "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to DEL Issue data from Store"})
 		return
 	}

--- a/repo-agent/review-ui/review-api/pkg/api/handlers_pr.go
+++ b/repo-agent/review-ui/review-api/pkg/api/handlers_pr.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"strconv"
 
@@ -17,16 +16,18 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 )
 
 func (s *Server) getPRs(c *gin.Context) {
+	log := klog.FromContext(c.Request.Context())
 	namespace := c.MustGet(auth.UserKey).(string)
 	repo := c.Param("repo")
 	s.fetchAndPopulatePRs(c.Request.Context(), namespace, repo)
 
 	prs, err := s.Store.ListPRs(c.Request.Context(), namespace, repo)
 	if err != nil {
-		log.Printf("Error listing PRs: %v", err)
+		log.Info("Error listing PRs", "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list PRs"})
 		return
 	}
@@ -35,6 +36,7 @@ func (s *Server) getPRs(c *gin.Context) {
 }
 
 func (s *Server) fetchAndPopulatePRs(ctx context.Context, namespace, repo string) {
+	log := klog.FromContext(ctx)
 	gvr := schema.GroupVersionResource{
 		Group:    "custom.agents.x-k8s.io",
 		Version:  "v1alpha1",
@@ -45,36 +47,36 @@ func (s *Server) fetchAndPopulatePRs(ctx context.Context, namespace, repo string
 			LabelSelector: fmt.Sprintf("review.gemini.google.com/repowatch=%s", repo),
 		})
 	if err != nil {
-		log.Printf("Failed to list ReviewSandbox CRs: %v. Serving mock data.", err)
+		log.Info("Failed to list ReviewSandbox CRs. Serving mock data.", "err", err)
 		return
 	}
 
-	log.Printf("Populating PRs: Found %d reviewsandboxes for Repo: %s", len(list.Items), repo)
+	log.Info("Populating PRs", "reviewsandbox_count", len(list.Items), "repo", repo)
 
 	activePRs := make(map[string]bool)
 	for _, item := range list.Items {
-		log.Printf("Creating PR entry for ReviewSandbox: %s/%s", item.GetNamespace(), item.GetName())
+		log.Info("Creating PR entry for ReviewSandbox", "namespace", item.GetNamespace(), "name", item.GetName())
 		// Get replicas and if it scaled down skip
 		replicas, found, err := unstructured.NestedInt64(item.Object, "spec", "replicas")
 		if err != nil || !found {
-			log.Printf("Replicas (.spec.replicas) not found in ReviewSandbox  %s", item.GetName())
+			log.Info("Replicas (.spec.replicas) not found in ReviewSandbox", "name", item.GetName())
 			continue
 		}
 
 		if item.GetDeletionTimestamp() != nil {
-			log.Printf("Skipping terminating ReviewSandbox: %s", item.GetName())
+			log.Info("Skipping terminating ReviewSandbox", "name", item.GetName())
 			continue
 		}
 
 		prID, found, err := unstructured.NestedString(item.Object, "spec", "source", "pr")
 		if err != nil || !found {
-			log.Printf("PR ID (.spec.source.pr) not found in ReviewSandbox  %s", item.GetName())
+			log.Info("PR ID (.spec.source.pr) not found in ReviewSandbox", "name", item.GetName())
 			continue
 		}
 
 		title, found, err := unstructured.NestedString(item.Object, "spec", "source", "title")
 		if err != nil || !found {
-			log.Printf("Title (.spec.source.title) not found in ReviewSandbox  %s", item.GetName())
+			log.Info("Title (.spec.source.title) not found in ReviewSandbox", "name", item.GetName())
 			continue
 		}
 
@@ -82,11 +84,11 @@ func (s *Server) fetchAndPopulatePRs(ctx context.Context, namespace, repo string
 
 		htmlurl, found, err := unstructured.NestedString(item.Object, "spec", "source", "htmlURL")
 		if err != nil || !found {
-			log.Printf("Title (.spec.source.htmlURL) not found in ReviewSandbox  %s", item.GetName())
+			log.Info("Title (.spec.source.htmlURL) not found in ReviewSandbox", "name", item.GetName())
 		}
 		diffurl, found, err := unstructured.NestedString(item.Object, "spec", "source", "diffURL")
 		if err != nil || !found {
-			log.Printf("diffURL (.spec.source.diffURL) not found in ReviewSandbox  %s", item.GetName())
+			log.Info("diffURL (.spec.source.diffURL) not found in ReviewSandbox", "name", item.GetName())
 		}
 
 		// get draft from annotation[agentDraft]
@@ -97,7 +99,7 @@ func (s *Server) fetchAndPopulatePRs(ctx context.Context, namespace, repo string
 		var labels []string
 		annotations := item.GetAnnotations()
 		if annotations == nil {
-			log.Printf("annotations (annotations=nil) not found in ReviewSandbox %s", item.GetName())
+			log.Info("annotations (annotations=nil) not found in ReviewSandbox", "name", item.GetName())
 		} else {
 			if val, ok := annotations["agentDraft"]; ok {
 				draft = val
@@ -132,22 +134,22 @@ func (s *Server) fetchAndPopulatePRs(ctx context.Context, namespace, repo string
 		}
 
 		if err := s.Store.SavePR(ctx, namespace, repo, pr); err != nil {
-			log.Printf("Failed to cache PR %s for repo %s: %v", pr.ID, repo, err)
+			log.Info("Failed to cache PR", "prID", pr.ID, "repo", repo, "err", err)
 		}
 	}
 
 	// Cleanup stale entries
 	storedPRs, err := s.Store.ListPRs(ctx, namespace, repo)
 	if err != nil {
-		log.Printf("Failed to list PRs for cleanup: %v", err)
+		log.Info("Failed to list PRs for cleanup", "err", err)
 		return
 	}
 
 	for _, pr := range storedPRs {
 		if !activePRs[pr.ID] {
-			log.Printf("Removing stale PR from store: %s", pr.ID)
+			log.Info("Removing stale PR from store", "prID", pr.ID)
 			if err := s.Store.DeletePR(ctx, namespace, repo, pr.ID); err != nil {
-				log.Printf("Failed to delete stale PR %s: %v", pr.ID, err)
+				log.Info("Failed to delete stale PR", "prID", pr.ID, "err", err)
 			}
 		}
 	}
@@ -175,6 +177,7 @@ func (s *Server) saveDraft(c *gin.Context) {
 }
 
 func (s *Server) submitReview(c *gin.Context) {
+	log := klog.FromContext(c.Request.Context())
 	namespace := c.MustGet(auth.UserKey).(string)
 	repo := c.Param("repo")
 	prID := c.Param("id")
@@ -187,12 +190,12 @@ func (s *Server) submitReview(c *gin.Context) {
 	}
 
 	ctx := c.Request.Context()
-	log.Printf("Submitting review for PR %s in repo %s with review: %s", prID, repo, payload.Review)
+	log.Info("Submitting review for PR", "prID", prID, "repo", repo, "review", payload.Review)
 
 	// Get draft and agentDraft from Redis
 	pr, err := s.Store.GetPR(ctx, namespace, repo, prID)
 	if err != nil {
-		log.Printf("Failed to get PR %s from Store for repo %s: %v", prID, repo, err)
+		log.Info("Failed to get PR from Store for repo", "prID", prID, "repo", repo, "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get PR data from Store"})
 		return
 	}
@@ -204,7 +207,7 @@ func (s *Server) submitReview(c *gin.Context) {
 	// Get RepoWatch to get repoURL and secret ref
 	repoWatch, err := s.K8sManager.GetRepoWatch(ctx, namespace, repo)
 	if err != nil {
-		log.Printf("Failed to get repowatch %s: %v", repo, err)
+		log.Info("Failed to get repowatch", "repo", repo, "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get repowatch config"})
 		return
 	}
@@ -217,13 +220,13 @@ func (s *Server) submitReview(c *gin.Context) {
 		owner, _, _ := parseRepoURL(repoURL)
 
 		if err := s.Store.SavePRFeedback(ctx, owner, repo, prID, draft, agentDraft, prompt, configdir); err != nil {
-			log.Printf("Failed to store feedback for PR %s in repo %s: %v", prID, repo, err)
+			log.Info("Failed to store feedback for PR", "prID", prID, "repo", repo, "err", err)
 			// Continue without failing the review submission
 		}
 
 		if sandboxName != "" {
 			if err := s.K8sManager.UpdateReviewSandboxUserDraft(ctx, namespace, sandboxName, draft); err != nil {
-				log.Printf("Failed to update reviewsandbox userDraft for PR %s in repo %s: %v", prID, repo, err)
+				log.Info("Failed to update reviewsandbox userDraft for PR", "prID", prID, "repo", repo, "err", err)
 				// Not failing the request for this, just logging.
 			}
 		}
@@ -232,7 +235,7 @@ func (s *Server) submitReview(c *gin.Context) {
 	// Get GitHub token from secret
 	token, err := s.K8sManager.GetGitHubToken(ctx, repoWatch)
 	if err != nil {
-		log.Printf("Failed to get github token for repo %s: %v", repo, err)
+		log.Info("Failed to get github token for repo", "repo", repo, "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get github token"})
 		return
 	}
@@ -247,13 +250,13 @@ func (s *Server) submitReview(c *gin.Context) {
 	// Parse repo URL
 	repoURL, found, err := unstructured.NestedString(repoWatch.Object, "spec", "repoURL")
 	if err != nil || !found {
-		log.Printf("repoURL not found in RepoWatch CR %s", repoWatch.GetName())
+		log.Info("repoURL not found in RepoWatch CR", "name", repoWatch.GetName())
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "repoURL not found in RepoWatch CR"})
 		return
 	}
 	owner, repoName, err := parseRepoURL(repoURL)
 	if err != nil {
-		log.Printf("Failed to parse repo url %s: %v", repoURL, err)
+		log.Info("Failed to parse repo url", "url", repoURL, "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to parse repo url"})
 		return
 	}
@@ -261,7 +264,7 @@ func (s *Server) submitReview(c *gin.Context) {
 	// Get PR number
 	prNumber, err := strconv.Atoi(prID)
 	if err != nil {
-		log.Printf("Failed to parse prID %s: %v", prID, err)
+		log.Info("Failed to parse prID", "prID", prID, "err", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid pr id"})
 		return
 	}
@@ -271,7 +274,7 @@ func (s *Server) submitReview(c *gin.Context) {
 	reviewRequest := &github.PullRequestReviewRequest{}
 	err = yaml.Unmarshal([]byte(payload.Review), &agentOutput)
 	if err != nil {
-		log.Printf("Failed to unmarshal review payload: %v", err)
+		log.Info("Failed to unmarshal review payload", "err", err)
 		reviewRequest.Body = github.String(payload.Review)
 	} else {
 		reviewRequest = agentOutput.Review
@@ -280,15 +283,15 @@ func (s *Server) submitReview(c *gin.Context) {
 	// Not setting event sets it as a draft
 	reviewRequest.Event = nil
 
-	log.Printf("reviewRequest being created: %v", reviewRequest)
+	log.Info("reviewRequest being created", "request", reviewRequest)
 	review, resp, err := client.PullRequests.CreateReview(ctx, owner, repoName, prNumber, reviewRequest)
 	if err != nil {
-		log.Printf("response: %v", resp)
-		log.Printf("Failed to create review on PR %d: %v", prNumber, err)
+		log.Info("response", "resp", resp)
+		log.Info("Failed to create review on PR", "prNumber", prNumber, "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create review on github", "details": err.Error()})
 		return
 	}
-	log.Printf("review created: %v", review)
+	log.Info("review created", "review", review)
 	// Set review in Redis
 	err = s.Store.UpdatePRReview(c.Request.Context(), namespace, repo, prID, payload.Review)
 	if err != nil {
@@ -305,7 +308,7 @@ func (s *Server) submitReview(c *gin.Context) {
 
 	if sandboxName != "" {
 		if err := s.K8sManager.UpdateReviewSandboxAnnotation(ctx, namespace, sandboxName, "reviewState", "submitted"); err != nil {
-			log.Printf("Failed to update reviewState annotation for PR %s in repo %s: %v", prID, repo, err)
+			log.Info("Failed to update reviewState annotation for PR", "prID", prID, "repo", repo, "err", err)
 		}
 	}
 
@@ -313,6 +316,7 @@ func (s *Server) submitReview(c *gin.Context) {
 }
 
 func (s *Server) deletePR(c *gin.Context) {
+	log := klog.FromContext(c.Request.Context())
 	namespace := c.MustGet(auth.UserKey).(string)
 	repo := c.Param("repo")
 	prID := c.Param("id")
@@ -325,7 +329,7 @@ func (s *Server) deletePR(c *gin.Context) {
 
 	// Clean up Redis keys
 	if err := s.Store.DeletePR(c.Request.Context(), namespace, repo, prID); err != nil {
-		log.Printf("Failed to DEL PR data from Redis: %v", err)
+		log.Info("Failed to DEL PR data from Redis", "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to DEL PR data from Redis"})
 		return
 	}
@@ -361,10 +365,11 @@ func (s *Server) scaleDownPR(c *gin.Context) {
 
 //nolint:unused
 func (s *Server) deleteSandbox(ctx context.Context, namespace, repo, prID string) error {
+	log := klog.FromContext(ctx)
 	pr, err := s.Store.GetPR(ctx, namespace, repo, prID)
 	if err != nil {
 		// If sandbox is not in Store, we can assume it's already deleted or never existed.
-		log.Printf("Sandbox for repo %s, PR %s not found in Store. Assuming it's already deleted.", repo, prID)
+		log.Info("Sandbox for repo and PR not found in Store. Assuming it's already deleted.", "repo", repo, "prID", prID)
 		return nil
 	}
 	sandboxName := pr.Sandbox
@@ -374,7 +379,7 @@ func (s *Server) deleteSandbox(ctx context.Context, namespace, repo, prID string
 		Version:  "v1alpha1",
 		Resource: "reviewsandboxes",
 	}
-	log.Printf("Deleting sandbox %s", sandboxName)
+	log.Info("Deleting sandbox", "name", sandboxName)
 	err = s.K8sManager.Client.Resource(gvr).Namespace(namespace).Delete(ctx, sandboxName, v1.DeleteOptions{})
 	if err != nil {
 		// We can choose to not return an error if it's already gone.

--- a/repo-agent/review-ui/review-api/pkg/api/handlers_repo.go
+++ b/repo-agent/review-ui/review-api/pkg/api/handlers_repo.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"sort"
 	"strings"
@@ -19,9 +18,11 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 )
 
 func (s *Server) createRepoWatch(c *gin.Context) {
+	log := klog.FromContext(c.Request.Context())
 	namespace := c.MustGet(auth.UserKey).(string)
 
 	if !s.ensureGeminiKeySet(c, namespace) {
@@ -90,14 +91,14 @@ func (s *Server) createRepoWatch(c *gin.Context) {
 								suggestedInterface = append(suggestedInterface, inner)
 							}
 							if setErr := unstructured.SetNestedSlice(obj.Object, suggestedInterface, "spec", "review", "labels"); setErr != nil {
-								log.Printf("Failed to set suggested labels: %v", setErr)
+								log.Info("Failed to set suggested labels", "err", setErr)
 							}
 						} else if suggestErr != nil {
-							log.Printf("Failed to get suggested labels: %v", suggestErr)
+							log.Info("Failed to get suggested labels", "err", suggestErr)
 						}
 					}
 				} else {
-					log.Printf("Debug: Could not get token for label suggestion: %v", tokenErr)
+					log.Info("Debug: Could not get token for label suggestion", "err", tokenErr)
 				}
 			}
 		}
@@ -123,28 +124,28 @@ func (s *Server) createRepoWatch(c *gin.Context) {
 				Resource: "configmaps",
 			}
 		} else {
-			log.Printf("Skipping disallowed resource type: %s/%s", gvk.Group, gvk.Kind)
+			log.Info("Skipping disallowed resource type", "group", gvk.Group, "kind", gvk.Kind)
 			continue
 		}
 
 		_, err := s.K8sManager.Client.Resource(gvr).Namespace(namespace).Create(c.Request.Context(), obj, v1.CreateOptions{})
 		if err != nil {
 			if errors.IsAlreadyExists(err) {
-				log.Printf("Resource %s %s already exists, attempting update...", gvk.Kind, obj.GetName())
+				log.Info("Resource already exists, attempting update...", "kind", gvk.Kind, "name", obj.GetName())
 				// Get existing resourceVersion
 				existing, getErr := s.K8sManager.Client.Resource(gvr).Namespace(namespace).Get(c.Request.Context(), obj.GetName(), v1.GetOptions{})
 				if getErr == nil {
 					obj.SetResourceVersion(existing.GetResourceVersion())
 					_, updateErr := s.K8sManager.Client.Resource(gvr).Namespace(namespace).Update(c.Request.Context(), obj, v1.UpdateOptions{})
 					if updateErr != nil {
-						log.Printf("Failed to update existing %s: %v", gvk.Kind, updateErr)
+						log.Info("Failed to update existing resource", "kind", gvk.Kind, "err", updateErr)
 					}
 				} else {
-					log.Printf("Failed to get existing %s for update: %v", gvk.Kind, getErr)
+					log.Info("Failed to get existing resource for update", "kind", gvk.Kind, "err", getErr)
 				}
 				continue
 			}
-			log.Printf("Failed to create %s from YAML: %v", gvk.Kind, err)
+			log.Info("Failed to create resource from YAML", "kind", gvk.Kind, "err", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Failed to create %s: %v", gvk.Kind, err)})
 			return
 		}
@@ -223,12 +224,13 @@ spec:
 }
 
 func (s *Server) getRepoWatchYAML(c *gin.Context) {
+	log := klog.FromContext(c.Request.Context())
 	namespace := c.MustGet(auth.UserKey).(string)
 	name := c.Param("repo")
 
 	repoWatch, err := s.K8sManager.GetRepoWatch(c.Request.Context(), namespace, name)
 	if err != nil {
-		log.Printf("Failed to get RepoWatch %s/%s: %v", namespace, name, err)
+		log.Info("Failed to get RepoWatch", "namespace", namespace, "name", name, "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get RepoWatch"})
 		return
 	}
@@ -249,6 +251,7 @@ func (s *Server) getRepoWatchYAML(c *gin.Context) {
 }
 
 func (s *Server) updateRepoWatch(c *gin.Context) {
+	log := klog.FromContext(c.Request.Context())
 	namespace := c.MustGet(auth.UserKey).(string)
 	name := c.Param("repo")
 
@@ -280,7 +283,7 @@ func (s *Server) updateRepoWatch(c *gin.Context) {
 	// Get existing resource
 	existing, err := s.K8sManager.Client.Resource(gvr).Namespace(namespace).Get(c.Request.Context(), name, v1.GetOptions{})
 	if err != nil {
-		log.Printf("Failed to get RepoWatch for update: %v", err)
+		log.Info("Failed to get RepoWatch for update", "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Failed to get RepoWatch: %v", err)})
 		return
 	}
@@ -295,7 +298,7 @@ func (s *Server) updateRepoWatch(c *gin.Context) {
 		spec = fixYAMLIntegers(spec).(map[string]interface{})
 
 		if err := unstructured.SetNestedField(existing.Object, spec, "spec"); err != nil {
-			log.Printf("Failed to set spec: %v", err)
+			log.Info("Failed to set spec", "err", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update object structure"})
 			return
 		}
@@ -304,7 +307,7 @@ func (s *Server) updateRepoWatch(c *gin.Context) {
 		// we should extract it from the new spec.
 		if newURL, found, _ := unstructured.NestedString(existing.Object, "spec", "repoURL"); found {
 			if err := s.Store.SaveRepo(c.Request.Context(), namespace, name, newURL); err != nil {
-				log.Printf("Failed to update repo URL in Redis for %s: %v", name, err)
+				log.Info("Failed to update repo URL in Redis", "name", name, "err", err)
 			}
 		}
 	}
@@ -313,7 +316,7 @@ func (s *Server) updateRepoWatch(c *gin.Context) {
 	if payload.AddPR != 0 {
 		pullRequestsSlice, found, err := unstructured.NestedSlice(existing.Object, "spec", "review", "pullRequests")
 		if err != nil {
-			log.Printf("Failed to get pullRequests: %v", err)
+			log.Info("Failed to get pullRequests", "err", err)
 		}
 
 		var pullRequests []int64
@@ -339,7 +342,7 @@ func (s *Server) updateRepoWatch(c *gin.Context) {
 		if !exists {
 			pullRequests = append(pullRequests, int64(payload.AddPR))
 			if err := unstructured.SetNestedSlice(existing.Object, convInt64SliceToInterfaceSlice(pullRequests), "spec", "review", "pullRequests"); err != nil {
-				log.Printf("Failed to set pullRequests: %v", err)
+				log.Info("Failed to set pullRequests", "err", err)
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update object structure for pullRequests"})
 				return
 			}
@@ -366,7 +369,7 @@ func (s *Server) updateRepoWatch(c *gin.Context) {
 			}
 			if changed {
 				if err := unstructured.SetNestedSlice(existing.Object, convInt64SliceToInterfaceSlice(newExclude), "spec", "review", "excludePullRequests"); err != nil {
-					log.Printf("Failed to update excludePullRequests: %v", err)
+					log.Info("Failed to update excludePullRequests", "err", err)
 				}
 			}
 		}
@@ -376,7 +379,7 @@ func (s *Server) updateRepoWatch(c *gin.Context) {
 	if payload.ExcludeIssue != 0 && payload.HandlerName != "" {
 		handlersSlice, found, err := unstructured.NestedSlice(existing.Object, "spec", "issueHandlers")
 		if err != nil {
-			log.Printf("Failed to get issueHandlers: %v", err)
+			log.Info("Failed to get issueHandlers", "err", err)
 		}
 
 		if found {
@@ -415,7 +418,7 @@ func (s *Server) updateRepoWatch(c *gin.Context) {
 						excludeIssues = append(excludeIssues, int64(payload.ExcludeIssue))
 						// Update the handler map
 						if err := unstructured.SetNestedSlice(handlerMap, convInt64SliceToInterfaceSlice(excludeIssues), "excludeIssues"); err != nil {
-							log.Printf("Failed to set excludeIssues: %v", err)
+							log.Info("Failed to set excludeIssues", "err", err)
 						} else {
 							updated = true
 						}
@@ -426,7 +429,7 @@ func (s *Server) updateRepoWatch(c *gin.Context) {
 
 			if updated {
 				if err := unstructured.SetNestedSlice(existing.Object, newHandlers, "spec", "issueHandlers"); err != nil {
-					log.Printf("Failed to update issueHandlers: %v", err)
+					log.Info("Failed to update issueHandlers", "err", err)
 					c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update object structure for issueHandlers"})
 					return
 				}
@@ -439,7 +442,7 @@ func (s *Server) updateRepoWatch(c *gin.Context) {
 		// Add to excludePullRequests
 		excludeSlice, found, err := unstructured.NestedSlice(existing.Object, "spec", "review", "excludePullRequests")
 		if err != nil {
-			log.Printf("Failed to get excludePullRequests: %v", err)
+			log.Info("Failed to get excludePullRequests", "err", err)
 		}
 
 		var excludeRequests []int64
@@ -464,7 +467,7 @@ func (s *Server) updateRepoWatch(c *gin.Context) {
 		if !exists {
 			excludeRequests = append(excludeRequests, int64(payload.ExcludePR))
 			if err := unstructured.SetNestedSlice(existing.Object, convInt64SliceToInterfaceSlice(excludeRequests), "spec", "review", "excludePullRequests"); err != nil {
-				log.Printf("Failed to set excludePullRequests: %v", err)
+				log.Info("Failed to set excludePullRequests", "err", err)
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update object structure for excludePullRequests"})
 				return
 			}
@@ -491,7 +494,7 @@ func (s *Server) updateRepoWatch(c *gin.Context) {
 			}
 			if changed {
 				if err := unstructured.SetNestedSlice(existing.Object, convInt64SliceToInterfaceSlice(newPull), "spec", "review", "pullRequests"); err != nil {
-					log.Printf("Failed to update pullRequests: %v", err)
+					log.Info("Failed to update pullRequests", "err", err)
 				}
 			}
 		}
@@ -501,7 +504,7 @@ func (s *Server) updateRepoWatch(c *gin.Context) {
 	if payload.ExcludeBranch != "" {
 		excludeSlice, found, err := unstructured.NestedStringSlice(existing.Object, "spec", "dev", "excludeBranches")
 		if err != nil {
-			log.Printf("Failed to get excludeBranches: %v", err)
+			log.Info("Failed to get excludeBranches", "err", err)
 		}
 
 		var excludeBranches []string
@@ -520,7 +523,7 @@ func (s *Server) updateRepoWatch(c *gin.Context) {
 		if !exists {
 			excludeBranches = append(excludeBranches, payload.ExcludeBranch)
 			if err := unstructured.SetNestedStringSlice(existing.Object, excludeBranches, "spec", "dev", "excludeBranches"); err != nil {
-				log.Printf("Failed to set excludeBranches: %v", err)
+				log.Info("Failed to set excludeBranches", "err", err)
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update object structure for excludeBranches"})
 				return
 			}
@@ -530,7 +533,7 @@ func (s *Server) updateRepoWatch(c *gin.Context) {
 	// Apply update
 	_, err = s.K8sManager.Client.Resource(gvr).Namespace(namespace).Update(c.Request.Context(), existing, v1.UpdateOptions{})
 	if err != nil {
-		log.Printf("Failed to update RepoWatch: %v", err)
+		log.Info("Failed to update RepoWatch", "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Failed to update RepoWatch: %v", err)})
 		return
 	}
@@ -539,6 +542,7 @@ func (s *Server) updateRepoWatch(c *gin.Context) {
 }
 
 func (s *Server) deleteRepoWatch(c *gin.Context) {
+	log := klog.FromContext(c.Request.Context())
 	namespace := c.MustGet(auth.UserKey).(string)
 	name := c.Param("repo")
 
@@ -550,7 +554,7 @@ func (s *Server) deleteRepoWatch(c *gin.Context) {
 
 	err := s.K8sManager.Client.Resource(gvr).Namespace(namespace).Delete(c.Request.Context(), name, v1.DeleteOptions{})
 	if err != nil {
-		log.Printf("Failed to delete RepoWatch: %v", err)
+		log.Info("Failed to delete RepoWatch", "err", err)
 		if !errors.IsNotFound(err) {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Failed to delete RepoWatch: %v", err)})
 			return
@@ -559,7 +563,7 @@ func (s *Server) deleteRepoWatch(c *gin.Context) {
 
 	// Also delete from Redis
 	if err := s.Store.DeleteRepo(c.Request.Context(), namespace, name); err != nil {
-		log.Printf("Failed to delete repo %s from Redis: %v", name, err)
+		log.Info("Failed to delete repo from Redis", "name", name, "err", err)
 		// Don't fail the request if Redis fails, as K8s deletion is the source of truth
 	}
 
@@ -567,25 +571,26 @@ func (s *Server) deleteRepoWatch(c *gin.Context) {
 }
 
 func (s *Server) getRepos(c *gin.Context) {
+	log := klog.FromContext(c.Request.Context())
 	namespace := c.MustGet(auth.UserKey).(string)
 	s.fetchAndPopulateRepos(c.Request.Context(), namespace)
 
 	repos := []models.Repo{}
 	repoNames, err := s.Store.ListRepos(c.Request.Context(), namespace)
 	if err != nil {
-		log.Printf("Error during Redis SCAN: %v", err)
+		log.Info("Error during Redis SCAN", "err", err)
 	}
 
 	for _, repoName := range repoNames {
 		repoWatch, err := s.K8sManager.GetRepoWatch(c.Request.Context(), namespace, repoName)
 		if err != nil {
-			log.Printf("Failed to get RepoWatch %s/%s: %v", namespace, repoName, err)
+			log.Info("Failed to get RepoWatch", "namespace", namespace, "name", repoName, "err", err)
 			continue
 		}
 
 		repoURL, found, _ := unstructured.NestedString(repoWatch.Object, "spec", "repoURL")
 		if !found {
-			log.Printf("repoURL not found in RepoWatch CR %s", repoWatch.GetName())
+			log.Info("repoURL not found in RepoWatch CR", "name", repoWatch.GetName())
 			continue
 		}
 
@@ -644,7 +649,7 @@ func (s *Server) getRepos(c *gin.Context) {
 							pendingPR.Title = pr.GetTitle()
 							pendingPR.HTMLURL = pr.GetHTMLURL()
 						} else {
-							log.Printf("Failed to get PR %d title: %v", prNum, err)
+							log.Info("Failed to get PR title", "prNumber", prNum, "err", err)
 						}
 					}
 					pendingPRs = append(pendingPRs, pendingPR)
@@ -711,6 +716,7 @@ func (s *Server) getRepos(c *gin.Context) {
 }
 
 func (s *Server) fetchAndPopulateRepos(ctx context.Context, namespace string) {
+	log := klog.FromContext(ctx)
 	gvr := schema.GroupVersionResource{
 		Group:    "review.gemini.google.com",
 		Version:  "v1alpha1",
@@ -718,28 +724,29 @@ func (s *Server) fetchAndPopulateRepos(ctx context.Context, namespace string) {
 	}
 	list, err := s.K8sManager.Client.Resource(gvr).Namespace(namespace).List(context.Background(), v1.ListOptions{})
 	if err != nil {
-		log.Printf("Failed to list RepoWatch CRs: %v. Serving mock data.", err)
+		log.Info("Failed to list RepoWatch CRs. Serving mock data.", "err", err)
 		return
 	}
 
 	for _, item := range list.Items {
 		repoURL, found, err := unstructured.NestedString(item.Object, "spec", "repoURL")
 		if err != nil || !found {
-			log.Printf("repoURL not found in RepoWatch CR %s", item.GetName())
+			log.Info("repoURL not found in RepoWatch CR", "name", item.GetName())
 			continue
 		}
 		// Ensure the URL is in Redis
 		if err := s.Store.SaveRepo(ctx, namespace, item.GetName(), repoURL); err != nil {
-			log.Printf("Failed to cache repo URL for %s: %v", item.GetName(), err)
+			log.Info("Failed to cache repo URL", "name", item.GetName(), "err", err)
 		}
 	}
 }
 
 func (s *Server) getTemplates(c *gin.Context) {
+	log := klog.FromContext(c.Request.Context())
 	namespace := c.MustGet(auth.UserKey).(string)
 	templates, err := s.Templates.List(c.Request.Context(), namespace)
 	if err != nil {
-		log.Printf("Failed to list templates: %v", err)
+		log.Info("Failed to list templates", "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list templates"})
 		return
 	}

--- a/repo-agent/review-ui/review-api/pkg/api/handlers_sandbox_proxy.go
+++ b/repo-agent/review-ui/review-api/pkg/api/handlers_sandbox_proxy.go
@@ -2,13 +2,13 @@ package api
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/review-ui/review-api/pkg/auth"
+	"k8s.io/klog/v2"
 )
 
 func (s *Server) proxySandbox(c *gin.Context) {
@@ -24,7 +24,7 @@ func (s *Server) proxySandbox(c *gin.Context) {
 	}
 	if user != namespace {
 		c.String(http.StatusUnauthorized, "Unauthorized")
-		log.Printf("Unauthorized access %s for %s", user, c.Request.URL.String())
+		klog.Infof("Unauthorized access %s for %s", user, c.Request.URL.String())
 		return
 	}
 
@@ -82,7 +82,7 @@ func (s *Server) proxySandbox(c *gin.Context) {
 	// Error handling
 	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
 		// Log the error
-		log.Printf("Proxy error for URL %s: %v\n", r.URL.String(), err)
+		klog.Infof("Proxy error for URL %s: %v\n", r.URL.String(), err)
 		w.WriteHeader(http.StatusBadGateway)
 		_, _ = w.Write([]byte(fmt.Sprintf("Bad Gateway: %v", err)))
 	}

--- a/repo-agent/review-ui/review-api/pkg/api/handlers_settings.go
+++ b/repo-agent/review-ui/review-api/pkg/api/handlers_settings.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -9,6 +8,7 @@ import (
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/review-ui/review-api/pkg/auth"
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/review-ui/review-api/pkg/k8s"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 )
 
 func (s *Server) getSettings(c *gin.Context) {
@@ -66,7 +66,7 @@ func (s *Server) updateSettings(c *gin.Context) {
 			}
 			err := s.K8sManager.UpdateSecret(c.Request.Context(), namespace, pkgk8s.GithubSecretName, data, nil)
 			if err != nil {
-				log.Printf("Failed to clear GitHub PAT: %v", err)
+				klog.Infof("Failed to clear GitHub PAT: %v", err)
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to clear GitHub PAT"})
 				return
 			}
@@ -79,7 +79,7 @@ func (s *Server) updateSettings(c *gin.Context) {
 			}
 			err := s.K8sManager.UpdateSecret(c.Request.Context(), namespace, pkgk8s.GithubSecretName, data, nil)
 			if err != nil {
-				log.Printf("Failed to update GitHub PAT: %v", err)
+				klog.Infof("Failed to update GitHub PAT: %v", err)
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update GitHub PAT"})
 				return
 			}
@@ -89,7 +89,7 @@ func (s *Server) updateSettings(c *gin.Context) {
 	if payload.GeminiAPIKey != "" {
 		err := s.K8sManager.UpdateSecret(c.Request.Context(), namespace, pkgk8s.GeminiSecretName, map[string][]byte{"gemini": []byte(payload.GeminiAPIKey)}, nil)
 		if err != nil {
-			log.Printf("Failed to update Gemini API Key: %v", err)
+			klog.Infof("Failed to update Gemini API Key: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update Gemini API Key"})
 			return
 		}

--- a/repo-agent/review-ui/review-api/pkg/api/server.go
+++ b/repo-agent/review-ui/review-api/pkg/api/server.go
@@ -3,7 +3,6 @@ package api
 import (
 	"bytes"
 	"io"
-	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -13,6 +12,7 @@ import (
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/review-ui/review-api/pkg/templates"
 	"github.com/go-redis/redis/v8"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog/v2"
 )
 
 type Server struct {
@@ -117,10 +117,10 @@ func RequestLoggerMiddleware() gin.HandlerFunc {
 			c.Request.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 
-		log.Printf("Request Method: %s\n", c.Request.Method)
-		log.Printf("Request URL: %s\n", c.Request.URL.String())
+		klog.Infof("Request Method: %s\n", c.Request.Method)
+		klog.Infof("Request URL: %s\n", c.Request.URL.String())
 		//log.Printf("Request Headers: %v\n", c.Request.Header)
-		log.Printf("Request Body: %s\n", string(bodyBytes))
+		klog.Infof("Request Body: %s\n", string(bodyBytes))
 
 		c.Next() // Process the request further
 	}
@@ -133,9 +133,9 @@ func ResponseLoggerMiddleware() gin.HandlerFunc {
 
 		c.Next() // Process the request and generate the response
 
-		log.Printf("Response Status: %d\n", c.Writer.Status())
-		log.Printf("Response Headers: %v\n", c.Writer.Header())
-		log.Printf("Response Body: %s\n", blw.body.String())
+		klog.Infof("Response Status: %d\n", c.Writer.Status())
+		klog.Infof("Response Headers: %v\n", c.Writer.Header())
+		klog.Infof("Response Body: %s\n", blw.body.String())
 	}
 }
 

--- a/repo-agent/review-ui/review-api/pkg/api/utils.go
+++ b/repo-agent/review-ui/review-api/pkg/api/utils.go
@@ -3,12 +3,12 @@ package api
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/url"
 	"sort"
 	"strings"
 
 	"github.com/google/go-github/v39/github"
+	"k8s.io/klog/v2"
 )
 
 func fixYAMLIntegers(in interface{}) interface{} {
@@ -56,6 +56,7 @@ func parseRepoURL(repoURL string) (string, string, error) {
 var allowedLabelPrefixes = []string{"area/", "kind/", "priority/", "sig/", "type/"}
 
 func getSuggestedLabels(ctx context.Context, client *github.Client, owner, repo string) ([][]string, error) {
+	log := klog.FromContext(ctx)
 	query := fmt.Sprintf("repo:%s/%s involves:@me is:pr", owner, repo)
 	opts := &github.SearchOptions{
 		Sort:        "updated",
@@ -69,10 +70,10 @@ func getSuggestedLabels(ctx context.Context, client *github.Client, owner, repo 
 	}
 
 	for _, issue := range result.Issues {
-		log.Printf("Found issue #%d with labels:", *issue.Number)
+		log.Info("Found issue", "issueNumber", *issue.Number)
 		for _, label := range issue.Labels {
 			if label.Name != nil {
-				log.Printf(" - %s", *label.Name)
+				log.Info("Issue label", "label", *label.Name)
 			}
 		}
 	}

--- a/repo-agent/review-ui/review-api/pkg/auth/auth.go
+++ b/repo-agent/review-ui/review-api/pkg/auth/auth.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -20,6 +19,7 @@ import (
 	"golang.org/x/oauth2"
 	githuboauth "golang.org/x/oauth2/github"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -48,7 +48,7 @@ func (a *Authenticator) InitOAuth() {
 	clientSecret := os.Getenv("GITHUB_CLIENT_SECRET")
 
 	if clientID == "" || clientSecret == "" {
-		log.Println("Warning: GITHUB_CLIENT_ID or GITHUB_CLIENT_SECRET not set. OAuth will not work.")
+		klog.Info("Warning: GITHUB_CLIENT_ID or GITHUB_CLIENT_SECRET not set. OAuth will not work.")
 	}
 
 	a.OAuthConfig = &oauth2.Config{
@@ -60,7 +60,7 @@ func (a *Authenticator) InitOAuth() {
 
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
-		log.Fatalf("Failed to generate random OAuth state: %v", err)
+		klog.Fatalf("Failed to generate random OAuth state: %v", err)
 	}
 	a.OAuthState = base64.URLEncoding.EncodeToString(b)
 }
@@ -104,13 +104,14 @@ func (a *Authenticator) Login(c *gin.Context) {
 }
 
 func (a *Authenticator) Callback(c *gin.Context) {
+	log := klog.FromContext(c.Request.Context())
 	if c.Query("state") != a.OAuthState {
 		c.String(http.StatusBadRequest, "Invalid OAuth state")
 		return
 	}
 	token, err := a.OAuthConfig.Exchange(c.Request.Context(), c.Query("code"))
 	if err != nil {
-		log.Printf("OAuth exchange failed: %v", err)
+		log.Info("OAuth exchange failed", "err", err)
 		c.String(http.StatusInternalServerError, "Authentication failed")
 		return
 	}
@@ -118,7 +119,7 @@ func (a *Authenticator) Callback(c *gin.Context) {
 	client := github.NewClient(a.OAuthConfig.Client(c.Request.Context(), token))
 	user, _, err := client.Users.Get(c.Request.Context(), "")
 	if err != nil {
-		log.Printf("Failed to get GitHub user: %v", err)
+		log.Info("Failed to get GitHub user", "err", err)
 		c.String(http.StatusInternalServerError, "Failed to get user info")
 		return
 	}
@@ -127,18 +128,18 @@ func (a *Authenticator) Callback(c *gin.Context) {
 
 	// Enforce allowlist for GitHub users
 	if !a.IsUserAllowed(ghUser) {
-		log.Printf("Unauthorized GitHub user attempted to log in: %s", ghUser)
+		log.Info("Unauthorized GitHub user attempted to log in", "user", ghUser)
 		c.String(http.StatusForbidden, "Unauthorized GitHub user. Please contact administrator.")
 		return
 	}
 
 	if err := pkgk8s.BootstrapNamespace(c.Request.Context(), a.K8sManager.Clientset, ghUser); err != nil {
-		log.Printf("Failed to bootstrap namespace %s: %v", ghUser, err)
+		log.Info("Failed to bootstrap namespace", "user", ghUser, "err", err)
 	}
 
 	// Update the secret with the user's token and info
 	if err := a.updateUserSecret(c.Request.Context(), ghUser, token, user); err != nil {
-		log.Printf("Failed to update user secret: %v", err)
+		log.Info("Failed to update user secret", "err", err)
 		c.String(http.StatusInternalServerError, "Failed to update user secret")
 		return
 	}
@@ -146,7 +147,7 @@ func (a *Authenticator) Callback(c *gin.Context) {
 	session := sessions.Default(c)
 	session.Set(UserKey, ghUser)
 	if err := session.Save(); err != nil {
-		log.Printf("Failed to save session: %v", err)
+		log.Info("Failed to save session", "err", err)
 		c.String(http.StatusInternalServerError, "Failed to save session")
 		return
 	}
@@ -183,10 +184,11 @@ func (a *Authenticator) Status(c *gin.Context) {
 }
 
 func (a *Authenticator) Logout(c *gin.Context) {
+	log := klog.FromContext(c.Request.Context())
 	session := sessions.Default(c)
 	session.Delete(UserKey)
 	if err := session.Save(); err != nil {
-		log.Printf("Failed to save session: %v", err)
+		log.Info("Failed to save session", "err", err)
 		c.String(http.StatusInternalServerError, "Failed to save session")
 		return
 	}
@@ -199,6 +201,7 @@ func (a *Authenticator) GetProviders(c *gin.Context) {
 }
 
 func (a *Authenticator) UpdateGithubConfig(c *gin.Context) {
+	log := klog.FromContext(c.Request.Context())
 	var payload struct {
 		ClientID     string `json:"client_id"`
 		ClientSecret string `json:"client_secret"`
@@ -217,7 +220,7 @@ func (a *Authenticator) UpdateGithubConfig(c *gin.Context) {
 	// We need to get the existing secret to preserve the PAT
 	secret, err := a.K8sManager.Clientset.CoreV1().Secrets(pkgk8s.SystemNamespace).Get(c.Request.Context(), pkgk8s.GithubSecretName, v1.GetOptions{})
 	if err != nil {
-		log.Printf("Failed to get github secret: %v", err)
+		log.Info("Failed to get github secret", "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get github secret"})
 		return
 	}
@@ -230,7 +233,7 @@ func (a *Authenticator) UpdateGithubConfig(c *gin.Context) {
 
 	_, err = a.K8sManager.Clientset.CoreV1().Secrets(pkgk8s.SystemNamespace).Update(c.Request.Context(), secret, v1.UpdateOptions{})
 	if err != nil {
-		log.Printf("Failed to update github secret: %v", err)
+		log.Info("Failed to update github secret", "err", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update github secret"})
 		return
 	}
@@ -244,6 +247,7 @@ func (a *Authenticator) UpdateGithubConfig(c *gin.Context) {
 
 func (a *Authenticator) Middleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		log := klog.FromContext(c.Request.Context())
 		session := sessions.Default(c)
 		userVal := session.Get(UserKey)
 
@@ -266,7 +270,7 @@ func (a *Authenticator) Middleware() gin.HandlerFunc {
 		if _, ok := a.bootstrappedUsers.Load(user); !ok {
 			// Lazy bootstrap checks if namespace exists, creating it if needed.
 			if err := pkgk8s.BootstrapNamespace(c.Request.Context(), a.K8sManager.Clientset, user); err != nil {
-				log.Printf("Lazy bootstrap failed for user %s: %v", user, err)
+				log.Info("Lazy bootstrap failed for user", "user", user, "err", err)
 			} else {
 				a.bootstrappedUsers.Store(user, true)
 			}

--- a/repo-agent/review-ui/review-api/pkg/k8s/k8s.go
+++ b/repo-agent/review-ui/review-api/pkg/k8s/k8s.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"log"
 
 	redis "github.com/go-redis/redis/v8"
 	corev1 "k8s.io/api/core/v1"
@@ -15,6 +14,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -145,6 +145,7 @@ func (m *Manager) UpdateSecret(ctx context.Context, namespace, name string, data
 }
 
 func (m *Manager) ScaledownSandbox(ctx context.Context, namespace, repo, prID string) error {
+	log := klog.FromContext(ctx)
 	prKey := fmt.Sprintf("pr:ns:%s:repo:%s:pr:%s", namespace, repo, prID)
 	sandboxName, err := m.Redis.HGet(ctx, prKey, "sandbox").Result()
 	if err != nil && err != redis.Nil {
@@ -160,7 +161,7 @@ func (m *Manager) ScaledownSandbox(ctx context.Context, namespace, repo, prID st
 		Version:  "v1alpha1",
 		Resource: "reviewsandboxes",
 	}
-	log.Printf("Scaling down sandbox %s", sandboxName)
+	log.Info("Scaling down sandbox", "name", sandboxName)
 
 	_, err = m.Client.Resource(gvr).Namespace(namespace).Get(ctx, sandboxName, v1.GetOptions{})
 	if err != nil {
@@ -324,6 +325,7 @@ func (m *Manager) GetRepoWatch(ctx context.Context, namespace, name string) (*un
 }
 
 func (m *Manager) ScaledownIssueSandbox(ctx context.Context, namespace, repo, issueID, handler string) error {
+	log := klog.FromContext(ctx)
 	sandboxName := fmt.Sprintf("%s-issue-%s-%s", repo, issueID, handler)
 
 	gvr := schema.GroupVersionResource{
@@ -331,7 +333,7 @@ func (m *Manager) ScaledownIssueSandbox(ctx context.Context, namespace, repo, is
 		Version:  "v1alpha1",
 		Resource: "issuesandboxes",
 	}
-	log.Printf("Scaling down issue sandbox %s", sandboxName)
+	log.Info("Scaling down issue sandbox", "name", sandboxName)
 
 	_, err := m.Client.Resource(gvr).Namespace(namespace).Get(ctx, sandboxName, v1.GetOptions{})
 	if err != nil {
@@ -364,12 +366,13 @@ func (m *Manager) ScaledownIssueSandbox(ctx context.Context, namespace, repo, is
 }
 
 func (m *Manager) ScaledownDevSandboxHelper(ctx context.Context, namespace, name string) error {
+	log := klog.FromContext(ctx)
 	gvr := schema.GroupVersionResource{
 		Group:    "custom.agents.x-k8s.io",
 		Version:  "v1alpha1",
 		Resource: "devsandboxes",
 	}
-	log.Printf("Scaling down dev sandbox %s", name)
+	log.Info("Scaling down dev sandbox", "name", name)
 
 	_, err := m.Client.Resource(gvr).Namespace(namespace).Get(ctx, name, v1.GetOptions{})
 	if err != nil {
@@ -402,6 +405,7 @@ func (m *Manager) ScaledownDevSandboxHelper(ctx context.Context, namespace, name
 }
 
 func (m *Manager) ScaleupSandbox(ctx context.Context, namespace, repo, prID string) error {
+	log := klog.FromContext(ctx)
 	prKey := fmt.Sprintf("pr:ns:%s:repo:%s:pr:%s", namespace, repo, prID)
 	sandboxName, err := m.Redis.HGet(ctx, prKey, "sandbox").Result()
 	if err != nil && err != redis.Nil {
@@ -416,7 +420,7 @@ func (m *Manager) ScaleupSandbox(ctx context.Context, namespace, repo, prID stri
 		Version:  "v1alpha1",
 		Resource: "reviewsandboxes",
 	}
-	log.Printf("Scaling up sandbox %s", sandboxName)
+	log.Info("Scaling up sandbox", "name", sandboxName)
 
 	_, err = m.Client.Resource(gvr).Namespace(namespace).Get(ctx, sandboxName, v1.GetOptions{})
 	if err != nil {
@@ -449,6 +453,7 @@ func (m *Manager) ScaleupSandbox(ctx context.Context, namespace, repo, prID stri
 }
 
 func (m *Manager) ScaleupIssueSandbox(ctx context.Context, namespace, repo, issueID, handler string) error {
+	log := klog.FromContext(ctx)
 	sandboxName := fmt.Sprintf("%s-issue-%s-%s", repo, issueID, handler)
 
 	gvr := schema.GroupVersionResource{
@@ -456,7 +461,7 @@ func (m *Manager) ScaleupIssueSandbox(ctx context.Context, namespace, repo, issu
 		Version:  "v1alpha1",
 		Resource: "issuesandboxes",
 	}
-	log.Printf("Scaling up issue sandbox %s", sandboxName)
+	log.Info("Scaling up issue sandbox", "name", sandboxName)
 
 	_, err := m.Client.Resource(gvr).Namespace(namespace).Get(ctx, sandboxName, v1.GetOptions{})
 	if err != nil {
@@ -489,12 +494,13 @@ func (m *Manager) ScaleupIssueSandbox(ctx context.Context, namespace, repo, issu
 }
 
 func (m *Manager) ScaleupDevSandboxHelper(ctx context.Context, namespace, name string) error {
+	log := klog.FromContext(ctx)
 	gvr := schema.GroupVersionResource{
 		Group:    "custom.agents.x-k8s.io",
 		Version:  "v1alpha1",
 		Resource: "devsandboxes",
 	}
-	log.Printf("Scaling up dev sandbox %s", name)
+	log.Info("Scaling up dev sandbox", "name", name)
 
 	_, err := m.Client.Resource(gvr).Namespace(namespace).Get(ctx, name, v1.GetOptions{})
 	if err != nil {

--- a/repo-agent/review-ui/review-api/pkg/store/redis.go
+++ b/repo-agent/review-ui/review-api/pkg/store/redis.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/review-ui/review-api/pkg/models"
 	redis "github.com/go-redis/redis/v8"
+	"k8s.io/klog/v2"
 )
 
 // NewClient creates a new Redis client
@@ -38,6 +38,7 @@ func (s *RedisStore) SaveRepo(ctx context.Context, namespace, name, url string) 
 }
 
 func (s *RedisStore) DeleteRepo(ctx context.Context, namespace, name string) error {
+	log := klog.FromContext(ctx)
 	key := s.RepoKey(namespace, name)
 	if err := s.client.Del(ctx, key).Err(); err != nil {
 		return err
@@ -48,7 +49,7 @@ func (s *RedisStore) DeleteRepo(ctx context.Context, namespace, name string) err
 		iter := s.client.Scan(ctx, 0, pattern, 0).Iterator()
 		for iter.Next(ctx) {
 			if err := s.client.Del(ctx, iter.Val()).Err(); err != nil {
-				log.Printf("Failed to delete key %s: %v", iter.Val(), err)
+				log.Info("Failed to delete key", "key", iter.Val(), "err", err)
 			}
 		}
 		return iter.Err()
@@ -56,17 +57,17 @@ func (s *RedisStore) DeleteRepo(ctx context.Context, namespace, name string) err
 
 	// Delete PRs
 	if err := deleteByPattern(fmt.Sprintf("pr:ns:%s:repo:%s:*", namespace, name)); err != nil {
-		log.Printf("Failed to delete PR keys for repo %s: %v", name, err)
+		log.Info("Failed to delete PR keys for repo", "name", name, "err", err)
 	}
 
 	// Delete Issues
 	if err := deleteByPattern(fmt.Sprintf("issue:ns:%s:repo:%s:*", namespace, name)); err != nil {
-		log.Printf("Failed to delete Issue keys for repo %s: %v", name, err)
+		log.Info("Failed to delete Issue keys for repo", "name", name, "err", err)
 	}
 
 	// Delete DevSandboxes
 	if err := deleteByPattern(fmt.Sprintf("dev:ns:%s:repo:%s:*", namespace, name)); err != nil {
-		log.Printf("Failed to delete DevSandbox keys for repo %s: %v", name, err)
+		log.Info("Failed to delete DevSandbox keys for repo", "name", name, "err", err)
 	}
 
 	return nil
@@ -92,6 +93,7 @@ func (s *RedisStore) IssueKey(namespace, repo, handler, issueID string) string {
 }
 
 func (s *RedisStore) ListIssues(ctx context.Context, namespace, repo, handler string) ([]models.Issue, error) {
+	log := klog.FromContext(ctx)
 	issues := []models.Issue{}
 	issueKeyPrefix := s.IssueKey(namespace, repo, handler, "*")
 	iter := s.client.Scan(ctx, 0, issueKeyPrefix, 0).Iterator()
@@ -107,7 +109,7 @@ func (s *RedisStore) ListIssues(ctx context.Context, namespace, repo, handler st
 
 		issueData, err := s.client.HGetAll(ctx, key).Result()
 		if err != nil {
-			log.Printf("Failed to get Issue %s from Redis for repo %s handler %s: %v", issueID, repo, handler, err)
+			log.Info("Failed to get Issue from Redis", "issueID", issueID, "repo", repo, "handler", handler, "err", err)
 			continue
 		}
 
@@ -269,6 +271,7 @@ func (s *RedisStore) DevSandboxKey(namespace, repo, name string) string {
 }
 
 func (s *RedisStore) ListDevSandboxes(ctx context.Context, namespace, repo string) ([]models.DevSandbox, error) {
+	log := klog.FromContext(ctx)
 	sandboxes := []models.DevSandbox{}
 	// prefix: dev:ns:NAMESPACE:repo:REPO:dev:*
 	prefix := s.DevSandboxKey(namespace, repo, "*")
@@ -285,7 +288,7 @@ func (s *RedisStore) ListDevSandboxes(ctx context.Context, namespace, repo strin
 
 		data, err := s.client.HGetAll(ctx, key).Result()
 		if err != nil {
-			log.Printf("Failed to get DevSandbox %s from Redis for repo %s: %v", name, repo, err)
+			log.Info("Failed to get DevSandbox from Redis", "name", name, "repo", repo, "err", err)
 			continue
 		}
 
@@ -347,6 +350,7 @@ func (s *RedisStore) PRKey(namespace, repo, prID string) string {
 }
 
 func (s *RedisStore) ListPRs(ctx context.Context, namespace, repo string) ([]models.PR, error) {
+	log := klog.FromContext(ctx)
 	prs := []models.PR{}
 	repoPRKeyPrefix := s.PRKey(namespace, repo, "*")
 	iter := s.client.Scan(ctx, 0, repoPRKeyPrefix, 0).Iterator()
@@ -355,7 +359,7 @@ func (s *RedisStore) ListPRs(ctx context.Context, namespace, repo string) ([]mod
 		prID := key[len(repoPRKeyPrefix)-1:]
 		prData, err := s.client.HGetAll(ctx, key).Result()
 		if err != nil {
-			log.Printf("Failed to get PR %s from Redis for repo %s: %v", prID, repo, err)
+			log.Info("Failed to get PR from Redis", "prID", prID, "repo", repo, "err", err)
 			continue
 		}
 		pr := models.PR{
@@ -512,6 +516,7 @@ func (s *RedisStore) DeletePR(ctx context.Context, namespace, repo, prID string)
 func PopulateMockData(ctx context.Context, rdb *redis.Client) {
 	// Create a temporary store to use the methods
 	s := NewRedisStore(rdb)
+	log := klog.FromContext(ctx)
 
 	mockRepos := []struct {
 		Name string
@@ -535,14 +540,14 @@ func PopulateMockData(ctx context.Context, rdb *redis.Client) {
 	for _, repo := range mockRepos {
 		// Store repo URL (Mock data in default namespace)
 		if err := s.SaveRepo(ctx, "default", repo.Name, repo.URL); err != nil {
-			log.Printf("Failed to set repo URL in Redis: %v", err)
+			log.Info("Failed to set repo URL in Redis", "err", err)
 		}
 
 		// Store PRs for the repo
 		for _, pr := range mockPRs[repo.Name] {
 			prKey := fmt.Sprintf("pr:ns:default:repo:%s:pr:%s", repo.Name, pr.ID)
 			if err := rdb.HSet(ctx, prKey, "title", pr.Title, "draft", pr.Draft, "sandbox", pr.Sandbox, "review", pr.Review).Err(); err != nil {
-				log.Printf("Failed to set PR info in Redis: %v", err)
+				log.Info("Failed to set PR info in Redis", "err", err)
 			}
 		}
 	}

--- a/repo-agent/syncer/cmd/gen-training-data/main.go
+++ b/repo-agent/syncer/cmd/gen-training-data/main.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -17,6 +16,7 @@ import (
 	"golang.org/x/oauth2"
 	"google.golang.org/api/iterator"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 )
 
@@ -52,10 +52,10 @@ func main() {
 	flag.Parse()
 
 	if *gcsBucket == "" {
-		log.Fatal("--gcs-bucket is required")
+		klog.Fatal("--gcs-bucket is required")
 	}
 	if *githubToken == "" {
-		log.Fatal("--github-token is required")
+		klog.Fatal("--github-token is required")
 	}
 
 	ctx := context.Background()
@@ -63,7 +63,7 @@ func main() {
 	// Initialize GCS Client
 	gcsClient, err := storage.NewClient(ctx)
 	if err != nil {
-		log.Fatalf("Failed to create GCS client: %v", err)
+		klog.Fatalf("Failed to create GCS client: %v", err)
 	}
 	defer gcsClient.Close()
 
@@ -80,13 +80,13 @@ func main() {
 		var err error
 		singleFile, err = os.Create(*outputFile)
 		if err != nil {
-			log.Fatalf("Failed to create output file: %v", err)
+			klog.Fatalf("Failed to create output file: %v", err)
 		}
 		defer singleFile.Close()
 	} else {
 		// Ensure output directory exists
 		if err := os.MkdirAll(*outputDir, 0755); err != nil {
-			log.Fatalf("Failed to create output directory: %v", err)
+			klog.Fatalf("Failed to create output directory: %v", err)
 		}
 	}
 
@@ -101,30 +101,30 @@ func main() {
 			break
 		}
 		if err != nil {
-			log.Fatalf("Failed to list objects: %v", err)
+			klog.Fatalf("Failed to list objects: %v", err)
 		}
 
 		if !strings.HasSuffix(attrs.Name, ".yaml") {
 			continue
 		}
 
-		log.Printf("Processing %s", attrs.Name)
+		klog.Infof("Processing %s", attrs.Name)
 		rc, err := gcsClient.Bucket(*gcsBucket).Object(attrs.Name).NewReader(ctx)
 		if err != nil {
-			log.Printf("Failed to read object %s: %v", attrs.Name, err)
+			klog.Infof("Failed to read object %s: %v", attrs.Name, err)
 			continue
 		}
 		data, err := io.ReadAll(rc)
 		rc.Close()
 		if err != nil {
-			log.Printf("Failed to read content of %s: %v", attrs.Name, err)
+			klog.Infof("Failed to read content of %s: %v", attrs.Name, err)
 			continue
 		}
 
 		// Parse Unstructured
 		var u unstructured.Unstructured
 		if err := yaml.Unmarshal(data, &u.Object); err != nil {
-			log.Printf("Failed to unmarshal YAML %s: %v", attrs.Name, err)
+			klog.Infof("Failed to unmarshal YAML %s: %v", attrs.Name, err)
 			continue
 		}
 
@@ -136,13 +136,13 @@ func main() {
 		annotations := u.GetAnnotations()
 		agentDraftYAML, ok := annotations["agentDraft"]
 		if !ok || agentDraftYAML == "" {
-			log.Printf("No agentDraft annotation in %s", attrs.Name)
+			klog.Infof("No agentDraft annotation in %s", attrs.Name)
 			continue
 		}
 
 		var agentOutput AgentOutput
 		if err := yaml.Unmarshal([]byte(agentDraftYAML), &agentOutput); err != nil {
-			log.Printf("Failed to unmarshal agentDraft in %s: %v", attrs.Name, err)
+			klog.Infof("Failed to unmarshal agentDraft in %s: %v", attrs.Name, err)
 			continue
 		}
 
@@ -152,35 +152,35 @@ func main() {
 		prURL, _, _ := unstructured.NestedString(source, "htmlURL")
 
 		if prURL == "" {
-			log.Printf("No htmlURL in source spec for %s", attrs.Name)
+			klog.Infof("No htmlURL in source spec for %s", attrs.Name)
 			continue
 		}
 
 		// URL format: https://github.com/owner/repo/pull/123 or just https://github.com/owner/repo
 		parts := strings.Split(strings.TrimPrefix(prURL, "https://github.com/"), "/")
 		if len(parts) < 4 || parts[2] != "pull" {
-			log.Printf("Invalid PR URL format: %s", prURL)
+			klog.Infof("Invalid PR URL format: %s", prURL)
 			continue
 		}
 		owner := parts[0]
 		repo := parts[1]
 		prNumber, err := strconv.Atoi(parts[3])
 		if err != nil {
-			log.Printf("Invalid PR number in URL: %s", prURL)
+			klog.Infof("Invalid PR number in URL: %s", prURL)
 			continue
 		}
 
 		// Fetch PR Status
 		pr, _, err := ghClient.PullRequests.Get(ctx, owner, repo, prNumber)
 		if err != nil {
-			log.Printf("Failed to get PR %s/%s/%d: %v", owner, repo, prNumber, err)
+			klog.Infof("Failed to get PR %s/%s/%d: %v", owner, repo, prNumber, err)
 			continue
 		}
 
 		// Fetch Reviews
 		reviews, _, err := ghClient.PullRequests.ListReviews(ctx, owner, repo, prNumber, nil)
 		if err != nil {
-			log.Printf("Failed to list reviews for %s/%s/%d: %v", owner, repo, prNumber, err)
+			klog.Infof("Failed to list reviews for %s/%s/%d: %v", owner, repo, prNumber, err)
 			continue
 		}
 
@@ -205,7 +205,7 @@ func main() {
 
 		jsonData, err := json.Marshal(record)
 		if err != nil {
-			log.Printf("Failed to marshal record: %v", err)
+			klog.Infof("Failed to marshal record: %v", err)
 			continue
 		}
 
@@ -221,7 +221,7 @@ func main() {
 			}
 			userDir := filepath.Join(*outputDir, namespace)
 			if err := os.MkdirAll(userDir, 0755); err != nil {
-				log.Printf("Failed to create user directory %s: %v", userDir, err)
+				klog.Infof("Failed to create user directory %s: %v", userDir, err)
 				continue
 			}
 
@@ -239,7 +239,7 @@ func main() {
 
 			f, err := os.OpenFile(fpath, flags, 0644)
 			if err != nil {
-				log.Printf("Failed to open file %s: %v", fpath, err)
+				klog.Infof("Failed to open file %s: %v", fpath, err)
 				continue
 			}
 			writer = f
@@ -248,17 +248,17 @@ func main() {
 		n, err := writer.Write(jsonData)
 		if err != nil {
 			if singleFile != nil {
-				log.Fatalf("Failed to write record: %v", err)
+				klog.Fatalf("Failed to write record: %v", err)
 			}
-			log.Printf("Failed to write record: %v", err)
+			klog.Infof("Failed to write record: %v", err)
 			writer.(*os.File).Close()
 			continue
 		}
 		if n != len(jsonData) {
 			if singleFile != nil {
-				log.Fatalf("Short write for record: %d != %d", n, len(jsonData))
+				klog.Fatalf("Short write for record: %d != %d", n, len(jsonData))
 			}
-			log.Printf("Short write for record: %d != %d", n, len(jsonData))
+			klog.Infof("Short write for record: %d != %d", n, len(jsonData))
 			writer.(*os.File).Close()
 			continue
 		}
@@ -266,17 +266,17 @@ func main() {
 		n, err = writer.Write([]byte("\n"))
 		if err != nil {
 			if singleFile != nil {
-				log.Fatalf("Failed to write record: %v", err)
+				klog.Fatalf("Failed to write record: %v", err)
 			}
-			log.Printf("Failed to write record: %v", err)
+			klog.Infof("Failed to write record: %v", err)
 			writer.(*os.File).Close()
 			continue
 		}
 		if n != len("\n") {
 			if singleFile != nil {
-				log.Fatalf("Short write for record: %d != %d", n, len("\n"))
+				klog.Fatalf("Short write for record: %d != %d", n, len("\n"))
 			}
-			log.Printf("Short write for record: %d != %d", n, len("\n"))
+			klog.Infof("Short write for record: %d != %d", n, len("\n"))
 			writer.(*os.File).Close()
 			continue
 		}
@@ -286,5 +286,5 @@ func main() {
 			writer.(*os.File).Close()
 		}
 	}
-	log.Println("Processing complete.")
+	klog.Info("Processing complete.")
 }

--- a/repo-agent/syncer/cmd/gen-user-instructions/main.go
+++ b/repo-agent/syncer/cmd/gen-user-instructions/main.go
@@ -6,11 +6,12 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"k8s.io/klog/v2"
 )
 
 const promptTemplate = `
@@ -71,7 +72,7 @@ func main() {
 
 	// Ensure output directory exists
 	if err := os.MkdirAll(*outputDir, 0755); err != nil {
-		log.Fatalf("Failed to create output directory: %v", err)
+		klog.Fatalf("Failed to create output directory: %v", err)
 	}
 
 	// Walk input directory
@@ -91,15 +92,15 @@ func main() {
 			return err
 		}
 
-		log.Printf("Processing %s", relPath)
+		klog.Infof("Processing %s", relPath)
 		if err := processFile(path, *outputDir, relPath, *geminiCmd, *maxRecords); err != nil {
-			log.Printf("Error processing %s: %v", path, err)
+			klog.Infof("Error processing %s: %v", path, err)
 		}
 		return nil
 	})
 
 	if err != nil {
-		log.Fatalf("Walk failed: %v", err)
+		klog.Fatalf("Walk failed: %v", err)
 	}
 }
 
@@ -120,7 +121,7 @@ func processFile(inputPath, outputDir, relPath, geminiCmd string, maxRecords int
 	for scanner.Scan() {
 		var r TrainingDataRecord
 		if err := json.Unmarshal(scanner.Bytes(), &r); err != nil {
-			log.Printf("Skipping invalid JSON line in %s: %v", inputPath, err)
+			klog.Infof("Skipping invalid JSON line in %s: %v", inputPath, err)
 			continue
 		}
 		records = append(records, r)
@@ -142,7 +143,7 @@ func processFile(inputPath, outputDir, relPath, geminiCmd string, maxRecords int
 	}
 
 	if len(usefulRecords) == 0 {
-		log.Printf("No records with human reviews in %s. Skipping.", inputPath)
+		klog.Infof("No records with human reviews in %s. Skipping.", inputPath)
 		return nil
 	}
 
@@ -168,7 +169,7 @@ func processFile(inputPath, outputDir, relPath, geminiCmd string, maxRecords int
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	log.Printf("Invoking Gemini for %s...", inputPath)
+	klog.Infof("Invoking Gemini for %s...", inputPath)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("gemini execution failed: %v. Stderr: %s", err, stderr.String())
 	}
@@ -197,7 +198,7 @@ func processFile(inputPath, outputDir, relPath, geminiCmd string, maxRecords int
 		return fmt.Errorf("failed to write output: %v", err)
 	}
 
-	log.Printf("Generated instructions at %s", outPath)
+	klog.Infof("Generated instructions at %s", outPath)
 	return nil
 }
 

--- a/repo-agent/syncer/cmd/inject-user-instructions/main.go
+++ b/repo-agent/syncer/cmd/inject-user-instructions/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,6 +15,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -60,13 +60,13 @@ func main() {
 		// Fallback to in-cluster config if kubeconfig not found or failed
 		config, err = ctrl.GetConfig()
 		if err != nil {
-			log.Fatalf("Failed to get kubeconfig: %v", err)
+			klog.Fatalf("Failed to get kubeconfig: %v", err)
 		}
 	}
 
 	k8sClient, err := client.New(config, client.Options{Scheme: scheme})
 	if err != nil {
-		log.Fatalf("Failed to create k8s client: %v", err)
+		klog.Fatalf("Failed to create k8s client: %v", err)
 	}
 
 	ctx := context.Background()
@@ -96,7 +96,7 @@ func main() {
 
 		parts := strings.Split(relPath, string(os.PathSeparator))
 		if len(parts) != 2 {
-			log.Printf("Skipping %s: unexpected directory structure. Expected <namespace>/<filename>", relPath)
+			klog.Infof("Skipping %s: unexpected directory structure. Expected <namespace>/<filename>", relPath)
 			return nil
 		}
 
@@ -108,7 +108,7 @@ func main() {
 
 		content, err := os.ReadFile(path)
 		if err != nil {
-			log.Printf("Failed to read %s: %v", path, err)
+			klog.Infof("Failed to read %s: %v", path, err)
 			return nil
 		}
 
@@ -116,7 +116,7 @@ func main() {
 			ProjectName string `json:"project_name"`
 		}
 		if err := json.Unmarshal(content, &instruction); err != nil {
-			log.Printf("Failed to parse JSON in %s: %v", path, err)
+			klog.Infof("Failed to parse JSON in %s: %v", path, err)
 			return nil
 		}
 
@@ -124,16 +124,16 @@ func main() {
 		if repoName == "" {
 			// Fallback to filename parsing if JSON doesn't have it
 			// This is risky if repo name has hyphens.
-			log.Printf("Warning: project_name empty in %s. Using matching logic might be flaky.", path)
+			klog.Infof("Warning: project_name empty in %s. Using matching logic might be flaky.", path)
 			// Try to find matching RepoWatch in the namespace
 		}
 
-		log.Printf("Processing %s for repo %s in namespace %s", relPath, repoName, namespace)
+		klog.Infof("Processing %s for repo %s in namespace %s", relPath, repoName, namespace)
 
 		// Find RepoWatch
 		rwList := &repowatchv1alpha1.RepoWatchList{}
 		if err := k8sClient.List(ctx, rwList, client.InNamespace(namespace)); err != nil {
-			log.Printf("Failed to list RepoWatches in %s: %v", namespace, err)
+			klog.Infof("Failed to list RepoWatches in %s: %v", namespace, err)
 			return nil
 		}
 
@@ -149,20 +149,20 @@ func main() {
 		}
 
 		if matchedRW == nil {
-			log.Printf("No RepoWatch found for %s in namespace %s", repoName, namespace)
+			klog.Infof("No RepoWatch found for %s in namespace %s", repoName, namespace)
 			return nil
 		}
 
 		configDirName := matchedRW.Spec.Review.LLM.ConfigdirRef
 		if configDirName == "" {
-			log.Printf("RepoWatch %s has no ConfigDirRef", matchedRW.Name)
+			klog.Infof("RepoWatch %s has no ConfigDirRef", matchedRW.Name)
 			return nil
 		}
 
 		// Get ConfigDir
 		configDir := &configdirv1alpha1.ConfigDir{}
 		if err := k8sClient.Get(ctx, client.ObjectKey{Name: configDirName, Namespace: namespace}, configDir); err != nil {
-			log.Printf("Failed to get ConfigDir %s: %v", configDirName, err)
+			klog.Infof("Failed to get ConfigDir %s: %v", configDirName, err)
 			return nil
 		}
 
@@ -189,7 +189,7 @@ func main() {
 					configDir.Spec.Files[i] = newFileItem
 					updated = true
 				} else {
-					log.Printf("ConfigDir %s already up to date for %s", configDirName, targetPath)
+					klog.Infof("ConfigDir %s already up to date for %s", configDirName, targetPath)
 				}
 				break
 			}
@@ -206,7 +206,7 @@ func main() {
 			newFiles := []configdirv1alpha1.FileItem{}
 			for _, f := range configDir.Spec.Files {
 				if f.Path == draftPath {
-					log.Printf("Removing draft file %s from ConfigDir %s", draftPath, configDirName)
+					klog.Infof("Removing draft file %s from ConfigDir %s", draftPath, configDirName)
 					updated = true
 					continue
 				}
@@ -217,9 +217,9 @@ func main() {
 
 		if updated {
 			if err := k8sClient.Update(ctx, configDir); err != nil {
-				log.Printf("Failed to update ConfigDir %s: %v", configDirName, err)
+				klog.Infof("Failed to update ConfigDir %s: %v", configDirName, err)
 			} else {
-				log.Printf("Updated ConfigDir %s with instructions at %s", configDirName, targetPath)
+				klog.Infof("Updated ConfigDir %s with instructions at %s", configDirName, targetPath)
 			}
 		}
 
@@ -227,6 +227,6 @@ func main() {
 	})
 
 	if err != nil {
-		log.Fatalf("Walk failed: %v", err)
+		klog.Fatalf("Walk failed: %v", err)
 	}
 }


### PR DESCRIPTION
* Updated imports in 20+ files to remove "log" and add "k8s.io/klog/v2".
* Replaced logging calls:
  * log.Printf -> klog.Infof
  * log.Println / log.Print -> klog.Info
  * log.Fatalf / log.Fatal -> klog.Fatalf / klog.Fatal
* Updated log.SetOutput to klog.SetOutput in tests.