### PR TITLE
refactor: move system prompt expansion to sandbox

### DIFF
--- a/repo-agent/docs/adding-a-new-llm-provider.md
+++ b/repo-agent/docs/adding-a-new-llm-provider.md
@@ -111,11 +111,14 @@ Modify the `switch` statement to include a new case for your provider. This allo
 
 ```diff
  // ... existing code ...
- func NewLLMProvider(name string) (Provider, error) {
+ func NewLLMProvider(name string, outputStartIndicator string) (Provider, error) {
  	switch name {
  	case "gemini-cli":
  		g := &Gemini{Executor: &RealCommandExecutor{}}
  		g.AddPostProcessor(StripYAMLMarkers)
+ 		if outputStartIndicator != "" {
+			g.AddPostProcessor(StripThoughts(outputStartIndicator))
+		}
  		return g, nil
  	case "claude":
  		c := &Claude{}

--- a/repo-agent/pkg/commands/review.go
+++ b/repo-agent/pkg/commands/review.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/agentoutput"
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/clients"
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/llm"
+	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/prompts"
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/tokens"
 	"github.com/google/go-github/v39/github"
 	"github.com/spf13/cobra"
@@ -77,8 +78,10 @@ func runReviewLogic(ctx context.Context) error {
 
 	maxReviewFiles := getMaxReviewFiles()
 
+	rawAgentPrompt := os.Getenv("AGENT_PROMPT")
+
 	// save the incoming prompt
-	if err := os.WriteFile("../agent-prompt.txt", []byte(os.Getenv("AGENT_PROMPT")), 0644); err != nil {
+	if err := os.WriteFile("../agent-prompt.txt", []byte(rawAgentPrompt), 0644); err != nil {
 		log.Error(err, "Failed to write prompt to file")
 	}
 
@@ -116,10 +119,7 @@ func runReviewLogic(ctx context.Context) error {
 		return fmt.Errorf("GIT_DIFF_URL not set, skipping diff-based validation")
 	}
 
-	agentPrompt := os.Getenv("AGENT_PROMPT")
-	agentPrompt = fmt.Sprintf("%s \n\n Try generating at least %d review comments", agentPrompt, expectedComments)
-
-	provider, err := llm.NewLLMProvider(agentName)
+	provider, err := llm.NewLLMProvider(agentName, "note:")
 	if err != nil {
 		return err
 	}
@@ -133,6 +133,8 @@ func runReviewLogic(ctx context.Context) error {
 	if githubToken == "" {
 		return fmt.Errorf("GitHub token not found in environment variables (tried MANUAL_PAT, OAUTH_PAT, and GITHUB_TOKEN)")
 	}
+	client := clients.NewGitHubClient(ctx, githubToken)
+
 	repoURL := os.Getenv("GIT_HTML_URL")
 	parts := strings.Split(strings.TrimPrefix(repoURL, "https://github.com/"), "/")
 	if len(parts) < 4 {
@@ -145,7 +147,23 @@ func runReviewLogic(ctx context.Context) error {
 		return fmt.Errorf("failed to parse PR number from GIT_HTML_URL: %w", err)
 	}
 
-	existingComments, err := getExistingComments(githubToken, owner, repo, prNumber)
+	pr, _, err := client.PullRequests.Get(ctx, owner, repo, prNumber)
+	if err != nil {
+		return fmt.Errorf("failed to get pull request: %w", err)
+	}
+
+	model := prompts.ReviewPromptModel{
+		PullRequest: *pr,
+		Prompt:      rawAgentPrompt,
+	}
+	expandedPrompt, err := prompts.ExpandReviewPrompt(model)
+	if err != nil {
+		return fmt.Errorf("failed to expand review prompt: %w", err)
+	}
+
+	agentPrompt := fmt.Sprintf("%s \n\n Try generating at least %d review comments", expandedPrompt, expectedComments)
+
+	existingComments, err := getExistingComments(ctx, client, owner, repo, prNumber)
 	if err != nil {
 		return fmt.Errorf("failed to get existing comments: %w", err)
 	}
@@ -322,10 +340,7 @@ func uniqueStrings(input []string) []string {
 	return sets.NewString(input...).List()
 }
 
-func getExistingComments(token, owner, repo string, prNumber int) ([]*github.PullRequestComment, error) {
-	ctx := context.Background()
-	client := clients.NewGitHubClient(ctx, token)
-
+func getExistingComments(ctx context.Context, client *github.Client, owner, repo string, prNumber int) ([]*github.PullRequestComment, error) {
 	var allComments []*github.PullRequestComment
 	opts := &github.PullRequestListCommentsOptions{
 		ListOptions: github.ListOptions{PerPage: 100},

--- a/repo-agent/pkg/controllers/repowatch/repowatch_controller.go
+++ b/repo-agent/pkg/controllers/repowatch/repowatch_controller.go
@@ -874,20 +874,7 @@ func (r *Reconciler) reconcileIssueHandlerSandboxesInternal(ctx context.Context,
 	return r.Status().Update(ctx, repoWatch)
 }
 
-// generateReviewPrompt generates a prompt for a pull request review.
-// It uses the prompt specified in the RepoWatch CRD, and if it is not
-// specified, it uses a default prompt.
-func (r *Reconciler) generateReviewPrompt(repoWatch *reviewv1alpha1.RepoWatch, pr *github.PullRequest) (string, error) {
-	model := prompts.ReviewPromptModel{
-		PullRequest: *pr,
-		Prompt:      repoWatch.Spec.Review.LLM.Prompt,
-	}
-
-	return prompts.ExpandReviewPrompt(model)
-}
-
 // generateIssueHandlerPrompt generates a prompt for an issue handler.
-// It uses the prompt specified in the RepoWatch CRD.
 func (r *Reconciler) generateIssueHandlerPrompt(handler reviewv1alpha1.IssueHandlerSpec, issue *github.Issue) (string, error) {
 	return prompts.ExpandIssueHandlerPrompt(handler.LLM.Prompt, issue)
 }
@@ -899,10 +886,7 @@ func (r *Reconciler) createReviewSandboxForPR(ctx context.Context, repoWatch *re
 	log := log.FromContext(ctx)
 	sandboxName := fmt.Sprintf("%s-pr-%d", repoWatch.Name, *pr.Number)
 
-	prompt, err := r.generateReviewPrompt(repoWatch, pr)
-	if err != nil {
-		return err
-	}
+	prompt := repoWatch.Spec.Review.LLM.Prompt
 
 	log.Info("Generated sandbox for PR", "pr", *pr, "llm.provider", repoWatch.Spec.Review.LLM.Provider)
 	sandbox := &unstructured.Unstructured{

--- a/repo-agent/pkg/llm/gemini.go
+++ b/repo-agent/pkg/llm/gemini.go
@@ -15,6 +15,7 @@
 package llm
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -170,4 +171,25 @@ func (g *Gemini) Run(agentPrompt string) ([]byte, error) {
 	}
 
 	return output, nil
+}
+
+func StripThoughts(outputStartIndicator string) PostProcessor {
+	return func(input []byte) ([]byte, error) {
+		if outputStartIndicator == "" {
+			return input, nil
+		}
+		indicator := []byte(outputStartIndicator)
+		// Check for indicator at the beginning
+		if bytes.HasPrefix(input, indicator) {
+			return input, nil
+		}
+
+		// Check for "\n" + indicator (indicator at the beginning of a line)
+		search := append([]byte("\n"), indicator...)
+		if idx := bytes.Index(input, search); idx != -1 {
+			return input[idx+1:], nil
+		}
+
+		return input, nil
+	}
 }

--- a/repo-agent/pkg/llm/gemini_test.go
+++ b/repo-agent/pkg/llm/gemini_test.go
@@ -350,3 +350,55 @@ func TestEnsureSettings(t *testing.T) {
 		}
 	})
 }
+
+func TestStripThoughts(t *testing.T) {
+	processor := StripThoughts("note:")
+
+	t.Run("with note at beginning", func(t *testing.T) {
+		input := []byte("note: content")
+		expected := []byte("note: content")
+		result, err := processor(input)
+		if err != nil {
+			t.Fatalf("StripThoughts failed: %v", err)
+		}
+		if !bytes.Equal(result, expected) {
+			t.Errorf("Expected %q, got %q", expected, result)
+		}
+	})
+
+	t.Run("with note after thoughts", func(t *testing.T) {
+		input := []byte("thoughts\nmore thoughts\nnote: content")
+		expected := []byte("note: content")
+		result, err := processor(input)
+		if err != nil {
+			t.Fatalf("StripThoughts failed: %v", err)
+		}
+		if !bytes.Equal(result, expected) {
+			t.Errorf("Expected %q, got %q", expected, result)
+		}
+	})
+
+	t.Run("without note", func(t *testing.T) {
+		input := []byte("just content")
+		expected := []byte("just content")
+		result, err := processor(input)
+		if err != nil {
+			t.Fatalf("StripThoughts failed: %v", err)
+		}
+		if !bytes.Equal(result, expected) {
+			t.Errorf("Expected %q, got %q", expected, result)
+		}
+	})
+
+	t.Run("with note inside line (not start)", func(t *testing.T) {
+		input := []byte("This is a note: content")
+		expected := []byte("This is a note: content")
+		result, err := processor(input)
+		if err != nil {
+			t.Fatalf("StripThoughts failed: %v", err)
+		}
+		if !bytes.Equal(result, expected) {
+			t.Errorf("Expected %q, got %q", expected, result)
+		}
+	})
+}

--- a/repo-agent/pkg/llm/provider.go
+++ b/repo-agent/pkg/llm/provider.go
@@ -52,11 +52,14 @@ func (e *QuotaError) Unwrap() error {
 	return e.Err
 }
 
-func NewLLMProvider(name string) (Provider, error) {
+func NewLLMProvider(name string, outputStartIndicator string) (Provider, error) {
 	switch name {
 	case "gemini-cli":
 		g := &Gemini{Executor: &RealCommandExecutor{}}
 		g.AddPostProcessor(StripYAMLMarkers)
+		if outputStartIndicator != "" {
+			g.AddPostProcessor(StripThoughts(outputStartIndicator))
+		}
 		return g, nil
 	case "claude":
 		c := &Claude{}

--- a/repo-agent/pkg/llm/provider_test.go
+++ b/repo-agent/pkg/llm/provider_test.go
@@ -95,7 +95,7 @@ func TestNewProvider(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			provider, err := NewLLMProvider(tt.provider)
+			provider, err := NewLLMProvider(tt.provider, "")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewProvider() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/repo-agent/pkg/sandbox/workflow.go
+++ b/repo-agent/pkg/sandbox/workflow.go
@@ -77,7 +77,7 @@ func RunAgent(ctx context.Context, cfg Config) error {
 	log := klog.FromContext(ctx)
 	log.Info("Starting agent", "agentName", cfg.AgentName)
 
-	provider, err := llm.NewLLMProvider(cfg.AgentName)
+	provider, err := llm.NewLLMProvider(cfg.AgentName, "")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## refactor: move system prompt expansion to sandbox
This change reduces the responsibility of the controller and ensures the sandbox has full context (via the fetched PR object) for prompt expansion, enabling "double expansion" where user prompts can also reference PR details.
1. `repo-agent/pkg/controllers/repowatch/repowatch_controller.go`:
  * Removed generateReviewPrompt helper function.
  * Modified createReviewSandboxForPR to pass the raw user prompt (repoWatch.Spec.Review.LLM.Prompt) directly to the sandbox spec, instead of expanding it.
2. `repo-agent/pkg/commands/review.go`:
  * Added prompts package import.
  * Updated getExistingComments to accept ctx and *github.Client, allowing client reuse.
  * Refactored runReviewLogic to:
    * Read the raw AGENT_PROMPT (which now contains the user instructions).
    * Initialize the GitHub client early.
    * Fetch the full PullRequest object using the client.
    * Construct prompts.ReviewPromptModel with the PR and raw prompt.
    * Call prompts.ExpandReviewPrompt to perform the prompt expansion (injecting both user instructions and PR details).
    * Use the expanded prompt for the agent execution.

## feat: add StripThoughts processor for LLM
1. Refactored `NewLLMProvider`:
  * Modified the signature to take startIndicator string
  * Updated the implementation to conditionally add the StripThoughts post-processor for the gemini-cli provider using the provided startIndicator.
2. Add `StripThoughts` processor:
  * Updated the corresponding test in repo-agent/pkg/llm/gemini_test.go.
3. Updated Callers:
  * Updated pkg/commands/review.go to pass "note:" as the start indicator (preserving existing behavior).
  * Updated pkg/sandbox/workflow.go to pass "note:" as the start indicator.
  * Updated pkg/llm/provider_test.go to pass "" or appropriate values for testing.
4. Documentation:
  * Updated repo-agent/docs/adding-a-new-llm-provider.md to reflect the new NewLLMProvider signature and usage example.