### PR TITLE
feat: Add optional Image field to IssueHandlerSpec

### DIFF
--- a/repo-agent/api/repowatch/v1alpha1/repowatch_types.go
+++ b/repo-agent/api/repowatch/v1alpha1/repowatch_types.go
@@ -159,6 +159,10 @@ type IssueHandlerSpec struct {
 	// DevcontainerConfigRef string
 	DevcontainerConfigRef string `json:"devcontainerConfigRef,omitempty"`
 
+	// Image to use for the development sandbox. If set, this overrides the devcontainer image.
+	// +kubebuilder:validation:Optional
+	Image string `json:"image,omitempty"`
+
 	// The maximum number of sandboxes to have active (replicas > 0) at any given time.
 	// +kubebuilder:validation:Required
 	MaxActiveSandboxes int `json:"maxActiveSandboxes"`

--- a/repo-agent/k8s/crds/review.gemini.google.com_repowatches.yaml
+++ b/repo-agent/k8s/crds/review.gemini.google.com_repowatches.yaml
@@ -77,6 +77,8 @@ spec:
                       items:
                         type: integer
                       type: array
+                    image:
+                      type: string
                     issueShutdownAfterMinutes:
                       type: integer
                     issues:

--- a/repo-agent/pkg/controllers/repowatch/repowatch_controller.go
+++ b/repo-agent/pkg/controllers/repowatch/repowatch_controller.go
@@ -1035,6 +1035,12 @@ func (r *Reconciler) createSandboxForIssueHandler(ctx context.Context, user *git
 		}
 	}
 
+	if handler.Image != "" {
+		if err := unstructured.SetNestedField(sandbox.Object, handler.Image, "spec", "image"); err != nil {
+			return err
+		}
+	}
+
 	if err := controllerutil.SetControllerReference(repoWatch, sandbox, r.Scheme); err != nil {
 		return err
 	}

--- a/repo-agent/pkg/controllers/repowatch/repowatch_controller_issue_image_test.go
+++ b/repo-agent/pkg/controllers/repowatch/repowatch_controller_issue_image_test.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package repowatch
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	reviewv1alpha1 "github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/api/repowatch/v1alpha1"
+	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/clients"
+	"github.com/google/go-github/v39/github"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestReconciler_Reconcile_Issue_With_Image(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	s := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(s)
+	_ = reviewv1alpha1.AddToScheme(s)
+
+	fakeClient := clientfake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&reviewv1alpha1.RepoWatch{}).Build()
+
+	mockHTTPClient := &http.Client{
+		Transport: &mockRoundTripper{
+			responses: map[string]func() *http.Response{
+				"https://api.github.com/repos/test/repo/pulls?direction=desc&per_page=100&sort=created&state=open": func() *http.Response {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`[]`)),
+					}
+				},
+				"https://api.github.com/repos/test/repo/issues?labels=bug&state=open": func() *http.Response {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(`[
+												{
+													"number": 10,
+													"title": "Test Issue",
+													"html_url": "https://github.com/test/repo/issues/10",
+													"repository_url": "https://api.github.com/repos/test/repo"
+												}
+											]`)),
+					}
+				},
+				"https://api.github.com/user": func() *http.Response {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`{"login": "test-user", "name": "Test User", "email": "test@example.com"}`)),
+					}
+				},
+			}},
+	}
+	ghClient := clients.NewGitHubClientFromHTTP(mockHTTPClient)
+
+	r := &Reconciler{
+		Client: fakeClient,
+		Scheme: s,
+		NewGithubClient: func(_ context.Context, _ client.Client, _ *reviewv1alpha1.RepoWatch) (*github.Client, map[string]string, error) {
+			return ghClient, map[string]string{"pat": "test-pat"}, nil
+		},
+	}
+
+	objName := "test-repowatch-issues"
+	objNamespace := "default"
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      objName,
+			Namespace: objNamespace,
+		},
+	}
+
+	repoWatch := &reviewv1alpha1.RepoWatch{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      objName,
+			Namespace: objNamespace,
+		},
+		Spec: reviewv1alpha1.RepoWatchSpec{
+			RepoURL:          "https://github.com/test/repo",
+			GithubSecretName: "github-secret",
+			IssueHandlers: []reviewv1alpha1.IssueHandlerSpec{
+				{
+					Name:               "test-handler",
+					MaxActiveSandboxes: 1,
+					Labels:             []string{"bug"},
+					LLM: reviewv1alpha1.LLMConfig{
+						Provider:        "gemini-cli",
+						APIKeySecretRef: "llm-secret",
+						Prompt:          "Triage this",
+					},
+					Image: "custom-image:latest",
+				},
+			},
+		},
+	}
+	g.Expect(fakeClient.Create(context.Background(), repoWatch)).To(gomega.Succeed())
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "github-secret",
+			Namespace: objNamespace,
+		},
+		Data: map[string][]byte{
+			"pat": []byte("test-pat"),
+		},
+	}
+	g.Expect(fakeClient.Create(context.Background(), secret)).To(gomega.Succeed())
+
+	llmSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "llm-secret",
+			Namespace: objNamespace,
+		},
+		Data: map[string][]byte{
+			"apiKey": []byte("test-api-key"),
+		},
+	}
+	g.Expect(fakeClient.Create(context.Background(), llmSecret)).To(gomega.Succeed())
+
+	_, err := r.Reconcile(context.Background(), req)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	issueSandboxList := &unstructured.UnstructuredList{}
+	issueSandboxList.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "custom.agents.x-k8s.io",
+		Version: "v1alpha1",
+		Kind:    "IssueSandbox",
+	})
+	g.Expect(fakeClient.List(context.Background(), issueSandboxList)).To(gomega.Succeed())
+	g.Expect(issueSandboxList.Items).To(gomega.HaveLen(1))
+
+	image, found, err := unstructured.NestedString(issueSandboxList.Items[0].Object, "spec", "image")
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(found).To(gomega.BeTrue())
+	g.Expect(image).To(gomega.Equal("custom-image:latest"))
+}


### PR DESCRIPTION
This change enables users to specify a custom container image for issue sandboxes via the `IssueHandlerSpec`. This aligns the configuration with `DevSpec` and provides greater flexibility for the environments used to reproduce and fix issues.

Changes:
- Added `Image` field to `IssueHandlerSpec` in `repowatch_types.go`.
- Updated `createSandboxForIssueHandler` in `repowatch_controller.go` to propagate the image setting to the created `IssueSandbox` resource.
- Regenerated deepcopy methods and CRDs.
- Added unit test `TestReconciler_Reconcile_Issue_With_Image` to verify the functionality.