### PR TITLE
fix: dev sandbox agentstate was not transitioning correctly

### DIFF
--- a/repo-agent/pkg/commands/dev.go
+++ b/repo-agent/pkg/commands/dev.go
@@ -138,19 +138,16 @@ func (c *SandboxCommand) Run(ctx context.Context) error {
 	var (
 		gvr           schema.GroupVersionResource
 		agentType     string
-		reportStatus  bool
 		commitMessage string
 	)
 
 	if c.IssueID != "" {
 		gvr = IssueGVR
 		agentType = "issue"
-		reportStatus = true
 		commitMessage = "fix for issue #" + c.IssueID
 	} else {
 		gvr = DevGVR
 		agentType = "dev"
-		reportStatus = false
 		commitMessage = "Agent changes for: " + c.AgentPrompt
 	}
 
@@ -210,7 +207,6 @@ func (c *SandboxCommand) Run(ctx context.Context) error {
 		GithubUserLogin:  c.GithubUserLogin,
 		GithubUserEmail:  c.GithubUserEmail,
 		GithubUserName:   c.GithubUserName,
-		ReportStatus:     reportStatus,
 		GVR:              gvr,
 
 		WorkspacesDir: c.WorkspaceDir,

--- a/repo-agent/pkg/sandbox/workflow.go
+++ b/repo-agent/pkg/sandbox/workflow.go
@@ -25,7 +25,6 @@ type Config struct {
 	GithubUserEmail  string
 	GithubUserName   string
 	GVR              schema.GroupVersionResource
-	ReportStatus     bool
 
 	// Directory paths
 	RepoDir       string
@@ -97,9 +96,7 @@ func RunAgent(ctx context.Context, cfg Config) error {
 	}
 
 	// Run gemini
-	if cfg.ReportStatus {
-		_ = agentoutput.SetAgentState(ctx, cfg.GVR, "running agent", "")
-	}
+	_ = agentoutput.SetAgentState(ctx, cfg.GVR, "running agent", "")
 
 	// We assume we are in the repo directory or the prompt should be written where the agent can find it?
 	// issue-sandbox writes to "../agent-prompt.txt".
@@ -149,9 +146,7 @@ func ProcessGitChanges(ctx context.Context, cfg Config, oldCommitID string, comm
 	if newCommitID != oldCommitID {
 		log.Info("New changes being committed")
 		if cfg.PushEnabled {
-			if cfg.ReportStatus {
-				_ = agentoutput.SetAgentState(ctx, cfg.GVR, "pushing changes", "")
-			}
+			_ = agentoutput.SetAgentState(ctx, cfg.GVR, "pushing changes", "")
 			if err := gitcli.Push("origin", cfg.BranchName, true); err != nil {
 				return fmt.Errorf("failed to push changes: %w", err)
 			}


### PR DESCRIPTION
it was transitioning from provisioning -> ready.
When running with a prompt it can be:
provisioning -> running agent -> pushing changes -> ready.

Enable always reporting. Added this flag during deduping which in hindsight was not required.