### PR TITLE
fix: use apply when updating agentdraft

### DIFF
--- a/repo-agent/pkg/agentoutput/client.go
+++ b/repo-agent/pkg/agentoutput/client.go
@@ -81,6 +81,42 @@ func SetAgentState(ctx context.Context, gvr schema.GroupVersionResource, state s
 	}
 
 	log.Info("applying resource with state", "namespace", namespace, "name", name, "state", state)
+	_, err = dc.Resource(gvr).Namespace(namespace).Apply(ctx, name, applyObj, metav1.ApplyOptions{FieldManager: "agent-draft-client", Force: true})
+	if err != nil {
+		log.Info("error applying resource", "namespace", namespace, "name", name, "err", err)
+		return err
+	}
+	return nil
+}
+
+// SetAgentDraft updates the agentDraft annotation.
+func SetAgentDraft(ctx context.Context, gvr schema.GroupVersionResource, draft string) error {
+	log := klog.FromContext(ctx)
+	dc, name, namespace, err := getClient()
+	if err != nil {
+		return err
+	}
+
+	obj, err := dc.Resource(gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	applyObj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": obj.GetAPIVersion(),
+			"kind":       obj.GetKind(),
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+				"annotations": map[string]string{
+					"agentDraft": draft,
+				},
+			},
+		},
+	}
+
+	log.Info("applying resource with draft", "namespace", namespace, "name", name)
 	_, err = dc.Resource(gvr).Namespace(namespace).Apply(ctx, name, applyObj, metav1.ApplyOptions{FieldManager: "agent-output-client", Force: true})
 	if err != nil {
 		log.Info("error applying resource", "namespace", namespace, "name", name, "err", err)
@@ -121,7 +157,7 @@ func SetAgentLabel(gvr schema.GroupVersionResource, labels []string) error {
 	}
 
 	klog.Infof("applying resource %s/%s labels\n", namespace, name)
-	_, err = dc.Resource(gvr).Namespace(namespace).Apply(context.TODO(), name, applyObj, metav1.ApplyOptions{FieldManager: "agent-output-client"})
+	_, err = dc.Resource(gvr).Namespace(namespace).Apply(context.TODO(), name, applyObj, metav1.ApplyOptions{FieldManager: "agent-label-client"})
 	if err != nil {
 		klog.Infof("error applying resource %s/%s: %v\n", namespace, name, err)
 		return err
@@ -189,7 +225,8 @@ func AddAgentLabel(gvr schema.GroupVersionResource, newLabels []string) error {
 			},
 		}
 
-		_, err = dc.Resource(gvr).Namespace(namespace).Apply(context.TODO(), name, applyObj, metav1.ApplyOptions{FieldManager: "agent-output-client"})
+		_, err = dc.Resource(gvr).Namespace(namespace).Apply(context.TODO(), name, applyObj, metav1.ApplyOptions{FieldManager: "agent-label-client"})
+		klog.Infof("added labels to resource %s/%s: %v\n", namespace, name, newLabels)
 		return err
 	}
 

--- a/repo-agent/pkg/agentoutput/watcher.go
+++ b/repo-agent/pkg/agentoutput/watcher.go
@@ -18,17 +18,11 @@ package agentoutput
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
-	dynamic "k8s.io/client-go/dynamic"
-	"k8s.io/client-go/rest"
-
-	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -53,16 +47,6 @@ func Run(componentName string, gvr schema.GroupVersionResource) {
 		os.Exit(1)
 	}
 
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		panic(err.Error())
-	}
-
-	dc, err := dynamic.NewForConfig(config)
-	if err != nil {
-		panic(err.Error())
-	}
-
 	var last string
 	for {
 		time.Sleep(sleepIntervalSeconds * time.Second)
@@ -80,31 +64,9 @@ func Run(componentName string, gvr schema.GroupVersionResource) {
 			continue
 		}
 		fmt.Println("file changed, updating crd")
-		obj, err := dc.Resource(gvr).Namespace(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+
+		err = SetAgentDraft(context.TODO(), gvr, string(b))
 		if err != nil {
-			fmt.Printf("getting %s resource: %v\n", componentName, err)
-			continue
-		}
-
-		// update the annotation[agentDraft]
-		if obj.GetAnnotations() == nil {
-			obj.SetAnnotations(make(map[string]string))
-		}
-		annotations := obj.GetAnnotations()
-		annotations[AgentDraftAnnotation] = string(b)
-
-		// Try to parse as AgentOutput to extract labels
-		var out AgentOutput
-		if err := yaml.Unmarshal(b, &out); err == nil && len(out.Labels) > 0 {
-			labelsJSON, _ := json.Marshal(out.Labels)
-			annotations["agentLabels"] = string(labelsJSON)
-		} else {
-			delete(annotations, "agentLabels")
-		}
-
-		obj.SetAnnotations(annotations)
-
-		if _, err := dc.Resource(gvr).Namespace(namespace).Update(context.TODO(), obj, metav1.UpdateOptions{}); err != nil {
 			fmt.Printf("updating %s resource: %v\n", componentName, err)
 			continue
 		}

--- a/repo-agent/pkg/llm/dummy.go
+++ b/repo-agent/pkg/llm/dummy.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"bytes"
 	"strings"
+	"time"
 
 	"k8s.io/klog/v2"
 )
@@ -63,6 +64,8 @@ func (d *Dummy) response(prompt string) []byte {
 func (d *Dummy) Run(prompt string) ([]byte, error) {
 	var err error
 	klog.Infof("Dummy provider running with prompt")
+	// sleep to simulate processing time
+	time.Sleep(5 * time.Second)
 	output := d.response(prompt)
 	for _, p := range d.processors {
 		output, err = p(output)


### PR DESCRIPTION
1. Implemented `SetAgentDraft`: added a new function SetAgentDraft to repo-agent/pkg/agentoutput/client.go that uses server-side apply to update the agentDraft annotation.
2. Updated `watcher.go`: modified repo-agent/pkg/agentoutput/watcher.go to use this new API instead of constructing its own client and performing a direct update