### PR TITLE
build: faster builds and tests

### DIFF
--- a/.github/workflows/presubmit-repo-agent.yaml
+++ b/.github/workflows/presubmit-repo-agent.yaml
@@ -34,6 +34,36 @@ jobs:
             dev/tools/go.sum
       - name: Run Lint
         run: ./dev/tools/lint-go --working-dir repo-agent/
+  docker-build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # commented images are built in e2e test job
+        image_name:
+          #- configdir-cli
+          #- configdir-controller
+          - github-mcp-server
+          #- redis
+          #- repowatch-controller
+          #- review-api
+          #- repo-sandbox
+          #- review-ui
+          #- syncer
+          - generic-golang
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: repo-agent/
+          file: repo-agent/images/${{ matrix.image_name }}/Dockerfile
+          push: false
   go-build:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/dev/ci/presubmits/test-e2e-repo-agent
+++ b/dev/ci/presubmits/test-e2e-repo-agent
@@ -57,7 +57,8 @@ def main():
     if result.returncode != 0:
         return result.returncode
 
-    result = subprocess.run([f"{repo_root}/dev/tools/push-images", "--kind-cluster-name", "e2e-test", "--image-prefix", "kind.local/" , "--working-dir", working_dir])
+    ## --skip generic-golang because we dont use local build of generic-golang image here
+    result = subprocess.run([f"{repo_root}/dev/tools/push-images", "--kind-cluster-name", "e2e-test", "--image-prefix", "kind.local/" , "--working-dir", working_dir, "--skip", "generic-golang", "--skip", "github-mcp-server"])
     if result.returncode != 0:
         return result.returncode
     result = subprocess.run([f"{repo_root}/dev/tools/deploy-to-kube", "--image-prefix", "kind.local/", "--working-dir", working_dir])

--- a/dev/tools/push-images
+++ b/dev/tools/push-images
@@ -99,6 +99,10 @@ def main(args):
             dockerfile_path = os.path.join(root, filename)
             service_name = os.path.basename(root)
 
+            if args.skipped_images and service_name in args.skipped_images:
+                print(f"skipping image {service_name}")
+                continue
+
             image_name = utils.get_full_image_name(args, service_name)
 
             print(f"create Docker buildx builder for {service_name}")
@@ -125,6 +129,12 @@ if __name__ == "__main__":
                         help="use working dir instead of repo root",
                         type=str,
                         default=None)
+    parser.add_argument("--skip",
+                        dest="skipped_images",
+                        action="append",
+                        help="Image name (folder name) to skip. Can be repeated.",
+                        type=str,
+                        default=[])
     args = parser.parse_args()
 
     if args.working_dir:

--- a/repo-agent/Makefile
+++ b/repo-agent/Makefile
@@ -114,9 +114,14 @@ create-kind:
 	../dev/tools/limit-docker-log-size --check || sudo ../dev/tools/limit-docker-log-size
 	../dev/tools/create-kind-cluster --recreate ${KIND_CLUSTER} --kubeconfig bin/KUBECONFIG
 
+# --skip generic-golang for faster builds
+# github presubmits builds and pushed this image separately
 .PHONY: build-and-push-repo-agent
 build-and-push-repo-agent:
-	../dev/tools/push-images --image-prefix=$(REGISTRY) $(KIND_CLUSTER_ARG) --working-dir .
+	../dev/tools/push-images --image-prefix=$(REGISTRY) $(KIND_CLUSTER_ARG) \
+	--working-dir . \
+	--skip generic-golang \
+	--skip github-mcp-server
 
 .PHONY: install-repo-agent
 install-repo-agent:

--- a/repo-agent/k8s/github-mcp-server.yaml
+++ b/repo-agent/k8s/github-mcp-server.yaml
@@ -4,7 +4,7 @@ metadata:
   name: github-mcp-server
   namespace: repo-agent-system
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: github-mcp-server

--- a/repo-agent/test/e2e/install-successful/repo-agent-components-assert.yaml
+++ b/repo-agent/test/e2e/install-successful/repo-agent-components-assert.yaml
@@ -15,14 +15,6 @@ status:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: github-mcp-server
-  namespace: repo-agent-system
-status:
-  readyReplicas: 1
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
   name: registry
   namespace: repo-agent-system
 status:


### PR DESCRIPTION
Images being skipped for kind tests:
* golang-generic: because we are pulling it from latest in ghcr.
* github-mcp-server: because we are not using it atm.

This would save us time:
- save 5m for e2e tests
- saves ~5m for local build loop

Adding a separate build target in presubmits for:
* golang-generic
* github-mcp-server