### PR TITLE
temp-fix: allow skipping specific images in build process

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -21,7 +21,8 @@ jobs:
           - review-sandbox
           - review-ui
           - syncer
-          - generic-golang
+          # TODO(barney-s): re-enable when npm install gemini-cli works
+          #- generic-golang
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,8 @@ jobs:
           - dev-sandbox
           - review-ui
           - syncer
-          - generic-golang
+          # TODO(barney-s): re-enable when npm install gemini-cli works
+          #- generic-golang
     permissions:
       contents: write
       packages: write

--- a/dev/ci/presubmits/test-e2e-repo-agent
+++ b/dev/ci/presubmits/test-e2e-repo-agent
@@ -57,7 +57,8 @@ def main():
     if result.returncode != 0:
         return result.returncode
 
-    result = subprocess.run([f"{repo_root}/dev/tools/push-images", "--kind-cluster-name", "e2e-test", "--image-prefix", "kind.local/" , "--working-dir", working_dir])
+    ## TODO(barney-s) : remove --skip generic-golang when npm install gemini-cli works
+    result = subprocess.run([f"{repo_root}/dev/tools/push-images", "--kind-cluster-name", "e2e-test", "--image-prefix", "kind.local/" , "--working-dir", working_dir, "--skip", "generic-golang"])
     if result.returncode != 0:
         return result.returncode
     result = subprocess.run([f"{repo_root}/dev/tools/deploy-to-kube", "--image-prefix", "kind.local/", "--working-dir", working_dir])

--- a/dev/tools/push-images
+++ b/dev/tools/push-images
@@ -99,6 +99,10 @@ def main(args):
             dockerfile_path = os.path.join(root, filename)
             service_name = os.path.basename(root)
 
+            if args.skipped_images and service_name in args.skipped_images:
+                print(f"skipping image {service_name}")
+                continue
+
             image_name = utils.get_full_image_name(args, service_name)
 
             print(f"create Docker buildx builder for {service_name}")
@@ -125,6 +129,12 @@ if __name__ == "__main__":
                         help="use working dir instead of repo root",
                         type=str,
                         default=None)
+    parser.add_argument("--skip",
+                        dest="skipped_images",
+                        action="append",
+                        help="Image name (folder name) to skip. Can be repeated.",
+                        type=str,
+                        default=[])
     args = parser.parse_args()
 
     if args.working_dir:

--- a/repo-agent/Makefile
+++ b/repo-agent/Makefile
@@ -114,9 +114,10 @@ create-kind:
 	../dev/tools/limit-docker-log-size --check || sudo ../dev/tools/limit-docker-log-size
 	../dev/tools/create-kind-cluster --recreate ${KIND_CLUSTER} --kubeconfig bin/KUBECONFIG
 
+# TODO(barney-s): remove --skip generic-golang when npm install gemini-cli works
 .PHONY: build-and-push-repo-agent
 build-and-push-repo-agent:
-	../dev/tools/push-images --image-prefix=$(REGISTRY) $(KIND_CLUSTER_ARG) --working-dir .
+	../dev/tools/push-images --image-prefix=$(REGISTRY) $(KIND_CLUSTER_ARG) --working-dir . --skip generic-golang
 
 .PHONY: install-repo-agent
 install-repo-agent:


### PR DESCRIPTION
Builds in github are failing because dockerfile is failing to install gemini-cli. Could be a temp issue. Lets disable this for now.

- Update `dev/tools/push-images` to support a `--skip` flag for excluding specific images.
- Temporarily disable `generic-golang` image build in `repo-agent/Makefile` and CI workflows (`publish-images.yaml`, `release.yaml`) due to `npm install gemini-cli` issues.