### PR TITLE
fix(repo-agent): update gemini-cli settings.json model format

### DIFF
--- a/repo-agent/pkg/llm/gemini.go
+++ b/repo-agent/pkg/llm/gemini.go
@@ -116,9 +116,16 @@ func ensureSettings(geminiDir string) error {
 		settings["general"] = general
 	}
 	general["previewFeatures"] = true
-	if _, ok := settings["model"]; !ok {
+	if model, ok := settings["model"]; !ok {
 		// if model is unset, set it to gemini-3-pro-preview
-		settings["model"] = "gemini-3-pro-preview"
+		settings["model"] = map[string]interface{}{
+			"name": "gemini-3-pro-preview",
+		}
+	} else if modelStr, ok := model.(string); ok {
+		// if model is a string, convert it to an object
+		settings["model"] = map[string]interface{}{
+			"name": modelStr,
+		}
 	}
 
 	data, err := json.MarshalIndent(settings, "", "  ")

--- a/repo-agent/pkg/llm/gemini_test.go
+++ b/repo-agent/pkg/llm/gemini_test.go
@@ -267,7 +267,9 @@ func TestEnsureSettings(t *testing.T) {
   "general": {
     "previewFeatures": true
   },
-  "model": "gemini-3-pro-preview"
+  "model": {
+    "name": "gemini-3-pro-preview"
+  }
 }`
 		if string(data) != expected {
 			t.Errorf("Expected settings:\n%s\nGot:\n%s", expected, string(data))
@@ -313,8 +315,9 @@ func TestEnsureSettings(t *testing.T) {
 		if general["previewFeatures"] != true {
 			t.Errorf("Expected 'general.previewFeatures' to be true, got %v", general["previewFeatures"])
 		}
-		if settings["model"] != "gemini-3-pro-preview" {
-			t.Errorf("Expected 'model' to be 'gemini-3-pro-preview', got %v", settings["model"])
+		model := settings["model"].(map[string]interface{})
+		if model["name"] != "gemini-3-pro-preview" {
+			t.Errorf("Expected 'model.name' to be 'gemini-3-pro-preview', got %v", model["name"])
 		}
 	})
 
@@ -325,7 +328,7 @@ func TestEnsureSettings(t *testing.T) {
 			t.Fatalf("failed to create gemini dir: %v", err)
 		}
 
-		initialSettings := `{"model": "my-custom-model"}`
+		initialSettings := `{"model": {"name": "my-custom-model"}}`
 		settingsPath := filepath.Join(geminiDir, "settings.json")
 		if err := os.WriteFile(settingsPath, []byte(initialSettings), 0644); err != nil {
 			t.Fatalf("failed to write initial settings: %v", err)
@@ -345,8 +348,45 @@ func TestEnsureSettings(t *testing.T) {
 			t.Fatalf("failed to unmarshal settings: %v", err)
 		}
 
-		if settings["model"] != "my-custom-model" {
-			t.Errorf("Expected 'model' to be 'my-custom-model', got %v", settings["model"])
+		model := settings["model"].(map[string]interface{})
+		if model["name"] != "my-custom-model" {
+			t.Errorf("Expected 'model.name' to be 'my-custom-model', got %v", model["name"])
+		}
+	})
+
+	t.Run("converts string model to object", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		geminiDir := filepath.Join(tmpDir, ".gemini")
+		if err := os.MkdirAll(geminiDir, 0755); err != nil {
+			t.Fatalf("failed to create gemini dir: %v", err)
+		}
+
+		initialSettings := `{"model": "string-model"}`
+		settingsPath := filepath.Join(geminiDir, "settings.json")
+		if err := os.WriteFile(settingsPath, []byte(initialSettings), 0644); err != nil {
+			t.Fatalf("failed to write initial settings: %v", err)
+		}
+
+		if err := ensureSettings(geminiDir); err != nil {
+			t.Fatalf("ensureSettings failed: %v", err)
+		}
+
+		data, err := os.ReadFile(settingsPath)
+		if err != nil {
+			t.Fatalf("failed to read settings.json: %v", err)
+		}
+
+		var settings map[string]interface{}
+		if err := json.Unmarshal(data, &settings); err != nil {
+			t.Fatalf("failed to unmarshal settings: %v", err)
+		}
+
+		model, ok := settings["model"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("Expected 'model' to be an object, but got %T", settings["model"])
+		}
+		if model["name"] != "string-model" {
+			t.Errorf("Expected 'model.name' to be 'string-model', got %v", model["name"])
 		}
 	})
 }


### PR DESCRIPTION
fixes #335 

The gemini-cli tool now requires the 'model' field in settings.json to be a JSON object with a 'name' field, rather than a simple string. This change updates the ensureSettings function to generate the correct format and automatically migrates existing string settings to the new object format.

- Updated gemini.go to use object format for model field
- Added migration logic for string-to-object conversion
- Updated unit tests to match new schema and verify migration

The migration logic was added as I believe this was a change to the gemini-cli settings.json format (vs it being correct ) so added this + tests.  Can remove this if we think it isn't necessary.


Manually tested that this settings.json format is correct by running `gemini-cli` locally and confirming the model was changed

```
aprindle@aprindle-ssd-v2 ~/gemini-test tree -a
.
└── .gemini
    └── settings.json

2 directories, 1 file
aprindle@aprindle-ssd-v2 ~/gemini-test cat .gemini/settings.json 
{
  "general": {
    "previewFeatures": true
  },
  "model": {
    "name": "gemini-2.5-pro"
  }
}

```
<img width="2134" height="882" alt="image" src="https://github.com/user-attachments/assets/5eb2f210-af0d-4bcc-9419-326f3a5c10a0" />
(uses gemini-2.5-pro in screenshot meaning it parsed the settings.json, without this it uses gemini-pro-3-preview by default)