### PR TITLE
refactor: use config struct for LLM providers

### DIFF
--- a/repo-agent/cmd/claude-test/main.go
+++ b/repo-agent/cmd/claude-test/main.go
@@ -19,9 +19,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"k8s.io/klog/v2"
-
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/llm"
+	"k8s.io/klog/v2"
 )
 
 // This binary tests the Claude LLM provider implementation found in `pkg/llm/claude.go`.
@@ -30,10 +29,6 @@ import (
 // It takes an optional prompt as a command-line argument, sends it to the
 // Claude LLM provider, and prints the response.
 func main() {
-	// Initialize the Claude LLM client. The implementation for Claude LLM provider
-	// is located at `pkg/llm/claude.go`.
-	claude := &llm.Claude{}
-
 	// --- Secure API Key Handling for Testing Primary Setup Path ---
 	// The Setup function in `pkg/llm/claude.go` prioritizes reading the API key from a file.
 	// To test this primary path securely without hardcoding or exposing the API key,
@@ -59,9 +54,18 @@ func main() {
 		klog.Fatalf("failed to write api key file: %v", err)
 	}
 
+	// Initialize the Claude LLM client. The implementation for Claude LLM provider
+	// is located at `pkg/llm/claude.go`.
+	claude := &llm.Claude{
+		ProviderConfig: llm.ProviderConfig{
+			WorkspacesDir: "",
+			TokensDir:     tempDir, // Point to the temp dir containing the API key file
+		},
+	}
+
 	// Call the Setup function, passing the temporary directory as the tokens directory.
 	// This ensures the file-based API key retrieval path is tested.
-	if err := claude.Setup("", tempDir); err != nil {
+	if err := claude.Setup(); err != nil {
 		klog.Fatalf("failed to setup claude: %v", err)
 	}
 

--- a/repo-agent/pkg/commands/dev.go
+++ b/repo-agent/pkg/commands/dev.go
@@ -45,11 +45,16 @@ type SandboxCommand struct {
 	GithubUserName   string
 	IssueID          string
 	PromptFilePath   string
+	TokensDir        string
+	RepoDir          string
 }
 
 func (c *SandboxCommand) InitDefaults() {
 	if c.WorkspaceDir == "" {
 		c.WorkspaceDir = "/workspaces"
+	}
+	if c.TokensDir == "" {
+		c.TokensDir = "/tokens"
 	}
 	if c.RepoURL == "" {
 		c.RepoURL = os.Getenv("GIT_HTML_URL")
@@ -207,6 +212,10 @@ func (c *SandboxCommand) Run(ctx context.Context) error {
 		GithubUserName:   c.GithubUserName,
 		ReportStatus:     reportStatus,
 		GVR:              gvr,
+
+		WorkspacesDir: c.WorkspaceDir,
+		RepoDir:       repoDir,
+		TokensDir:     c.TokensDir,
 	}
 
 	// Prepare git branch (checkout)

--- a/repo-agent/pkg/commands/review.go
+++ b/repo-agent/pkg/commands/review.go
@@ -46,11 +46,15 @@ type ReviewCommand struct {
 	AgentPrompt      string
 	DiffURL          string
 	MaxReviewFiles   int
+	TokensDir        string
 }
 
 func (c *ReviewCommand) InitDefaults() {
 	if c.WorkspaceDir == "" {
 		c.WorkspaceDir = "/workspaces"
+	}
+	if c.TokensDir == "" {
+		c.TokensDir = "/tokens"
 	}
 	if c.RepoURL == "" {
 		c.RepoURL = os.Getenv("GIT_HTML_URL")
@@ -211,13 +215,19 @@ func (c *ReviewCommand) Run(ctx context.Context) error {
 		return fmt.Errorf("GIT_DIFF_URL not set, skipping diff-based validation")
 	}
 
-	provider, err := llm.NewLLMProvider(c.AgentName, "note:")
+	provider, err := llm.NewLLMProvider(llm.ProviderConfig{
+		Name:                 c.AgentName,
+		OutputStartIndicator: "note:",
+		WorkspacesDir:        c.WorkspaceDir,
+		TokensDir:            c.TokensDir,
+		RepoDir:              repoDir,
+	})
 	if err != nil {
 		updateState("error", err.Error())
 		return err
 	}
 
-	if err := provider.Setup("/workspaces", "/tokens"); err != nil {
+	if err := provider.Setup(); err != nil {
 		updateState("error", err.Error())
 		return err
 	}

--- a/repo-agent/pkg/llm/claude.go
+++ b/repo-agent/pkg/llm/claude.go
@@ -51,6 +51,7 @@ type Claude struct {
 	client         HTTPClient
 	postProcessors []PostProcessor
 	URL            string
+	ProviderConfig
 }
 
 func (c *Claude) AddPostProcessor(p PostProcessor) {
@@ -61,7 +62,8 @@ func (c *Claude) QuotaCheck() bool {
 	return true
 }
 
-func (c *Claude) Setup(_, tokensDir string) error {
+func (c *Claude) Setup() error {
+	tokensDir := c.TokensDir
 	// Read API key from the mounted secret file
 	apiKeyPath := filepath.Join(tokensDir, AnthropicAPIKeySecretKey)
 	apiKeyBytes, err := os.ReadFile(apiKeyPath)
@@ -79,7 +81,7 @@ func (c *Claude) Setup(_, tokensDir string) error {
 	return nil
 }
 
-func (c *Claude) Cleanup(_ string) error {
+func (c *Claude) Cleanup() error {
 	return nil
 }
 

--- a/repo-agent/pkg/llm/claude_test.go
+++ b/repo-agent/pkg/llm/claude_test.go
@@ -223,8 +223,8 @@ func TestClaudeSetup(t *testing.T) {
 			}
 
 			// Run the test
-			c := &Claude{}
-			err = c.Setup("", tokensDir)
+			c := &Claude{ProviderConfig: ProviderConfig{WorkspacesDir: "", TokensDir: tokensDir}}
+			err = c.Setup()
 
 			// Assertions
 			if tc.expectError {
@@ -336,7 +336,7 @@ func TestClaudeRunWithStripYAMLMarkers(t *testing.T) {
 
 func TestClaudeCleanup(t *testing.T) {
 	c := &Claude{}
-	if err := c.Cleanup(""); err != nil {
+	if err := c.Cleanup(); err != nil {
 		t.Errorf("Cleanup() error = %v, want nil", err)
 	}
 }

--- a/repo-agent/pkg/llm/dummy.go
+++ b/repo-agent/pkg/llm/dummy.go
@@ -34,14 +34,15 @@ var _ Provider = &Dummy{}
 
 type Dummy struct {
 	processors []PostProcessor
+	ProviderConfig
 }
 
-func (d *Dummy) Setup(_, _ string) error {
+func (d *Dummy) Setup() error {
 	klog.Info("Dummy provider setup")
 	return nil
 }
 
-func (d *Dummy) Cleanup(_ string) error {
+func (d *Dummy) Cleanup() error {
 	klog.Info("Dummy provider cleanup")
 	return nil
 }

--- a/repo-agent/pkg/llm/dummy_test.go
+++ b/repo-agent/pkg/llm/dummy_test.go
@@ -19,14 +19,14 @@ func TestDummy_Run(t *testing.T) {
 
 func TestDummy_Setup(t *testing.T) {
 	d := &Dummy{}
-	if err := d.Setup("", ""); err != nil {
+	if err := d.Setup(); err != nil {
 		t.Fatalf("Dummy.Setup failed: %v", err)
 	}
 }
 
 func TestDummy_Cleanup(t *testing.T) {
 	d := &Dummy{}
-	if err := d.Cleanup(""); err != nil {
+	if err := d.Cleanup(); err != nil {
 		t.Fatalf("Dummy.Cleanup failed: %v", err)
 	}
 }

--- a/repo-agent/pkg/llm/gemini.go
+++ b/repo-agent/pkg/llm/gemini.go
@@ -34,6 +34,7 @@ var _ Provider = &Gemini{}
 type Gemini struct {
 	Executor   CommandExecutor
 	processors []PostProcessor
+	ProviderConfig
 }
 
 func (g *Gemini) AddPostProcessor(p PostProcessor) {
@@ -44,20 +45,22 @@ func (g *Gemini) QuotaCheck() bool {
 	return true
 }
 
-func (g *Gemini) Setup(workspacesDir, tokensDir string) error {
-	// if .gemini directory exists in /workspaces copy it to home directory
-	geminiConfigDir := filepath.Join(workspacesDir, ".gemini")
-	if _, err := os.Stat(geminiConfigDir); err == nil {
+func (g *Gemini) Setup() error {
+	// if .gemini directory exists in /workspaces copy it to repo directory
+	wsGeminiConfigDir := filepath.Join(g.WorkspacesDir, ".gemini")
+	repoGeminiConfigDir := filepath.Join(g.RepoDir, ".gemini")
+	backupGeminiConfigDir := filepath.Join(g.WorkspacesDir, ".gemini.bak")
+	if _, err := os.Stat(wsGeminiConfigDir); err == nil {
 		klog.Info(".gemini directory exists in /workspaces, copying to repo directory")
 		// if desitation .gemini directory exists move it to .gemini.bak
-		if _, err := os.Stat(".gemini"); err == nil {
+		if _, err := os.Stat(repoGeminiConfigDir); err == nil {
 			klog.Info(".gemini directory exists in repo directory, moving to .gemini.bak")
-			err := os.Rename(".gemini", ".gemini.bak")
+			err := os.Rename(repoGeminiConfigDir, backupGeminiConfigDir)
 			if err != nil {
 				return fmt.Errorf("failed to move .gemini to .gemini.bak: %v", err)
 			}
 		}
-		cmd := exec.Command("cp", "-R", geminiConfigDir, ".gemini")
+		cmd := exec.Command("cp", "-R", wsGeminiConfigDir, repoGeminiConfigDir)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
@@ -68,7 +71,7 @@ func (g *Gemini) Setup(workspacesDir, tokensDir string) error {
 	}
 
 	// Ensure root settings.json has previewFeatures
-	if err := ensureSettings(".gemini"); err != nil {
+	if err := ensureSettings(repoGeminiConfigDir); err != nil {
 		klog.Infof("Warning: failed to ensure .gemini/settings.json: %v", err)
 	}
 
@@ -80,7 +83,7 @@ func (g *Gemini) Setup(workspacesDir, tokensDir string) error {
 		}
 	}
 
-	geminiTokenFile := filepath.Join(tokensDir, "gemini")
+	geminiTokenFile := filepath.Join(g.TokensDir, "gemini")
 	geminiKey, err := os.ReadFile(geminiTokenFile)
 	if err != nil {
 		return fmt.Errorf("failed to read %s: %v", geminiTokenFile, err)
@@ -132,14 +135,16 @@ func ensureSettings(geminiDir string) error {
 	return nil
 }
 
-func (g *Gemini) Cleanup(workspacesDir string) error {
-	geminiBackupDir := filepath.Join(workspacesDir, ".gemini.bak")
-	if _, err := os.Stat(geminiBackupDir); err == nil {
+func (g *Gemini) Cleanup() error {
+	wsGeminiConfigDir := filepath.Join(g.WorkspacesDir, ".gemini")
+	repoGeminiConfigDir := filepath.Join(g.RepoDir, ".gemini")
+	backupGeminiConfigDir := filepath.Join(g.WorkspacesDir, ".gemini.bak")
+	if _, err := os.Stat(backupGeminiConfigDir); err == nil {
 		klog.Info("moving .gemini.bak -> .gemini")
-		if err := os.RemoveAll(geminiBackupDir); err != nil {
+		if err := os.RemoveAll(repoGeminiConfigDir); err != nil {
 			klog.Infof("failed to remove .gemini directory: %v", err)
 		}
-		if err := os.Rename(".gemini.bak", ".gemini"); err != nil {
+		if err := os.Rename(backupGeminiConfigDir, wsGeminiConfigDir); err != nil {
 			return fmt.Errorf("failed to move .gemini.bak to .gemini: %w", err)
 		}
 	}

--- a/repo-agent/pkg/llm/gemini_test.go
+++ b/repo-agent/pkg/llm/gemini_test.go
@@ -58,8 +58,8 @@ func TestGemini_Setup(t *testing.T) {
 		}
 
 		// Create a Gemini provider and run Setup
-		g := &Gemini{}
-		if err := g.Setup(workspacesDir, tokensDir); err != nil {
+		g := &Gemini{ProviderConfig: ProviderConfig{WorkspacesDir: workspacesDir, TokensDir: tokensDir}}
+		if err := g.Setup(); err != nil {
 			t.Fatalf("Gemini.Setup() failed: %v", err)
 		}
 
@@ -91,8 +91,8 @@ func TestGemini_Setup(t *testing.T) {
 		}
 
 		// Create a Gemini provider and run Setup
-		g := &Gemini{}
-		if err := g.Setup(workspacesDir, tokensDir); err == nil {
+		g := &Gemini{ProviderConfig: ProviderConfig{WorkspacesDir: workspacesDir, TokensDir: tokensDir}}
+		if err := g.Setup(); err == nil {
 			t.Fatal("Gemini.Setup() should have failed, but it didn't")
 		}
 	})
@@ -243,7 +243,7 @@ func TestGeminiCleanup(t *testing.T) {
 	}
 
 	g := &Gemini{}
-	if err := g.Cleanup(""); err != nil {
+	if err := g.Cleanup(); err != nil {
 		t.Errorf("Cleanup() error = %v, want nil", err)
 	}
 }

--- a/repo-agent/pkg/llm/provider.go
+++ b/repo-agent/pkg/llm/provider.go
@@ -27,10 +27,19 @@ const (
 // PostProcessor defines the signature for functions that can post-process the LLM's raw output.
 type PostProcessor func([]byte) ([]byte, error)
 
+// ProviderConfig holds the configuration for an LLM provider.
+type ProviderConfig struct {
+	Name                 string
+	WorkspacesDir        string
+	RepoDir              string
+	TokensDir            string
+	OutputStartIndicator string
+}
+
 // Provider defines the interface for interacting with an LLM.
 type Provider interface {
-	Setup(workspacesDir, tokensDir string) error
-	Cleanup(workspacesDir string) error
+	Setup() error
+	Cleanup() error
 	ExpandPrompt(prompt string) (string, error)
 	Run(prompt string) ([]byte, error)
 	// AddPostProcessor adds a post-processing function to the provider.
@@ -52,25 +61,32 @@ func (e *QuotaError) Unwrap() error {
 	return e.Err
 }
 
-func NewLLMProvider(name string, outputStartIndicator string) (Provider, error) {
-	switch name {
+func NewLLMProvider(cfg ProviderConfig) (Provider, error) {
+	switch cfg.Name {
 	case "gemini-cli":
-		g := &Gemini{Executor: &RealCommandExecutor{}}
+		g := &Gemini{
+			Executor:       &RealCommandExecutor{},
+			ProviderConfig: cfg,
+		}
 		g.AddPostProcessor(StripYAMLMarkers)
-		if outputStartIndicator != "" {
-			g.AddPostProcessor(StripThoughts(outputStartIndicator))
+		if cfg.OutputStartIndicator != "" {
+			g.AddPostProcessor(StripThoughts(cfg.OutputStartIndicator))
 		}
 		return g, nil
 	case "claude":
-		c := &Claude{}
+		c := &Claude{
+			ProviderConfig: cfg,
+		}
 		c.AddPostProcessor(StripYAMLMarkers)
 		return c, nil
 	case "dummy":
-		d := &Dummy{}
+		d := &Dummy{
+			ProviderConfig: cfg,
+		}
 		d.AddPostProcessor(StripYAMLMarkers)
 		return d, nil
 	default:
-		return nil, fmt.Errorf("unknown provider: %s", name)
+		return nil, fmt.Errorf("unknown provider: %s", cfg.Name)
 	}
 }
 

--- a/repo-agent/pkg/llm/provider_test.go
+++ b/repo-agent/pkg/llm/provider_test.go
@@ -95,7 +95,7 @@ func TestNewProvider(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			provider, err := NewLLMProvider(tt.provider, "")
+			provider, err := NewLLMProvider(ProviderConfig{Name: tt.provider})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewProvider() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/repo-agent/pkg/sandbox/workflow.go
+++ b/repo-agent/pkg/sandbox/workflow.go
@@ -26,6 +26,11 @@ type Config struct {
 	GithubUserName   string
 	GVR              schema.GroupVersionResource
 	ReportStatus     bool
+
+	// Directory paths
+	RepoDir       string
+	WorkspacesDir string
+	TokensDir     string
 }
 
 func PrepareGitBranch(cfg Config) (string, error) {
@@ -77,12 +82,17 @@ func RunAgent(ctx context.Context, cfg Config) error {
 	log := klog.FromContext(ctx)
 	log.Info("Starting agent", "agentName", cfg.AgentName)
 
-	provider, err := llm.NewLLMProvider(cfg.AgentName, "")
+	provider, err := llm.NewLLMProvider(llm.ProviderConfig{
+		Name:          cfg.AgentName,
+		WorkspacesDir: cfg.WorkspacesDir,
+		TokensDir:     cfg.TokensDir,
+		RepoDir:       cfg.RepoDir,
+	})
 	if err != nil {
 		return err
 	}
 
-	if err := provider.Setup("/workspaces", "/tokens"); err != nil {
+	if err := provider.Setup(); err != nil {
 		return err
 	}
 
@@ -115,7 +125,7 @@ func RunAgent(ctx context.Context, cfg Config) error {
 	}
 
 	// Cleanup
-	if err := provider.Cleanup("/workspaces"); err != nil {
+	if err := provider.Cleanup(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
With a lot of refactoring and changes we did recently, reviews were broken #331 
The issue turned out to be inconsistent directory path handling under different flows.
devcontainer flow sets up the cwd to be the repo's directory and we used relative paths from that.
But with bring your own image, relative paths dont work.
So making paths explicitly configured via settings pattern.

Changes:

1. `pkg/llm/provider.go`:
  * Defined ProviderConfig struct containing Name, WorkspacesDir, RepoDir, TokensDir, and OutputStartIndicator.
  * Updated NewLLMProvider to accept ProviderConfig instead of individual arguments.
  * Updated Provider interface: Setup() and Cleanup() now take no arguments (they use the config stored in the provider instance).
2. `pkg/llm/gemini.go`:
  * Updated Gemini struct to store ProviderConfig.
  * Updated Setup and Cleanup to use WorkspacesDir and TokensDir from the stored config.
3. `pkg/llm/claude.go`:
  * Updated Claude struct to store ProviderConfig.
  * Updated Setup to use TokensDir from the stored config.
  * Updated Cleanup signature.
4. `pkg/llm/dummy.go`:
  * Updated Dummy struct and methods to match the new interface and config pattern.
5. `pkg/commands/review.go` & `pkg/sandbox/workflow.go`:
  * Updated NewLLMProvider calls to pass ProviderConfig.
  * Updated Setup() and Cleanup() calls to match the new signature.
6. `pkg/llm/provider_test.go`:
  * Updated tests to use ProviderConfig.
7. `docs/adding-a-new-llm-provider.md`:
  * Updated documentation to reflect the API changes.