### PR TITLE
feat(ui): prioritize active PRs by status in review dashboard

### DIFF
--- a/repo-agent/review-ui/ui/src/App.js
+++ b/repo-agent/review-ui/ui/src/App.js
@@ -873,7 +873,28 @@ function App() {
         if (prs.length > 0) {
             prs.forEach(pr => activeList.push({ ...pr, type: 'active', sortId: parseInt(pr.id) }));
         }
-        activeList.sort((a, b) => b.sortId - a.sortId);
+
+        const getPriority = (pr) => {
+            const isReviewDraftCreated = pr.reviewState === 'submitted' || !!pr.review;
+            if (isReviewDraftCreated) return 5;
+
+            if (!pr.agentState) return 6;
+
+            const state = pr.agentState.toLowerCase();
+            if (state === 'review ready') return 1;
+            if (state.includes('error')) return 2;
+            if (state === 'quota exceeded') return 3;
+            if (state === 'too many files') return 4;
+
+            return 6;
+        };
+
+        activeList.sort((a, b) => {
+            const pA = getPriority(a);
+            const pB = getPriority(b);
+            if (pA !== pB) return pA - pB;
+            return b.sortId - a.sortId;
+        });
         
         // 2. Pending PRs
         const pending = activeRepo.pendingPRs || [];


### PR DESCRIPTION
Updates the sorting logic for active Pull Requests in the review UI to group them by priority:
1. Review Ready
2. Error states
3. Quota Exceeded
4. Too many files
5. Review Draft Created (Submitted/Draft exists)
6. Others (e.g., Generating)

Within each priority group, PRs remain sorted by ID descending. This ensures actionable items appear at the top of the list.


<img width="2782" height="1544" alt="image" src="https://github.com/user-attachments/assets/f2264865-4714-41b3-929c-d0d74e919cd7" />
