### PR TITLE
feat: Implement LLM quota checking and enhance command execution

### DIFF
--- a/repo-agent/cmd/dev-sandbox/main.go
+++ b/repo-agent/cmd/dev-sandbox/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,6 +12,7 @@ import (
 	"syscall"
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/agentoutput"
+	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/llm"
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/sshd"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -131,6 +133,16 @@ func InitContainer(ctx context.Context) error {
 		ReportStatus:     false,
 	}
 
+	var b ImageBuilder
+	if dotFilesRepo := os.Getenv("USER_DOTFILESREPO"); dotFilesRepo != "" {
+		_ = agentoutput.SetAgentState(ctx, gvr, "provisioning", "installing dotfiles")
+		if err := b.InstallDotfilesRepo(ctx, dotFilesRepo); err != nil {
+			// Note: we don't fail the entire startup if dotfiles installation fails
+			log.Error(err, "installing dotfiles repo", "repo", dotFilesRepo)
+			_ = agentoutput.SetAgentState(ctx, gvr, "warning", fmt.Sprintf("dotfiles install failed: %v", err))
+		}
+	}
+
 	// Prepare git branch (checkout)
 	oldCommitID, err := sandbox.PrepareGitBranch(cfg)
 	if err != nil {
@@ -141,24 +153,19 @@ func InitContainer(ctx context.Context) error {
 	if cfg.AgentPrompt != "" {
 		log.Info("Running agent with prompt", "prompt", cfg.AgentPrompt)
 		if err := sandbox.RunAgent(ctx, cfg); err != nil {
-			_ = agentoutput.SetAgentState(ctx, gvr, "error", fmt.Sprintf("running agent failed: %v", err))
-			return fmt.Errorf("running agent: %w", err)
-		}
-
-		commitMsg := "Agent changes for: " + cfg.AgentPrompt
-		if err := sandbox.ProcessGitChanges(ctx, cfg, oldCommitID, commitMsg); err != nil {
-			_ = agentoutput.SetAgentState(ctx, gvr, "error", fmt.Sprintf("processing git changes failed: %v", err))
-			return fmt.Errorf("processing git changes: %w", err)
-		}
-	}
-
-	var b ImageBuilder
-	if dotFilesRepo := os.Getenv("USER_DOTFILESREPO"); dotFilesRepo != "" {
-		_ = agentoutput.SetAgentState(ctx, gvr, "provisioning", "installing dotfiles")
-		if err := b.InstallDotfilesRepo(ctx, dotFilesRepo); err != nil {
-			// Note: we don't fail the entire startup if dotfiles installation fails
-			log.Error(err, "installing dotfiles repo", "repo", dotFilesRepo)
-			_ = agentoutput.SetAgentState(ctx, gvr, "warning", fmt.Sprintf("dotfiles install failed: %v", err))
+			var quotaErr *llm.QuotaError
+			if errors.As(err, &quotaErr) {
+				_ = agentoutput.SetAgentState(ctx, gvr, "QUOTA ERROR", err.Error())
+			} else {
+				_ = agentoutput.SetAgentState(ctx, gvr, "error", fmt.Sprintf("running agent failed: %v", err))
+				return fmt.Errorf("running agent: %w", err)
+			}
+		} else {
+			commitMsg := "Agent changes for: " + cfg.AgentPrompt
+			if err := sandbox.ProcessGitChanges(ctx, cfg, oldCommitID, commitMsg); err != nil {
+				_ = agentoutput.SetAgentState(ctx, gvr, "error", fmt.Sprintf("processing git changes failed: %v", err))
+				return fmt.Errorf("processing git changes: %w", err)
+			}
 		}
 	}
 

--- a/repo-agent/cmd/issue-sandbox/main.go
+++ b/repo-agent/cmd/issue-sandbox/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/agentoutput"
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/codeserver"
+	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/llm"
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/sandbox"
 )
 
@@ -65,18 +67,23 @@ func main() {
 	if _, err := os.Stat("../agent-prompt.txt"); os.IsNotExist(err) {
 		// Try solving the issue
 		if err := sandbox.RunAgent(ctx, cfg); err != nil {
-			_ = agentoutput.SetAgentState(ctx, gvr, "error", err.Error())
-			log.Error(err, "failed solving issue")
-			os.Exit(1)
-		}
-		_ = agentoutput.SetAgentState(ctx, gvr, "done", "")
-
-		// Push the changes
-		commitMessage := "fix for issue # " + os.Getenv("ISSUEID")
-		if err := sandbox.ProcessGitChanges(ctx, cfg, oldCommitID, commitMessage); err != nil {
-			_ = agentoutput.SetAgentState(ctx, gvr, "error", err.Error())
-			log.Error(err, "failed to process git changes")
-			os.Exit(1)
+			var quotaErr *llm.QuotaError
+			if errors.As(err, &quotaErr) {
+				_ = agentoutput.SetAgentState(ctx, gvr, "QUOTA ERROR", err.Error())
+			} else {
+				_ = agentoutput.SetAgentState(ctx, gvr, "error", err.Error())
+				log.Error(err, "failed solving issue")
+				os.Exit(1)
+			}
+		} else {
+			_ = agentoutput.SetAgentState(ctx, gvr, "done", "")
+			// Push the changes
+			commitMessage := "fix for issue # " + os.Getenv("ISSUEID")
+			if err := sandbox.ProcessGitChanges(ctx, cfg, oldCommitID, commitMessage); err != nil {
+				_ = agentoutput.SetAgentState(ctx, gvr, "error", err.Error())
+				log.Error(err, "failed to process git changes")
+				os.Exit(1)
+			}
 		}
 	} else {
 		log.Info("agent-prompt.txt exists, skipping code generation")

--- a/repo-agent/cmd/review-sandbox/main.go
+++ b/repo-agent/cmd/review-sandbox/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -53,14 +54,18 @@ func main() {
 	_ = agentoutput.SetAgentState(ctx, gvr, "reviewing", "")
 	err = runReview(ctx)
 	if err != nil {
-		if strings.Contains(err.Error(), "Too many files") {
+		var quotaErr *llm.QuotaError
+		if errors.As(err, &quotaErr) {
+			_ = agentoutput.SetAgentState(ctx, gvr, "QUOTA ERROR", err.Error())
+		} else if strings.Contains(err.Error(), "Too many files") {
 			_ = agentoutput.SetAgentState(ctx, gvr, "Error: Too many files", err.Error())
 		} else {
 			_ = agentoutput.SetAgentState(ctx, gvr, "error", err.Error())
+			klog.Fatalf("failed reviewing: %v", err)
 		}
-		klog.Fatalf("failed reviewing: %v", err)
+	} else {
+		_ = agentoutput.SetAgentState(ctx, gvr, "review ready", "")
 	}
-	_ = agentoutput.SetAgentState(ctx, gvr, "review ready", "")
 
 	err = cmdCodeSrv.Wait()
 	if err != nil {
@@ -203,6 +208,11 @@ func runReview(ctx context.Context) error {
 		// RUN THE AGENT
 		output, err := provider.Run(currentPrompt)
 		if err != nil {
+			var quotaErr *llm.QuotaError
+			if errors.As(err, &quotaErr) {
+				log.Error(err, "Agent run failed due to quota.")
+				return err
+			}
 			log.Error(err, "Agent run failed. Continuing...")
 			time.Sleep(10 * time.Second)
 			continue
@@ -479,6 +489,10 @@ func dedupeAndCombineText(provider llm.Provider, text string) (string, error) {
 
 	output, err := provider.Run(prompt)
 	if err != nil {
+		var quotaErr *llm.QuotaError
+		if errors.As(err, &quotaErr) {
+			return "", quotaErr
+		}
 		return "", err
 	}
 

--- a/repo-agent/pkg/llm/claude.go
+++ b/repo-agent/pkg/llm/claude.go
@@ -57,6 +57,10 @@ func (c *Claude) AddPostProcessor(p PostProcessor) {
 	c.postProcessors = append(c.postProcessors, p)
 }
 
+func (c *Claude) QuotaCheck() bool {
+	return true
+}
+
 func (c *Claude) Setup(_, tokensDir string) error {
 	// Read API key from the mounted secret file
 	apiKeyPath := filepath.Join(tokensDir, AnthropicAPIKeySecretKey)

--- a/repo-agent/pkg/llm/dummy.go
+++ b/repo-agent/pkg/llm/dummy.go
@@ -76,3 +76,7 @@ func (d *Dummy) Run(prompt string) ([]byte, error) {
 func (d *Dummy) AddPostProcessor(p PostProcessor) {
 	d.processors = append(d.processors, p)
 }
+
+func (d *Dummy) QuotaCheck() bool {
+	return true
+}

--- a/repo-agent/pkg/llm/exec.go
+++ b/repo-agent/pkg/llm/exec.go
@@ -19,14 +19,14 @@ import (
 )
 
 type CommandExecutor interface {
-	Run(command string, args ...string) ([]byte, error)
+	Run(command string, args ...string) ([]byte, []byte, error)
 }
 
 // RealCommandExecutor is a real implementation of CommandExecutor that runs commands.
 
 type RealCommandExecutor struct{}
 
-func (e *RealCommandExecutor) Run(command string, args ...string) ([]byte, error) {
+func (e *RealCommandExecutor) Run(command string, args ...string) ([]byte, []byte, error) {
 	const errBufferSize = 25 * 1024 * 1024 // 25MB
 	const outBufferSize = 1024 * 1024      // 1MB
 	stderrBuffer := NewCircularBuffer(errBufferSize)
@@ -45,8 +45,8 @@ func (e *RealCommandExecutor) Run(command string, args ...string) ([]byte, error
 		println(capturedOutput)
 	}
 	if err != nil {
-		return nil, err
+		return nil, stderrBuffer.Bytes(), err
 	}
 
-	return stdoutBuffer.Bytes(), nil
+	return stdoutBuffer.Bytes(), stderrBuffer.Bytes(), nil
 }

--- a/repo-agent/pkg/llm/exec_test.go
+++ b/repo-agent/pkg/llm/exec_test.go
@@ -24,36 +24,47 @@ func TestRealCommandExecutor_Run(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		// This test will fail if `echo` is not in the path
 		executor := &RealCommandExecutor{}
-		output, err := executor.Run("echo", "-n", "hello")
+		stdout, stderr, err := executor.Run("echo", "-n", "hello")
 		if err != nil {
 			t.Fatalf("RealCommandExecutor.Run() failed: %v", err)
 		}
-		if string(output) != "hello" {
-			t.Errorf("Expected output %q, but got %q", "hello", string(output))
+		if string(stdout) != "hello" {
+			t.Errorf("Expected stdout %q, but got %q", "hello", string(stdout))
+		}
+		if len(stderr) > 0 {
+			t.Errorf("Expected empty stderr, but got %q", string(stderr))
 		}
 	})
 
 	t.Run("error", func(t *testing.T) {
 		// This test will fail if `command-that-does-not-exist` is in the path
 		executor := &RealCommandExecutor{}
-		_, err := executor.Run("command-that-does-not-exist")
+		_, stderr, err := executor.Run("command-that-does-not-exist")
 		if err == nil {
 			t.Fatal("RealCommandExecutor.Run() should have failed, but it didn't")
 		}
-
 		// Check if the error is of type *exec.Error
 		var execErr *exec.Error
 		if !errors.As(err, &execErr) {
 			t.Errorf("Expected error of type *exec.Error, but got %T", err)
+		}
+		if len(stderr) > 0 {
+			t.Errorf("Expected empty stderr, but got %q", string(stderr))
 		}
 	})
 
 	t.Run("stderr", func(t *testing.T) {
 		// This test will fail if `sh` is not in the path
 		executor := &RealCommandExecutor{}
-		_, err := executor.Run("sh", "-c", "echo -n hello >&2")
+		stdout, stderr, err := executor.Run("sh", "-c", "echo -n hello >&2")
 		if err != nil {
 			t.Fatalf("RealCommandExecutor.Run() failed: %v", err)
+		}
+		if len(stdout) > 0 {
+			t.Errorf("Expected empty stdout, but got %q", string(stdout))
+		}
+		if string(stderr) != "hello" {
+			t.Errorf("Expected stderr %q, but got %q", "hello", string(stderr))
 		}
 	})
 }

--- a/repo-agent/pkg/llm/gemini.go
+++ b/repo-agent/pkg/llm/gemini.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"k8s.io/klog/v2"
 )
@@ -36,6 +37,10 @@ type Gemini struct {
 
 func (g *Gemini) AddPostProcessor(p PostProcessor) {
 	g.processors = append(g.processors, p)
+}
+
+func (g *Gemini) QuotaCheck() bool {
+	return true
 }
 
 func (g *Gemini) Setup(workspacesDir, tokensDir string) error {
@@ -147,12 +152,16 @@ func (g *Gemini) ExpandPrompt(prompt string) (string, error) {
 func (g *Gemini) Run(agentPrompt string) ([]byte, error) {
 	klog.Info("running gemini")
 
-	output, err := g.Executor.Run("gemini", "-y", "-p", agentPrompt)
+	stdout, stderr, err := g.Executor.Run("gemini", "-y", "-p", agentPrompt)
 	if err != nil {
-		klog.Infof("gemini command failed: %v. Output: %s", err, string(output))
+		klog.Infof("gemini command failed: %v. Stderr: %s", err, string(stderr))
+		if strings.Contains(string(stderr), "[API Error: You have exhausted your daily quota on this model.]") {
+			return nil, &QuotaError{Err: err}
+		}
 		return nil, err
 	}
 
+	output := stdout
 	for _, p := range g.processors {
 		output, err = p(output)
 		if err != nil {

--- a/repo-agent/pkg/llm/gemini_test.go
+++ b/repo-agent/pkg/llm/gemini_test.go
@@ -103,13 +103,14 @@ type MockCommandExecutor struct {
 	Command string
 	Args    []string
 	Output  []byte
+	Stderr  []byte
 	Err     error
 }
 
-func (e *MockCommandExecutor) Run(command string, args ...string) ([]byte, error) {
+func (e *MockCommandExecutor) Run(command string, args ...string) ([]byte, []byte, error) {
 	e.Command = command
 	e.Args = args
-	return e.Output, e.Err
+	return e.Output, e.Stderr, e.Err
 }
 
 func TestGemini_Run(t *testing.T) {
@@ -121,16 +122,17 @@ func TestGemini_Run(t *testing.T) {
 		}
 
 		// Create a Gemini provider with the mock executor
-		g := &Gemini{Executor: mockExecutor}
+		tg := &Gemini{Executor: mockExecutor}
+		tg.AddPostProcessor(StripYAMLMarkers)
 
 		// Run the provider
-		output, err := g.Run("test prompt")
+		output, err := tg.Run("test prompt")
 		if err != nil {
 			t.Fatalf("Gemini.Run() failed: %v", err)
 		}
 
 		// Check the output
-		expectedOutput := []byte("```yaml\nfoo: bar\n```")
+		expectedOutput := []byte("foo: bar")
 		if !bytes.Equal(output, expectedOutput) {
 			t.Errorf("Expected output %q, but got %q", expectedOutput, output)
 		}
@@ -151,12 +153,16 @@ func TestGemini_Run(t *testing.T) {
 		if mockExecutor.Args[2] != "test prompt" {
 			t.Errorf("Expected third argument to be 'test prompt', but got '%s'", mockExecutor.Args[2])
 		}
+		if len(mockExecutor.Stderr) > 0 {
+			t.Errorf("Expected empty stderr, but got %q", string(mockExecutor.Stderr))
+		}
 	})
 
 	t.Run("error", func(t *testing.T) {
 		// Create a mock executor that returns an error
 		mockExecutor := &MockCommandExecutor{
 			Output: nil,
+			Stderr: nil,
 			Err:    errors.New("command failed"),
 		}
 
@@ -168,12 +174,38 @@ func TestGemini_Run(t *testing.T) {
 		if err == nil {
 			t.Fatal("Gemini.Run() should have failed, but it didn't")
 		}
+		if errors.Is(err, &QuotaError{}) {
+			t.Errorf("Expected generic error, but got QuotaError: %v", err)
+		}
+	})
+
+	t.Run("quota error", func(t *testing.T) {
+		// Create a mock executor that returns a quota error in stderr
+		mockExecutor := &MockCommandExecutor{
+			Output: []byte("some output"),
+			Stderr: []byte("[API Error: You have exhausted your daily quota on this model.]"),
+			Err:    errors.New("command failed due to quota"),
+		}
+
+		// Create a Gemini provider with the mock executor
+		g := &Gemini{Executor: mockExecutor}
+
+		// Run the provider
+		_, err := g.Run("test prompt")
+		if err == nil {
+			t.Fatal("Gemini.Run() should have failed with quota error, but it didn't")
+		}
+		var quotaErr *QuotaError
+		if !errors.As(err, &quotaErr) {
+			t.Errorf("Expected QuotaError, but got %T: %v", err, err)
+		}
 	})
 
 	t.Run("post-processor error", func(t *testing.T) {
 		// Create a mock executor
 		mockExecutor := &MockCommandExecutor{
 			Output: []byte("some output"),
+			Stderr: nil,
 			Err:    nil,
 		}
 

--- a/repo-agent/pkg/llm/provider.go
+++ b/repo-agent/pkg/llm/provider.go
@@ -36,6 +36,20 @@ type Provider interface {
 	// AddPostProcessor adds a post-processing function to the provider.
 	// These functions are applied sequentially to the LLM's raw output.
 	AddPostProcessor(p PostProcessor)
+	QuotaCheck() bool
+}
+
+// QuotaError is returned by Run() when the LLM API returns an "Out of Quota" error.
+type QuotaError struct {
+	Err error
+}
+
+func (e *QuotaError) Error() string {
+	return fmt.Sprintf("quota exceeded: %v", e.Err)
+}
+
+func (e *QuotaError) Unwrap() error {
+	return e.Err
 }
 
 func NewLLMProvider(name string) (Provider, error) {

--- a/repo-agent/pkg/sandbox/workflow.go
+++ b/repo-agent/pkg/sandbox/workflow.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -100,7 +101,14 @@ func RunAgent(ctx context.Context, cfg Config) error {
 
 	output, err := provider.Run(cfg.AgentPrompt)
 	if err != nil {
+		var quotaErr *llm.QuotaError
+		if errors.As(err, &quotaErr) {
+			_ = agentoutput.SetAgentState(ctx, cfg.GVR, "QUOTA ERROR", err.Error())
+			log.Info("Agent run failed due to quota", "err", err)
+			return err
+		}
 		log.Info("Agent run failed", "err", err, "output", string(output))
+		return err
 	}
 	if err := os.WriteFile("../agent-output.txt", output, 0644); err != nil {
 		return fmt.Errorf("failed to write agent-output.txt: %w", err)


### PR DESCRIPTION
This commit introduces a robust quota checking mechanism for LLM providers and extends the command execution interface to return standa error (stderr) output explicitly.

The changes address the following:
- Define `QuotaError` and add `QuotaCheck()` to the `Provider` interface for LLM quota management.
- Modify `CommandExecutor.Run` to return `stdout`, `stderr`, and `error` for better command output inspection.
- Update `Gemini.Run` to detect "Out of Quota" errors from stderr and return `*llm.QuotaError`.
- Implement a default `QuotaCheck()` returning `true` for all LLM providers (`Gemini`, `Claude`, `Dummy`).
- Adjust `review-sandbox` and `pkg/sandbox/workflow` to handle `*llm.QuotaError` by updating the agent state to "QUOTA ERROR".
- Update all relevant unit tests (`pkg/llm/exec_test.go`, `pkg/llm/gemini_test.go`) to reflect the changes in `CommandExecutor.Run` signature and to thoroughly test `QuotaError` handling and `stderr` content.


<img width="2692" height="792" alt="image" src="https://github.com/user-attachments/assets/99d5ad22-4967-4fc0-8cee-d2e9c2c57948" />

<img width="2780" height="494" alt="image" src="https://github.com/user-attachments/assets/574c0d49-355d-4543-b667-1b551ac9b821" />
