### PR TITLE
feat: Add Image field to Reviews

### DIFF
--- a/repo-agent/api/repowatch/v1alpha1/repowatch_types.go
+++ b/repo-agent/api/repowatch/v1alpha1/repowatch_types.go
@@ -63,6 +63,10 @@ type PRReviewSpec struct {
 	// DevcontainerConfigRef string
 	DevcontainerConfigRef string `json:"devcontainerConfigRef,omitempty"`
 
+	// Image to use for the development sandbox. If set, this overrides the devcontainer image.
+	// +kubebuilder:validation:Optional
+	Image string `json:"image,omitempty"`
+
 	// The maximum number of sandboxes to have active (replicas > 0) at any given time.
 	// +kubebuilder:validation:Required
 	MaxActiveSandboxes int `json:"maxActiveSandboxes"`

--- a/repo-agent/cmd/review-sandbox/main.go
+++ b/repo-agent/cmd/review-sandbox/main.go
@@ -41,6 +41,7 @@ func run(ctx context.Context) error {
 	rootCommand.AddCommand(commands.BuildReviewDaemonCommand())
 	rootCommand.AddCommand(commands.BuildSSHDCommand())
 	rootCommand.AddCommand(commands.BuildCodeServerCommand())
+	rootCommand.AddCommand(commands.BuildInjectCommand())
 
 	return rootCommand.ExecuteContext(ctx)
 }

--- a/repo-agent/cmd/review-sandbox/review-sandbox-rgd.yaml
+++ b/repo-agent/cmd/review-sandbox/review-sandbox-rgd.yaml
@@ -19,6 +19,7 @@ spec:
         apiKeySecretName: string
       serviceAccountName: string | default="review-sandbox"
       devcontainerConfigRef: string | default="devcontainer-json"
+      image: string | default=""
       githubSecretName: string | default="github-pat"
       resources:
         ephemeralStorage: string | default="6Gi"
@@ -72,9 +73,16 @@ spec:
                   volumeMounts:
                     - name: workspaces-pvc
                       mountPath: /workspaces
+                - name: inject-agent
+                  image: ko://repo-agent/images/review-sandbox
+                  command: ["/repo-agent/review-sandbox", "inject", "--path", "/opt/repo-agent"]
+                  volumeMounts:
+                    - name: agent-bin
+                      mountPath: /opt/repo-agent
               containers:
                 - name: sandbox
-                  image: ko://repo-agent/review-sidecar/images/review-sandbox
+                  image: ${schema.spec.image != "" ? schema.spec.image:"ko://repo-agent/images/review-sandbox"}
+                  command: ${schema.spec.image != "" ? ["/opt/repo-agent/review-sandbox", "daemon"]:[]}
                   resources:
                     limits:
                       ephemeral-storage: ${schema.spec.resources.ephemeralStorage}
@@ -133,7 +141,7 @@ spec:
                     - name: ENVBUILDER_GIT_CLONE_SINGLE_BRANCH
                       value: "true"
                     - name: ENVBUILDER_INIT_SCRIPT
-                      value: /repo-agent/review-sandbox
+                      value: /opt/repo-agent/review-sandbox daemon
                     - name: ENVBUILDER_IGNORE_PATHS
                       value: "/var/run,/product_uuid,/product_name,/tokens,/repo-agent/"
                   volumeMounts:
@@ -145,9 +153,13 @@ spec:
                     - name: devcontainer-config
                       mountPath: /devcontainer.json
                       subPath: devcontainer.json
+                    - name: agent-bin
+                      mountPath: /opt/repo-agent
                   ports:
                     - containerPort: 13337
               volumes:
+              - name: agent-bin
+                emptyDir: {}
               # configmap volume for devcontainer.json mounting
               - name: devcontainer-config
                 configMap:

--- a/repo-agent/k8s/crds/review.gemini.google.com_repowatches.yaml
+++ b/repo-agent/k8s/crds/review.gemini.google.com_repowatches.yaml
@@ -138,6 +138,8 @@ spec:
                     items:
                       type: integer
                     type: array
+                  image:
+                    type: string
                   labels:
                     items:
                       items:

--- a/repo-agent/k8s/review-sandbox-rgd.yaml
+++ b/repo-agent/k8s/review-sandbox-rgd.yaml
@@ -19,6 +19,7 @@ spec:
         apiKeySecretName: string
       serviceAccountName: string | default="review-sandbox"
       devcontainerConfigRef: string | default="devcontainer-json"
+      image: string | default=""
       githubSecretName: string | default="github-pat"
       resources:
         ephemeralStorage: string | default="6Gi"
@@ -72,9 +73,16 @@ spec:
                   volumeMounts:
                     - name: workspaces-pvc
                       mountPath: /workspaces
+                - name: inject-agent
+                  image: ko://repo-agent/images/review-sandbox
+                  command: ["/repo-agent/review-sandbox", "inject", "--path", "/opt/repo-agent"]
+                  volumeMounts:
+                    - name: agent-bin
+                      mountPath: /opt/repo-agent
               containers:
                 - name: sandbox
-                  image: ko://repo-agent/review-sidecar/images/review-sandbox
+                  image: ${schema.spec.image != "" ? schema.spec.image:"ko://repo-agent/images/review-sandbox"}
+                  command: ${schema.spec.image != "" ? ["/opt/repo-agent/review-sandbox", "daemon"]:[]}
                   resources:
                     limits:
                       ephemeral-storage: ${schema.spec.resources.ephemeralStorage}
@@ -133,7 +141,7 @@ spec:
                     - name: ENVBUILDER_GIT_CLONE_SINGLE_BRANCH
                       value: "true"
                     - name: ENVBUILDER_INIT_SCRIPT
-                      value: /repo-agent/review-sandbox
+                      value: /opt/repo-agent/review-sandbox daemon
                     - name: ENVBUILDER_IGNORE_PATHS
                       value: "/var/run,/product_uuid,/product_name,/tokens,/repo-agent/"
                   volumeMounts:
@@ -145,9 +153,13 @@ spec:
                     - name: devcontainer-config
                       mountPath: /devcontainer.json
                       subPath: devcontainer.json
+                    - name: agent-bin
+                      mountPath: /opt/repo-agent
                   ports:
                     - containerPort: 13337
               volumes:
+              - name: agent-bin
+                emptyDir: {}
               # configmap volume for devcontainer.json mounting
               - name: devcontainer-config
                 configMap:

--- a/repo-agent/pkg/controllers/repowatch/repowatch_controller.go
+++ b/repo-agent/pkg/controllers/repowatch/repowatch_controller.go
@@ -935,6 +935,12 @@ func (r *Reconciler) createReviewSandboxForPR(ctx context.Context, repoWatch *re
 		}
 	}
 
+	if repoWatch.Spec.Review.Image != "" {
+		if err := unstructured.SetNestedField(sandbox.Object, repoWatch.Spec.Review.Image, "spec", "image"); err != nil {
+			return err
+		}
+	}
+
 	if err := controllerutil.SetControllerReference(repoWatch, sandbox, r.Scheme); err != nil {
 		return err
 	}

--- a/repo-agent/pkg/controllers/repowatch/repowatch_controller_pr_image_test.go
+++ b/repo-agent/pkg/controllers/repowatch/repowatch_controller_pr_image_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package repowatch
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	reviewv1alpha1 "github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/api/repowatch/v1alpha1"
+	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/clients"
+	"github.com/google/go-github/v39/github"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestReconciler_Reconcile_PR_With_Image(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	s := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(s)
+	_ = reviewv1alpha1.AddToScheme(s)
+
+	fakeClient := clientfake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&reviewv1alpha1.RepoWatch{}).Build()
+
+	mockHTTPClient := &http.Client{
+		Transport: &mockRoundTripper{
+			responses: map[string]func() *http.Response{
+				"https://api.github.com/repos/test/repo/pulls?direction=desc&per_page=100&sort=created&state=open": func() *http.Response {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(`[
+												{
+													"number": 1,
+													"head": {"repo": {"clone_url": "https://github.com/test/repo", "html_url": "https://github.com/test/repo"}, "ref": "main"},
+													"html_url": "https://github.com/test/repo/pull/1",
+													"title": "Test PR",
+													"diff_url": "https://github.com/test/repo/pull/1.diff"
+												}
+											]`)),
+					}
+				},
+				"https://api.github.com/user": func() *http.Response {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`{"login": "test-user", "name": "Test User", "email": "test@example.com"}`)),
+					}
+				},
+			}},
+	}
+	ghClient := clients.NewGitHubClientFromHTTP(mockHTTPClient)
+
+	r := &Reconciler{
+		Client: fakeClient,
+		Scheme: s,
+		NewGithubClient: func(_ context.Context, _ client.Client, _ *reviewv1alpha1.RepoWatch) (*github.Client, map[string]string, error) {
+			return ghClient, map[string]string{"pat": "test-pat"}, nil
+		},
+	}
+
+	objName := "test-repowatch-pr-image"
+	objNamespace := "default"
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      objName,
+			Namespace: objNamespace,
+		},
+	}
+
+	repoWatch := &reviewv1alpha1.RepoWatch{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      objName,
+			Namespace: objNamespace,
+		},
+		Spec: reviewv1alpha1.RepoWatchSpec{
+			RepoURL:          "https://github.com/test/repo",
+			GithubSecretName: "github-secret",
+			Review: reviewv1alpha1.PRReviewSpec{
+				MaxActiveSandboxes: 1,
+				LLM: reviewv1alpha1.LLMConfig{
+					Provider:        "gemini-cli",
+					APIKeySecretRef: "llm-secret",
+					Prompt:          "Review this",
+				},
+				Image: "custom-review-image:latest",
+			},
+		},
+	}
+	g.Expect(fakeClient.Create(context.Background(), repoWatch)).To(gomega.Succeed())
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "github-secret",
+			Namespace: objNamespace,
+		},
+		Data: map[string][]byte{
+			"pat": []byte("test-pat"),
+		},
+	}
+	g.Expect(fakeClient.Create(context.Background(), secret)).To(gomega.Succeed())
+
+	llmSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "llm-secret",
+			Namespace: objNamespace,
+		},
+		Data: map[string][]byte{
+			"apiKey": []byte("test-api-key"),
+		},
+	}
+	g.Expect(fakeClient.Create(context.Background(), llmSecret)).To(gomega.Succeed())
+
+	_, err := r.Reconcile(context.Background(), req)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	reviewSandboxList := &unstructured.UnstructuredList{}
+	reviewSandboxList.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "custom.agents.x-k8s.io",
+		Version: "v1alpha1",
+		Kind:    "ReviewSandbox",
+	})
+	g.Expect(fakeClient.List(context.Background(), reviewSandboxList)).To(gomega.Succeed())
+	g.Expect(reviewSandboxList.Items).To(gomega.HaveLen(1))
+
+	image, found, err := unstructured.NestedString(reviewSandboxList.Items[0].Object, "spec", "image")
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(found).To(gomega.BeTrue())
+	g.Expect(image).To(gomega.Equal("custom-review-image:latest"))
+}


### PR DESCRIPTION
This change enables users to specify a custom container image for PR review sandboxes via the `PRReviewSpec`. This allows for greater customization of the review environment.

Changes:
- Added `Image` field to `PRReviewSpec` in `repowatch_types.go`.
- Updated `createReviewSandboxForPR` in `repowatch_controller.go` to propagate the image setting to the created `ReviewSandbox` resource.
- Updated `review-sandbox-rgd.yaml` to support the `image` parameter and added an init container (`inject-agent`) to install the review sandbox binary, mirroring the issue sandbox pattern.
- Added `install` command (aliased to `inject`) to `review-sandbox` CLI to support the init container workflow.
- Regenerated deepcopy methods and CRDs.
- Added unit test `TestReconciler_Reconcile_PR_With_Image` to verify the functionality.