### PR TITLE
feat: Add Feedback button that creates an issue in github

### DIFF
--- a/repo-agent/pkg/api/handlers_feedback.go
+++ b/repo-agent/pkg/api/handlers_feedback.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/clients"
+	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/k8s"
+	"github.com/google/go-github/v39/github"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+func (s *Server) submitFeedback(c *gin.Context) {
+	log := klog.FromContext(c.Request.Context())
+	namespace := s.Auth.GetUserFromContext(c)
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	var payload struct {
+		Text  string `json:"text"`
+		Image string `json:"image"` // base64
+	}
+	if err := c.ShouldBindJSON(&payload); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if payload.Text == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Text is required"})
+		return
+	}
+
+	// Get Token
+
+	token, err := s.getUserGitHubToken(c.Request.Context(), namespace)
+	if err != nil {
+		log.Info("Failed to get GitHub token", "user", namespace, "err", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get GitHub token. Please login or set a PAT in settings."})
+		return
+	}
+
+	client := clients.NewGitHubClient(c.Request.Context(), token)
+
+	// Create Issue
+	owner := "gke-labs"
+	repo := "gemini-for-kubernetes-development"
+	title := fmt.Sprintf("Feedback from %s", namespace)
+	body := fmt.Sprintf("User: %s\n\n%s", namespace, payload.Text)
+
+	if payload.Image != "" {
+		body += "\n\n[Screenshot attached in request but ignored due to missing image host configuration]"
+	}
+
+	req := &github.IssueRequest{
+		Title: &title,
+		Body:  &body,
+	}
+
+	issue, _, err := client.Issues.Create(c.Request.Context(), owner, repo, req)
+	if err != nil {
+		log.Info("Failed to create issue", "err", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create issue on GitHub"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"issue_url": issue.GetHTMLURL()})
+}
+
+func (s *Server) getUserGitHubToken(ctx context.Context, namespace string) (string, error) {
+	secretName := k8s.GithubSecretName
+	secret, err := s.K8sManager.Clientset.CoreV1().Secrets(namespace).Get(ctx, secretName, v1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	var token string
+	if val, ok := secret.Data[k8s.ManualPATKey]; ok && len(val) > 0 {
+		token = string(val)
+	} else if val, ok := secret.Data[k8s.OAuthPATKey]; ok && len(val) > 0 {
+		token = string(val)
+	} else if val, ok := secret.Data["pat"]; ok && len(val) > 0 {
+		token = string(val)
+	} else {
+		return "", fmt.Errorf("no token found")
+	}
+
+	return token, nil
+}

--- a/repo-agent/pkg/api/server.go
+++ b/repo-agent/pkg/api/server.go
@@ -84,6 +84,7 @@ func (s *Server) RegisterRoutes(router *gin.Engine) {
 		api.DELETE("/repo/:repo/dev/:name", s.deleteDevSandbox)
 		api.POST("/repo/:repo/dev/:name/scaleup", s.scaleUpDevSandbox)
 		api.POST("/repo/:repo/dev/:name/scaledown", s.scaleDownDevSandbox)
+		api.POST("/feedback", s.submitFeedback)
 		api.GET("/proxy", s.proxy)
 	}
 

--- a/repo-agent/review-ui/ui/src/App.js
+++ b/repo-agent/review-ui/ui/src/App.js
@@ -42,6 +42,10 @@ function App() {
   const [devModalOpen, setDevModalOpen] = useState(false);
   const [newDevBranch, setNewDevBranch] = useState('');
   const [newDevPrompt, setNewDevPrompt] = useState('');
+  const [feedbackModalOpen, setFeedbackModalOpen] = useState(false);
+  const [feedbackText, setFeedbackText] = useState('');
+  const [feedbackImage, setFeedbackImage] = useState('');
+  const [isSubmittingFeedback, setIsSubmittingFeedback] = useState(false);
 
 
   useEffect(() => {
@@ -864,6 +868,73 @@ function App() {
     }
   };
 
+  const handleFeedbackClick = async () => {
+    try {
+      const stream = await navigator.mediaDevices.getDisplayMedia({
+        video: { cursor: "always" },
+        audio: false
+      });
+      const video = document.createElement("video");
+      video.srcObject = stream;
+      video.onloadedmetadata = () => {
+        video.play();
+        const canvas = document.createElement("canvas");
+        canvas.width = video.videoWidth;
+        canvas.height = video.videoHeight;
+        const ctx = canvas.getContext("2d");
+        ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+        const image = canvas.toDataURL("image/png");
+        setFeedbackImage(image);
+        setFeedbackModalOpen(true);
+        stream.getTracks().forEach(track => track.stop());
+
+        // Automatically open image in new tab
+        const w = window.open("");
+        if (w) {
+            w.document.write('<img src="' + image + '" style="max-width: 100%;" />');
+            // Attempt to keep focus on current window (background the new tab)
+            try {
+                w.blur();
+                window.focus();
+            } catch (e) {
+                // ignore
+            }
+        }
+      };
+    } catch (err) {
+      console.error("Error capturing screen:", err);
+      // Fallback to text only if user cancels or error
+      setFeedbackImage('');
+      setFeedbackModalOpen(true);
+    }
+  };
+
+  const submitFeedback = () => {
+    setIsSubmittingFeedback(true);
+    fetch('/api/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: feedbackText, image: feedbackImage })
+    })
+    .then(res => {
+        if (res.ok) {
+            res.json().then(data => {
+                alert(`Feedback submitted successfully!`);
+                if (data.issue_url) {
+                    window.open(data.issue_url, '_blank');
+                }
+                setFeedbackModalOpen(false);
+                setFeedbackText('');
+                setFeedbackImage('');
+            });
+        } else {
+            res.json().then(data => alert("Failed to submit feedback: " + (data.error || res.statusText)));
+        }
+    })
+    .catch(err => alert("Failed to submit feedback: " + err))
+    .finally(() => setIsSubmittingFeedback(false));
+  };
+
   const renderContent = () => {
     if (!activeRepo) return <p>Please select or add a repository to watch.</p>;
     const namespace = user || 'default';
@@ -1198,6 +1269,7 @@ function App() {
         <div className="header-right">
           {user && <span className="user-greeting">Hi, {user}</span>}
           {isGuest && <span className="user-greeting">Guest</span>}
+          <button className="btn" onClick={handleFeedbackClick} style={{marginRight: '10px', backgroundColor: '#28a745'}}>Feedback</button>
           <button className="btn" onClick={() => setView('settings')} style={{marginRight: '10px'}}>Settings</button>
           <button className="btn btn-delete" onClick={handleLogout} style={{marginRight: '20px'}}>Logout</button>
           <div className="theme-switch-wrapper">
@@ -1216,6 +1288,48 @@ function App() {
       {view === 'settings' && <Settings onBack={() => setView('dashboard')} />}
       {view === 'add_repo' && <AddRepo onCancel={() => setView('dashboard')} onRepoAdded={() => { fetchRepos(); setView('dashboard'); }} />}
       {view === 'update_repo' && <UpdateRepo repo={activeRepo} onCancel={() => setView('dashboard')} onRepoUpdated={() => { fetchRepos(); setView('dashboard'); }} onRepoDeleted={handleRepoDeleted} />}
+
+      {feedbackModalOpen && (
+        <div className="modal-overlay" onClick={() => setFeedbackModalOpen(false)} style={{position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: 'rgba(0,0,0,0.5)', display: 'flex', justifyContent: 'center', alignItems: 'center', zIndex: 2000}}>
+            <div className="modal-content" onClick={(e) => e.stopPropagation()} style={{backgroundColor: '#fff', padding: '20px', borderRadius: '5px', width: '800px', maxHeight: '90vh', overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: '10px', color: 'black'}}>
+                <h4>Send Feedback</h4>
+                {feedbackImage && (
+                    <>
+                        <div style={{border: '1px solid #ccc', padding: '5px', maxHeight: '300px', overflow: 'hidden'}}>
+                            <img 
+                                src={feedbackImage} 
+                                alt="Screenshot" 
+                                style={{maxWidth: '100%', display: 'block', cursor: 'pointer'}} 
+                                title="Click to open in new tab"
+                                onClick={() => {
+                                    const w = window.open("");
+                                    if (w) {
+                                        w.document.write('<img src="' + feedbackImage + '" style="max-width: 100%;" />');
+                                    }
+                                }}
+                            />
+                        </div>
+                        <p style={{fontSize: '0.9em', color: '#555', marginTop: '5px', marginBottom: '5px'}}>
+                           <strong>Note:</strong> The screenshot has been opened in a new tab. You can also click the image above to open it again. Please copy and manually paste the screenshot into the GitHub issue that will be created after you click "Send Feedback".
+                        </p>
+                    </>
+                )}
+                <textarea 
+                    placeholder="Describe your issue or feedback..." 
+                    value={feedbackText} 
+                    onChange={(e) => setFeedbackText(e.target.value)} 
+                    rows="5" 
+                    style={{padding: '5px', border: '1px solid #ccc'}} 
+                />
+                <div style={{display: 'flex', justifyContent: 'flex-end', gap: '10px'}}>
+                    <button className="btn" onClick={() => setFeedbackModalOpen(false)} style={{backgroundColor: '#ccc', color: 'black'}}>Cancel</button>
+                    <button className="btn" onClick={submitFeedback} disabled={isSubmittingFeedback} style={{backgroundColor: '#007bff', color: 'white'}}>
+                        {isSubmittingFeedback ? 'Sending...' : 'Send Feedback'}
+                    </button>
+                </div>
+            </div>
+        </div>
+      )}
 
     </div>
   );


### PR DESCRIPTION
#324 was created using this

You can now use the "Feedback" button in the UI to report issues directly to the gemini-for-kubernetes-development repository.

1. Backend API (`pkg/api/handlers_feedback.go`):
  * Created a new handler submitFeedback that accepts JSON payload with text and image (base64).
  * Implemented logic to retrieve the authenticated user's GitHub token from their Kubernetes secret (github-pat), supporting both Manual and OAuth tokens.
  * The handler creates a new issue in gke-labs/gemini-for-kubernetes-development with the user's feedback.
  * Note: Since no external image hosting (like GCS) is currently configured or available in the environment variables, the image upload is skipped, and a note is appended to the issue body indicating that a screenshot was attached but not processed.

2. Server Registration (`pkg/api/server.go`):
  * Registered the new POST /api/feedback route in the RegisterRoutes method.

3. Frontend UI (`review-ui/ui/src/App.js`):
  * Added a "Feedback" button to the application header.
  * Implemented a handleFeedbackClick function that uses the browser's navigator.mediaDevices.getDisplayMedia API to capture a screenshot. This avoids adding new dependencies like html2canvas and allows the user to select exactly what to share (tab, window, or screen).
  * Created a Modal component to preview the screenshot, enter free-form text, and submit the feedback to the new API endpoint.

<img width="1658" height="314" alt="image" src="https://github.com/user-attachments/assets/171f1b45-f660-42f3-8ec7-0228470cae8d" />

<img width="1700" height="1278" alt="image" src="https://github.com/user-attachments/assets/38ea1bf8-bd8c-4927-8cc4-a16228cd92d6" />
