### PR TITLE
refactor: Introduce GitHub domain models and simplify Sandbox Executor

### DIFF
--- a/repo-agent/pkg/commands/github-autopoll.go
+++ b/repo-agent/pkg/commands/github-autopoll.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -188,11 +189,18 @@ func (p *AutoPoller) pollOnce(ctx context.Context) error {
 			issueURL := fmt.Sprintf("https://github.com/%s/%s/issues/%d", repo.Owner, repo.Name, issue.GetNumber())
 
 			go func(issueURL string) {
-				fixIssueOpt := GithubFixIssueOptions{
-					URL: issueURL,
+				// TODO (barney-s): set additional fields
+				fixIssue := GithubFixIssueCommand{
+					URL:             issueURL,
+					InPod:           false,
+					GithubUserLogin: "codebot-robot",
+					GithubUserEmail: "codebot-robot@google.com",
+					GithubUserName:  "codebot-robot",
+					GithubUserToken: os.Getenv("CODEBOT_ROBOT_GITHUB_TOKEN"),
 				}
+				// fixIssue.InitDefaults()
 
-				if err := RunGithubFixIssue(ctx, fixIssueOpt); err != nil {
+				if err := fixIssue.Run(ctx); err != nil {
 					log.Error(err, "failed to process issue", "issue", issueKey)
 					// Don't return error, continue processing other issues
 				}

--- a/repo-agent/pkg/commands/github-fix-issue.go
+++ b/repo-agent/pkg/commands/github-fix-issue.go
@@ -1,12 +1,14 @@
 package commands
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
-	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/clients"
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/github"
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/prompts"
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/sandbox"
@@ -14,14 +16,30 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// GithubFixIssueOptions holds options for the RunCode function.
-type GithubFixIssueOptions struct {
-	URL string
+// GithubFixIssueCommand holds options for the RunCode function.
+type GithubFixIssueCommand struct {
+	// Configurable options
+	URL             string
+	AgentName       string
+	GithubUserLogin string
+	GithubUserEmail string
+	GithubUserName  string
+	GithubUserToken string
+	InPod           bool
+	WorkspaceDir    string
+	TaskDir         string
+
+	// loaded objects
+	issue     *github.Issue
+	repo      *github.Repository
+	user      *github.User
+	sandbox   *sandbox.IssueSandbox
+	sandboxID string
 }
 
 // BuildGithubFixIssueCommand creates a new cobra command for using a dev sandbox to solve a github issue
 func BuildGithubFixIssueCommand() *cobra.Command {
-	var opt GithubFixIssueOptions
+	fixCommand := GithubFixIssueCommand{}
 
 	cmd := &cobra.Command{
 		Use:   "github-fix-issue",
@@ -31,119 +49,298 @@ func BuildGithubFixIssueCommand() *cobra.Command {
 			if len(args) != 0 {
 				return fmt.Errorf("command does not take positional arguments")
 			}
-
-			return RunGithubFixIssue(cmd.Context(), opt)
+			if fixCommand.URL == "" {
+				return fmt.Errorf("--issue-url is required")
+			}
+			fixCommand.InitDefaults()
+			return fixCommand.Run(cmd.Context())
 		},
 	}
 
-	cmd.Flags().StringVar(&opt.URL, "url", opt.URL, "GitHub issue URL")
+	cmd.Flags().StringVar(&fixCommand.URL, "issue-url", os.Getenv("ISSUE_URL"), "GitHub issue URL")
+	cmd.Flags().StringVar(&fixCommand.AgentName, "agent-name", os.Getenv("AGENT_NAME"), "Agent name")
+	cmd.Flags().StringVar(&fixCommand.GithubUserLogin, "github-user-login", os.Getenv("GITHUB_USER_LOGIN"), "Github user login")
+	cmd.Flags().StringVar(&fixCommand.GithubUserEmail, "github-user-email", os.Getenv("GITHUB_USER_EMAIL"), "Github user email")
+	cmd.Flags().StringVar(&fixCommand.GithubUserName, "github-user-name", os.Getenv("GITHUB_USER_NAME"), "Github user name")
+	cmd.Flags().BoolVar(&fixCommand.InPod, "in-pod", false, "Whether running inside the pod")
 	return cmd
 }
 
-// RunGithubFixIssue launches VS Code connected to the specified dev sandbox.
-func RunGithubFixIssue(ctx context.Context, opt GithubFixIssueOptions) error {
-	log := klog.FromContext(ctx)
-
-	codebotRobotToken := os.Getenv("CODEBOT_ROBOT_GITHUB_TOKEN")
-	if codebotRobotToken == "" {
-		return fmt.Errorf("CODEBOT_ROBOT_GITHUB_TOKEN environment variable is not set")
+func (c *GithubFixIssueCommand) InitDefaults() {
+	if c.AgentName == "" {
+		c.AgentName = "gemini-cli"
 	}
 
-	kube, err := clients.NewKubernetesClient()
+	if c.WorkspaceDir == "" {
+		c.WorkspaceDir = "/workspaces"
+	}
+	if c.TaskDir == "" {
+		c.TaskDir = os.Getenv("TASKDIR")
+	}
+	if c.TaskDir == "" {
+		c.TaskDir = c.WorkspaceDir
+	}
+	if c.GithubUserToken == "" {
+		c.GithubUserToken = os.Getenv("GITHUB_USER_TOKEN")
+	}
+}
+
+func (c *GithubFixIssueCommand) taskPath(name string, args ...interface{}) string {
+	// Ensure the task path is correctly joined
+	file := fmt.Sprintf(name, args...)
+	return filepath.Join(c.TaskDir, file)
+}
+
+func (c *GithubFixIssueCommand) loadGithubObjects(ctx context.Context) error {
+	githubAPI, err := github.NewClient(context.Background())
 	if err != nil {
 		return err
 	}
 
-	githubAPI, err := github.NewClient(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to create github client: %w", err)
-	}
-
-	if opt.URL == "" {
-		return fmt.Errorf("--url is required")
-	}
-
-	issue, err := github.ParseIssueURL(opt.URL)
-	if err != nil {
-		return err
-	}
-	repo := issue.Repo
-
-	prompt, err := prompts.FixIssuePrompt(ctx, githubAPI, issue)
-	if err != nil {
-		return fmt.Errorf("failed to generate prompt for issue: %w", err)
-	}
-
-	sb, found, err := sandbox.FindSandboxForIssue(ctx, kube, repo, issue)
+	c.issue, err = githubAPI.GetIssue(ctx, c.URL, true)
 	if err != nil {
 		return err
 	}
 
-	if !found {
-		sb, err = sandbox.LaunchSandboxForIssue(ctx, kube, repo, issue)
-		if err != nil {
-			return fmt.Errorf("launching sandbox for issue: %w", err)
+	c.repo, err = githubAPI.GetRepositoryFromIssueURL(ctx, c.URL)
+	if err != nil {
+		return err
+	}
+
+	user := github.User{
+		UserID: c.GithubUserLogin,
+		Email:  c.GithubUserEmail,
+		Name:   c.GithubUserName,
+		Token:  c.GithubUserToken,
+	}
+
+	c.user = &user
+	return nil
+}
+
+func (c *GithubFixIssueCommand) loadSandbox(ctx context.Context) error {
+	sb, err := sandbox.NewIssueSandbox(ctx, c.InPod, c.repo, c.issue, *c.user)
+	if err != nil {
+		return err
+	}
+	c.sandbox = sb
+	c.sandboxID = sb.GetSandboxID()
+	return nil
+}
+
+func (c *GithubFixIssueCommand) SetupGit() error {
+	//log := klog.FromContext(ctx)
+
+	{
+		config := `github.com:
+    users:
+        {{UserID}}:
+            oauth_token: {{Token}}
+    git_protocol: https
+    oauth_token: {{Token}}
+    user: {{UserID}}
+`
+
+		if c.user.Token == "" {
+			return fmt.Errorf("user token is not set")
+		}
+
+		config = strings.ReplaceAll(config, "{{Token}}", c.user.Token)
+		config = strings.ReplaceAll(config, "{{UserID}}", c.user.UserID)
+
+		opts := sandbox.ExecOptions{
+			Command: []string{"mkdir", "-p", "/root/.config/gh"},
+		}
+		if err := c.sandbox.Exec(opts); err != nil {
+			return fmt.Errorf("creating /root/.config/gh directory: %w", err)
+		}
+
+		if err := c.sandbox.WriteFile("/root/.config/gh/hosts.yml", []byte(config)); err != nil {
+			return fmt.Errorf("writing gh config: %w", err)
 		}
 	}
 
-	podID := sb.GetPodID()
+	// Run git config
+	{
+		opts := sandbox.ExecOptions{
+			Command: []string{"git", "config", "--global", "user.email", c.user.Email},
+		}
+		if err := c.sandbox.Exec(opts); err != nil {
+			return fmt.Errorf("running git config user.email: %w", err)
+		}
+		opts = sandbox.ExecOptions{
+			Command: []string{"git", "config", "--global", "user.name", c.user.Name},
+		}
+		if err := c.sandbox.Exec(opts); err != nil {
+			return fmt.Errorf("running git config user.name: %w", err)
+		}
+	}
 
-	geminiAPIKey, err := GetGeminiAPIKey(podID.Namespace + "/" + podID.Name)
+	// Run gh auth setup-git
+	{
+		opts := sandbox.ExecOptions{
+			Command: []string{"gh", "auth", "setup-git"},
+		}
+		if err := c.sandbox.Exec(opts); err != nil {
+			return fmt.Errorf("running gh auth setup-git: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (c *GithubFixIssueCommand) SetupGitRepos(ctx context.Context) error {
+	log := klog.FromContext(ctx)
+
+	workdir := fmt.Sprintf("/workspaces/%s", c.repo.Name())
+
+	// Run gh repo fork
+	log.Info("Forking repository", "sandbox", c.sandboxID, "repo", c.repo.CloneURL())
+	{
+		// TODO: Does gh support -C ?
+		opts := sandbox.ExecOptions{
+			Command: []string{"sh", "-c", fmt.Sprintf("cd %s && gh repo fork --remote", workdir)},
+		}
+		if err := c.sandbox.Exec(opts); err != nil {
+			return fmt.Errorf("running gh repo fork: %w", err)
+		}
+	}
+
+	// Setup default remote
+	{
+		defaultRepo := c.repo.CloneURL()
+
+		// TODO: Does gh support -C ?
+		opts := sandbox.ExecOptions{
+			Command: []string{"sh", "-c", fmt.Sprintf("cd %s && gh repo set-default %s", workdir, defaultRepo)},
+		}
+		if err := c.sandbox.Exec(opts); err != nil {
+			return fmt.Errorf("running gh repo fork: %w", err)
+		}
+
+	}
+
+	// Wait for checkout to complete
+	{
+		timeoutAt := time.Now().Add(time.Minute)
+		for {
+			log.Info("Waiting for checkout to be ready")
+
+			var stdout bytes.Buffer
+			opts := sandbox.ExecOptions{
+				Command: []string{"git", "-C", workdir, "branch", "--show-current"},
+				Stdout:  &stdout,
+			}
+			if err := c.sandbox.Exec(opts); err != nil {
+				klog.Infof("stdout: %v", stdout.String())
+				if time.Now().After(timeoutAt) {
+					return fmt.Errorf("timed out waiting for initial checkout to complete: %w", err)
+				}
+			} else {
+				klog.Infof("current branch: %v", stdout.String())
+				break
+			}
+
+			time.Sleep(2 * time.Second)
+		}
+	}
+
+	return nil
+}
+
+func (c *GithubFixIssueCommand) CheckoutNewBranch(ctx context.Context) error {
+	log := klog.FromContext(ctx)
+
+	workdir := fmt.Sprintf("/workspaces/%s", c.repo.Name())
+
+	branchName := fmt.Sprintf("issue_%d", c.issue.Number())
+
+	// Create a new branch
+	log.Info("Creating new branch", "sandbox", c.sandboxID, "branch", branchName)
+
+	opts := sandbox.ExecOptions{
+		Command: []string{"git", "-C", workdir, "checkout", "-b", branchName},
+	}
+	if err := c.sandbox.Exec(opts); err != nil {
+		return fmt.Errorf("creating new branch: %w", err)
+	}
+
+	return nil
+}
+
+// RunGithubFixIssue launches VS Code connected to the specified dev sandbox.
+func (c *GithubFixIssueCommand) Run(ctx context.Context) error {
+	log := klog.FromContext(ctx)
+
+	// Load data from github.com
+	err := c.loadGithubObjects(ctx)
 	if err != nil {
 		return err
 	}
 
-	if err := sb.SetupGit(ctx); err != nil {
+	// get sandbox
+	err = c.loadSandbox(ctx)
+	if err != nil {
+		return err
+	}
+
+	// setup git repo clone in sandbox
+	if err := c.SetupGit(); err != nil {
 		return fmt.Errorf("setting up git in sandbox: %w", err)
 	}
 
-	if err := sb.SetupGitRepos(ctx); err != nil {
+	if err := c.SetupGitRepos(ctx); err != nil {
 		return fmt.Errorf("setting up git branches in sandbox: %w", err)
-	}
-
-	// Copy the prompt into the pod (for now)
-	if len(prompt) > 0 {
-		log.Info("copying prompt into sandbox pod", "pod", podID)
-
-		path := "/workspaces/prompt.txt"
-		if err := sb.WriteFile(ctx, path, prompt); err != nil {
-			return fmt.Errorf("copying prompt into sandbox pod: %w", err)
-		}
-
-		log.Info("Copied prompt into sandbox pod", "pod", podID, "path", path)
 	}
 
 	// HACK: Avoid git lock issues
 	time.Sleep(5 * time.Second)
 
-	if err := sb.CheckoutNewBranch(ctx); err != nil {
+	if err := c.CheckoutNewBranch(ctx); err != nil {
 		return fmt.Errorf("checking out branch: %w", err)
 	}
 
-	if err := sandbox.ConfigureGemini(ctx, sb); err != nil {
+	// Prepare prompt
+	model := prompts.FixIssueModel{
+		Issue:         c.issue,
+		IssueComments: c.issue.IssueComments,
+		Repo:          c.repo,
+	}
+	prompt, err := prompts.FixIssuePrompt(model)
+	if err != nil {
+		return fmt.Errorf("failed to generate prompt for issue: %w", err)
+	}
+
+	log.Info("copying prompt into sandbox", "sandbox", c.sandboxID)
+
+	promptPath := c.taskPath("agent-prompt.txt")
+	if err := c.sandbox.WriteFile(promptPath, prompt); err != nil {
+		return fmt.Errorf("copying prompt into sandbox: %w", err)
+	}
+
+	log.Info("Copied prompt into sandbox", "sandbox", c.sandboxID, "path", promptPath)
+
+	if err := c.sandbox.ConfigureGemini(ctx); err != nil {
 		return fmt.Errorf("configuring gemini in sandbox: %w", err)
 	}
 
-	// Run gemini with API key and prompt
-	{
-		log.Info("Running gemini in pod", "pod", podID)
+	apikey, err := GetGeminiAPIKey(c.sandboxID)
+	if err != nil {
+		return err
+	}
+	log.Info("Running gemini in sandbox", "sandbox", c.sandboxID)
 
-		workdir := fmt.Sprintf("/workspaces/%s", sb.GetRepo().FilesystemName())
+	workdir := fmt.Sprintf("/workspaces/%s", c.repo.Name())
 
-		// TODO:
-		// export GEMINI_TELEMETRY_ENABLED=true
-		// export GEMINI_TELEMETRY_OTLP_ENDPOINT=http://otel-portal.otel-system:4317
+	opts := sandbox.ExecOptions{
+		Command: []string{"sh", "-c", fmt.Sprintf("cd %s && export GEMINI_API_KEY=%s && gemini --yolo --model gemini-3-pro-preview < %s", workdir, apikey, promptPath)},
+		Stdout:  os.Stdout,
+		Stderr:  os.Stderr,
+	}
+	opts.Secrets = []string{apikey}
 
-		opts := sandbox.ExecOptions{
-			Command: []string{"sh", "-c", fmt.Sprintf("cd %s && export GEMINI_API_KEY=%s && gemini --yolo --model gemini-3-pro-preview < /workspaces/prompt.txt", workdir, geminiAPIKey)},
-			Stdout:  os.Stdout,
-			Stderr:  os.Stderr,
-		}
-		opts.Secrets = []string{geminiAPIKey}
-
-		if err := sb.Exec(ctx, opts); err != nil {
-			return fmt.Errorf("running gemini: %w", err)
-		}
+	if err := c.sandbox.Exec(opts); err != nil {
+		return fmt.Errorf("running gemini: %w", err)
 	}
 
 	return nil

--- a/repo-agent/pkg/commands/threads_append.go
+++ b/repo-agent/pkg/commands/threads_append.go
@@ -82,7 +82,7 @@ func RunAppendToThread(ctx context.Context, opt AppendToThreadOptions) error {
 	}
 
 	// We need to read the current thread both to validate it exists and to infer the workspace
-	thread, err := sandbox.GetThread(ctx, executor, opt.ThreadID, false)
+	thread, err := sandbox.GetThread(executor, opt.ThreadID, false)
 	if err != nil {
 		return fmt.Errorf("failed to get thread: %w", err)
 	}

--- a/repo-agent/pkg/commands/threads_get.go
+++ b/repo-agent/pkg/commands/threads_get.go
@@ -70,7 +70,7 @@ func RunGetThreads(ctx context.Context, opt GetThreadsOptions) error {
 		PodID: *podID,
 	}
 
-	thread, err := sandbox.GetThread(ctx, executor, opt.ThreadID, opt.IncludeMessages)
+	thread, err := sandbox.GetThread(executor, opt.ThreadID, opt.IncludeMessages)
 	if err != nil {
 		return fmt.Errorf("failed to get thread: %w", err)
 	}

--- a/repo-agent/pkg/commands/threads_list.go
+++ b/repo-agent/pkg/commands/threads_list.go
@@ -56,7 +56,7 @@ func RunListThreads(ctx context.Context, opt ListThreadsOptions) error {
 		PodID: *podID,
 	}
 
-	threads, err := sandbox.ListThreads(ctx, executor)
+	threads, err := sandbox.ListThreads(executor)
 	if err != nil {
 		return fmt.Errorf("failed to list threads: %w", err)
 	}

--- a/repo-agent/pkg/github/client.go
+++ b/repo-agent/pkg/github/client.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/clients"
-	"github.com/google/go-github/v39/github"
+	githubv39 "github.com/google/go-github/v39/github"
 )
 
 func NewClient(ctx context.Context) (*Client, error) {
@@ -22,10 +23,82 @@ func NewClient(ctx context.Context) (*Client, error) {
 	}
 
 	token := strings.TrimSpace(stdout.String())
-	githubAPI := clients.NewGitHubClient(ctx, token)
-	return &Client{Client: githubAPI}, nil
+	return &Client{
+		Client: clients.NewGitHubClient(ctx, token),
+	}, nil
 }
 
 type Client struct {
-	*github.Client
+	*githubv39.Client
+}
+
+func parseIssueURL(url string) (owner string, repo string, number int, err error) {
+	u := strings.TrimPrefix(url, "https://")
+	tokens := strings.Split(u, "/")
+	// e.g. https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/6010
+	if len(tokens) == 5 && tokens[0] == "github.com" && tokens[3] == "issues" {
+		owner := tokens[1]
+		repo := tokens[2]
+		number, err := strconv.Atoi(tokens[4])
+		if err != nil {
+			return "", "", 0, fmt.Errorf("invalid issue number %q: %w", tokens[4], err)
+		}
+		return owner, repo, number, nil
+	}
+	return "", "", 0, fmt.Errorf("issue format %q not recognized", url)
+}
+
+func (c *Client) GetIssue(ctx context.Context, url string, includeComments bool) (*Issue, error) {
+	owner, repo, number, err := parseIssueURL(url)
+	if err != nil {
+		return nil, err
+	}
+	issue, _, err := c.Client.Issues.Get(ctx, owner, repo, number)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get github issue: %w", err)
+	}
+	issueComments := []IssueComment{}
+	if includeComments {
+		issueComments, err = c.GetIssueComments(ctx, url)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &Issue{
+		issue:         issue,
+		IssueComments: issueComments,
+	}, nil
+}
+
+func (c *Client) GetIssueComments(ctx context.Context, url string) ([]IssueComment, error) {
+	owner, repo, number, err := parseIssueURL(url)
+	if err != nil {
+		return nil, err
+	}
+
+	comments, _, err := c.Client.Issues.ListComments(ctx, owner, repo, number, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list github issue comments: %w", err)
+	}
+	issueComments := []IssueComment{}
+	for _, comment := range comments {
+		issueComments = append(issueComments, IssueComment{
+			issuecomment: comment,
+		})
+	}
+	return issueComments, nil
+}
+
+func (c *Client) GetRepositoryFromIssueURL(ctx context.Context, url string) (*Repository, error) {
+	owner, repo, _, err := parseIssueURL(url)
+	if err != nil {
+		return nil, err
+	}
+	repository, _, err := c.Client.Repositories.Get(ctx, owner, repo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get github repository: %w", err)
+	}
+	return &Repository{
+		repository: repository,
+	}, nil
 }

--- a/repo-agent/pkg/github/issue.go
+++ b/repo-agent/pkg/github/issue.go
@@ -1,40 +1,14 @@
 package github
 
 import (
-	"fmt"
-	"strconv"
-	"strings"
+	githubv39 "github.com/google/go-github/v39/github"
 )
 
 type Issue struct {
-	Repo *Repo
+	issue *githubv39.Issue
 
-	IssueNumber int
-}
-
-func ParseIssueURL(s string) (*Issue, error) {
-	u := strings.TrimPrefix(s, "https://")
-	tokens := strings.Split(u, "/")
-
-	// e.g. https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/6010
-	if len(tokens) == 5 && tokens[0] == "github.com" && tokens[3] == "issues" {
-		issue := &Issue{
-			Repo: &Repo{
-				Host:  "github.com",
-				Owner: tokens[1],
-				Name:  tokens[2],
-			},
-		}
-		// Parse issue number
-		n, err := strconv.Atoi(tokens[4])
-		if err != nil {
-			return nil, fmt.Errorf("invalid issue number %q: %w", tokens[4], err)
-		}
-		issue.IssueNumber = n
-		return issue, nil
-	}
-
-	return nil, fmt.Errorf("issue format %q not recognized", s)
+	IssueComments []IssueComment
+	//Upstream:  repo.GitCloneURL(),
 }
 
 func (i *Issue) String() string {
@@ -42,5 +16,17 @@ func (i *Issue) String() string {
 }
 
 func (i *Issue) HTMLURL() string {
-	return fmt.Sprintf("https://%s/%s/%s/issues/%d", i.Repo.Host, i.Repo.Owner, i.Repo.Name, i.IssueNumber)
+	return i.issue.GetHTMLURL()
+}
+
+func (i *Issue) Number() int {
+	return i.issue.GetNumber()
+}
+
+func (i *Issue) Title() string {
+	return i.issue.GetTitle()
+}
+
+func (i *Issue) Body() string {
+	return i.issue.GetBody()
 }

--- a/repo-agent/pkg/github/issuecomment.go
+++ b/repo-agent/pkg/github/issuecomment.go
@@ -1,0 +1,17 @@
+package github
+
+import (
+	githubv39 "github.com/google/go-github/v39/github"
+)
+
+type IssueComment struct {
+	issuecomment *githubv39.IssueComment
+}
+
+func (ic *IssueComment) Body() string {
+	return ic.issuecomment.GetBody()
+}
+
+func (ic *IssueComment) UserLogin() string {
+	return ic.issuecomment.GetUser().GetLogin()
+}

--- a/repo-agent/pkg/github/repository.go
+++ b/repo-agent/pkg/github/repository.go
@@ -1,0 +1,21 @@
+package github
+
+import (
+	githubv39 "github.com/google/go-github/v39/github"
+)
+
+type Repository struct {
+	repository *githubv39.Repository
+}
+
+func (r *Repository) CloneURL() string {
+	return r.repository.GetCloneURL()
+}
+
+func (r *Repository) Name() string {
+	return r.repository.GetName()
+}
+
+func (r *Repository) Owner() string {
+	return r.repository.GetOwner().GetLogin()
+}

--- a/repo-agent/pkg/github/user.go
+++ b/repo-agent/pkg/github/user.go
@@ -1,0 +1,9 @@
+package github
+
+// User represents the user identity in the sandbox.
+type User struct {
+	UserID string
+	Name   string
+	Email  string
+	Token  string
+}

--- a/repo-agent/pkg/prompts/fix_issue.go
+++ b/repo-agent/pkg/prompts/fix_issue.go
@@ -2,63 +2,25 @@ package prompts
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/github"
 )
 
-func FixIssuePrompt(ctx context.Context, githubAPI *github.Client, i *github.Issue) ([]byte, error) {
+type FixIssueModel struct {
+	Issue         *github.Issue
+	IssueComments []github.IssueComment
+	Repo          *github.Repository
+}
 
-	repo := i.Repo
-
-	issueData, _, err := githubAPI.Issues.Get(ctx, repo.Owner, repo.Name, i.IssueNumber)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get github issue: %w", err)
-	}
-
-	model := FixIssuePromptModel{
-		IssueURL:         issueData.GetHTMLURL(),
-		IssueNumber:      issueData.GetNumber(),
-		IssueTitle:       issueData.GetTitle(),
-		IssueDescription: issueData.GetBody(),
-		Upstream:         repo.GitCloneURL(),
-	}
-
-	comments, _, err := githubAPI.Issues.ListComments(ctx, repo.Owner, repo.Name, i.IssueNumber, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list github issue comments: %w", err)
-	}
-	for _, comment := range comments {
-		model.IssueComments = append(model.IssueComments, IssueComment{
-			Author: comment.GetUser().GetLogin(),
-			Body:   comment.GetBody(),
-		})
-	}
-
+func FixIssuePrompt(model FixIssueModel) ([]byte, error) {
 	tmpl, err := getTemplate("fix_issue.txt")
 	if err != nil {
 		return nil, err
 	}
 	var w bytes.Buffer
-	if err := tmpl.Execute(&w, &model); err != nil {
+	if err := tmpl.Execute(&w, model); err != nil {
 		return nil, fmt.Errorf("failed to execute prompt template: %w", err)
 	}
-
 	return w.Bytes(), nil
-}
-
-type FixIssuePromptModel struct {
-	IssueURL         string
-	IssueNumber      int
-	IssueTitle       string
-	IssueDescription string
-	IssueComments    []IssueComment
-
-	Upstream string
-}
-
-type IssueComment struct {
-	Author string
-	Body   string
 }

--- a/repo-agent/pkg/prompts/fix_issue.txt
+++ b/repo-agent/pkg/prompts/fix_issue.txt
@@ -9,7 +9,7 @@ Use good PR hygene:
 
 Tips:
 * Your fork has already been created; the git remote is named "origin".  Push your changes to a branch on "origin", using `git push --set-upstream origin <branch>`; setting the upstream helps tooling like gh.
-* The upstream repo is {{ .Upstream }} and a git remote is set up for it at "upstream".
+* The upstream repo is {{ .Repo.CloneURL }} and a git remote is set up for it at "upstream".
 * Where the issue references another issue or a PR, use the github MCP server to read that issue/PR too - there are often important details in those links.
 * Also use the github MCP tools to read related issues and PRs, and follow patterns established there.
 * If you get stuck, push a PR but start the PR title with "[WIP]".  Other people on github may have suggestions on how to proceed.  Some tasks are blocked on problems in other libraries, and we probably want to fix those in separate PRs anyway.
@@ -19,15 +19,15 @@ Tips:
 
 Please create a Pull Request to fix this github issue:
 
-<issue_url>{{ .IssueURL}}/issue_url>
-<issue_number>{{ .IssueNumber}}</issue_number>
-<issue_title>{{ .IssueTitle}}</issue_title>
+<issue_url>{{ .Issue.HTMLURL }}/issue_url>
+<issue_number>{{ .Issue.Number }}</issue_number>
+<issue_title>{{ .Issue.Title }}</issue_title>
 <issue_description>
-{{ .IssueDescription}}
+{{ .Issue.Body }}
 </issue_description>
 {{ range  $comment := .IssueComments }}
 <issue_comment>
-<author>{{ $comment.Author }}</author>
+<author>{{ $comment.UserLogin }}</author>
 <body>
 {{ $comment.Body }}
 </body>

--- a/repo-agent/pkg/sandbox/exec.go
+++ b/repo-agent/pkg/sandbox/exec.go
@@ -23,9 +23,10 @@ import (
 // Executor defines the interface for executing commands and managing files.
 // It abstracts away the difference between running in a pod and running locally.
 type Executor interface {
-	Exec(ctx context.Context, opts ExecOptions) error
-	WriteFile(ctx context.Context, path string, data []byte) error
-	ReadFile(ctx context.Context, path string) ([]byte, error)
+	Exec(opts ExecOptions) error
+	WriteFile(path string, data []byte) error
+	ReadFile(path string) ([]byte, error)
+	ID() string
 }
 
 // ExecOptions holds options for executing a command.
@@ -40,25 +41,30 @@ type ExecOptions struct {
 
 // PodExecutor implements Executor for running commands in a Kubernetes pod.
 type PodExecutor struct {
+	Ctx   context.Context
 	Kube  *clients.KubernetesClient
 	PodID types.NamespacedName
 }
 
-func (e *PodExecutor) Exec(ctx context.Context, opts ExecOptions) error {
-	return ExecInPod(ctx, e.Kube, e.PodID, opts)
+func (e *PodExecutor) Exec(opts ExecOptions) error {
+	return ExecInPod(e.Ctx, e.Kube, e.PodID, opts)
 }
 
-func (e *PodExecutor) WriteFile(ctx context.Context, path string, data []byte) error {
-	return WriteFileInPod(ctx, e.Kube, e.PodID, path, data)
+func (e *PodExecutor) ID() string {
+	return fmt.Sprintf("%s/%s", e.PodID.Namespace, e.PodID.Name)
 }
 
-func (e *PodExecutor) ReadFile(ctx context.Context, path string) ([]byte, error) {
+func (e *PodExecutor) WriteFile(path string, data []byte) error {
+	return WriteFileInPod(e.Ctx, e.Kube, e.PodID, path, data)
+}
+
+func (e *PodExecutor) ReadFile(path string) ([]byte, error) {
 	var stdout bytes.Buffer
 	opts := ExecOptions{
 		Command: []string{"cat", path},
 		Stdout:  &stdout,
 	}
-	if err := e.Exec(ctx, opts); err != nil {
+	if err := e.Exec(opts); err != nil {
 		return nil, fmt.Errorf("reading file %q in pod: %w", path, err)
 	}
 	return stdout.Bytes(), nil
@@ -66,16 +72,22 @@ func (e *PodExecutor) ReadFile(ctx context.Context, path string) ([]byte, error)
 
 // LocalExecutor implements Executor for running commands locally.
 type LocalExecutor struct {
+	Ctx     context.Context
 	WorkDir string
+	Name    string
 }
 
-func (e *LocalExecutor) Exec(ctx context.Context, opts ExecOptions) error {
-	log := klog.FromContext(ctx)
+func (e *LocalExecutor) ID() string {
+	return e.Name
+}
+
+func (e *LocalExecutor) Exec(opts ExecOptions) error {
+	log := klog.FromContext(e.Ctx)
 
 	name := opts.Command[0]
 	args := opts.Command[1:]
 
-	cmd := exec.CommandContext(ctx, name, args...)
+	cmd := exec.CommandContext(e.Ctx, name, args...)
 	if e.WorkDir != "" {
 		cmd.Dir = e.WorkDir
 	}
@@ -110,7 +122,7 @@ func (e *LocalExecutor) Exec(ctx context.Context, opts ExecOptions) error {
 	return nil
 }
 
-func (e *LocalExecutor) WriteFile(_ context.Context, path string, data []byte) error {
+func (e *LocalExecutor) WriteFile(path string, data []byte) error {
 	// If path is absolute, use it? Or relative to WorkDir?
 	// The paths in our code are often absolute container paths like /workspaces/...
 	// For local execution, we might need to map these or just assume user knows what they are doing.
@@ -127,7 +139,7 @@ func (e *LocalExecutor) WriteFile(_ context.Context, path string, data []byte) e
 	return nil
 }
 
-func (e *LocalExecutor) ReadFile(_ context.Context, path string) ([]byte, error) {
+func (e *LocalExecutor) ReadFile(path string) ([]byte, error) {
 	return os.ReadFile(path)
 }
 

--- a/repo-agent/pkg/sandbox/interactive.go
+++ b/repo-agent/pkg/sandbox/interactive.go
@@ -5,9 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
-	"time"
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/clients"
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/github"
@@ -23,47 +21,94 @@ import (
 
 const RepoSandboxBinary = "/repo-agent/repo-sandbox"
 
-// InteractiveSandbox represents an agent sandbox being used to fix a GitHub issue.
-type InteractiveSandbox struct {
-	kube     *clients.KubernetesClient
-	podID    types.NamespacedName
-	repo     *github.Repo
+// IssueSandbox represents an agent sandbox being used to fix a GitHub issue.
+type IssueSandbox struct {
+	repo     *github.Repository
 	issue    *github.Issue
 	executor Executor
+	user     github.User
 }
 
-// GetPodID returns the pod ID of the sandbox.
-func (s *InteractiveSandbox) GetPodID() types.NamespacedName {
-	return s.podID
+func NewIssueSandbox(ctx context.Context, local bool, repo *github.Repository, issue *github.Issue, user github.User) (*IssueSandbox, error) {
+	log := klog.FromContext(ctx)
+
+	kube, err := clients.NewKubernetesClient()
+	if err != nil {
+		return nil, err
+	}
+
+	if local {
+		log.Info("Using local executor for sandbox")
+		return &IssueSandbox{
+			repo:  repo,
+			issue: issue,
+			executor: &LocalExecutor{
+				Ctx:     ctx,
+				Name:    fmt.Sprintf("local-%s/issue/%d", repo.Name(), issue.Number()),
+				WorkDir: fmt.Sprintf("/workspaces/%s", repo.Name()),
+			},
+			user: user,
+		}, nil
+	}
+	log.Info("Looking for existing sandbox for issue", "repo", repo.CloneURL(), "issue", issue.String())
+	sb, found, err := FindSandboxForIssue(ctx, kube, repo, issue, user)
+	if err != nil {
+		return nil, err
+	}
+
+	if !found {
+		sb, err = LaunchSandboxForIssue(ctx, kube, repo, issue, user)
+		if err != nil {
+			return nil, fmt.Errorf("launching sandbox for issue: %w", err)
+		}
+	}
+	return sb, nil
+}
+
+// GetPodID returns the pod ID of the sandbox if it is running in a pod.
+func (s *IssueSandbox) GetPodID() types.NamespacedName {
+	if podExecutor, ok := s.executor.(*PodExecutor); ok {
+		return podExecutor.PodID
+	}
+	return types.NamespacedName{}
+}
+
+// GetIssue returns the issue associated with the sandbox.
+func (s *IssueSandbox) GetIssue() *github.Issue {
+	return s.issue
+}
+
+func (s *IssueSandbox) GetSandboxID() string {
+	return s.executor.ID()
 }
 
 // GetRepo returns the repo associated with the sandbox.
-func (s *InteractiveSandbox) GetRepo() *github.Repo {
+func (s *IssueSandbox) GetRepo() *github.Repository {
 	return s.repo
 }
 
-func (s *InteractiveSandbox) Exec(ctx context.Context, opts ExecOptions) error {
-	return s.executor.Exec(ctx, opts)
+func (s *IssueSandbox) Exec(opts ExecOptions) error {
+	return s.executor.Exec(opts)
 }
 
-func (s *InteractiveSandbox) MkdirAll(ctx context.Context, path string) error {
+func (s *IssueSandbox) MkdirAll(path string) error {
 	opts := ExecOptions{
 		Command: []string{"mkdir", "-p", path},
 	}
-	if err := s.executor.Exec(ctx, opts); err != nil {
+	if err := s.executor.Exec(opts); err != nil {
 		return fmt.Errorf("creating directory %q: %w", path, err)
 	}
 	return nil
 }
 
-func (s *InteractiveSandbox) WriteFile(ctx context.Context, path string, data []byte) error {
-	if err := s.executor.WriteFile(ctx, path, data); err != nil {
+func (s *IssueSandbox) WriteFile(path string, data []byte) error {
+	if err := s.executor.WriteFile(path, data); err != nil {
 		return fmt.Errorf("writing file %q: %w", path, err)
 	}
 	return nil
 }
 
-func LaunchSandboxForIssue(ctx context.Context, kube *clients.KubernetesClient, repo *github.Repo, issue *github.Issue) (*InteractiveSandbox, error) {
+func LaunchSandboxForIssue(ctx context.Context, kube *clients.KubernetesClient, repo *github.Repository, issue *github.Issue, user github.User) (*IssueSandbox, error) {
 	log := klog.FromContext(ctx)
 
 	sandboxName := NameForIssue(repo, issue)
@@ -71,7 +116,7 @@ func LaunchSandboxForIssue(ctx context.Context, kube *clients.KubernetesClient, 
 	issueURL := issue.String()
 
 	cloneRepos := []string{
-		fmt.Sprintf("/workspaces/%s=%s", repo.FilesystemName(), repo.GitCloneURL()),
+		fmt.Sprintf("/workspaces/%s=%s", repo.Name(), repo.CloneURL()),
 	}
 
 	log.Info("Creating sandbox", "name", sandboxName, "repos", cloneRepos, "issue", issueURL)
@@ -126,26 +171,26 @@ func LaunchSandboxForIssue(ctx context.Context, kube *clients.KubernetesClient, 
 		return nil, err
 	}
 
-	return &InteractiveSandbox{
-		kube:  kube,
-		podID: podID,
+	return &IssueSandbox{
 		repo:  repo,
 		issue: issue,
 		executor: &PodExecutor{
+			Ctx:   ctx,
 			Kube:  kube,
 			PodID: podID,
 		},
+		user: user,
 	}, nil
 }
 
-func NameForIssue(repo *github.Repo, issue *github.Issue) string {
-	sandboxName := fmt.Sprintf("github-%s-%s-%d", repo.Owner, repo.Name, issue.IssueNumber)
+func NameForIssue(repo *github.Repository, issue *github.Issue) string {
+	sandboxName := fmt.Sprintf("github-%s-%s-%d", repo.Owner(), repo.Name(), issue.Number())
 	sandboxName = strings.ToLower(sandboxName) // Repos can have capital letters, but k8s names must be lowercase
 
 	return sandboxName
 }
 
-func FindSandboxForIssue(ctx context.Context, kube *clients.KubernetesClient, repo *github.Repo, issue *github.Issue) (*InteractiveSandbox, bool, error) {
+func FindSandboxForIssue(ctx context.Context, kube *clients.KubernetesClient, repo *github.Repository, issue *github.Issue, user github.User) (*IssueSandbox, bool, error) {
 	sandboxName := NameForIssue(repo, issue)
 
 	podIDPtr, err := FindSandboxPod(ctx, sandboxName)
@@ -157,15 +202,15 @@ func FindSandboxForIssue(ctx context.Context, kube *clients.KubernetesClient, re
 		return nil, false, nil
 	}
 
-	return &InteractiveSandbox{
-		kube:  kube,
-		podID: *podIDPtr,
+	return &IssueSandbox{
 		repo:  repo,
 		issue: issue,
 		executor: &PodExecutor{
+			Ctx:   ctx,
 			Kube:  kube,
 			PodID: *podIDPtr,
 		},
+		user: user,
 	}, true, nil
 }
 
@@ -211,180 +256,39 @@ func FindSandboxPod(ctx context.Context, sandboxName string) (*types.NamespacedN
 	return podID, nil
 }
 
-func (s *InteractiveSandbox) ReadFile(ctx context.Context, path string) ([]byte, error) {
-	return s.executor.ReadFile(ctx, path)
+func (s *IssueSandbox) ReadFile(path string) ([]byte, error) {
+	return s.executor.ReadFile(path)
 }
 
-func (s *InteractiveSandbox) SetupGit(ctx context.Context) error {
-	// log := klog.FromContext(ctx)
-
-	// Write gh config
-	{
-		config := `github.com:
-    users:
-        codebot-robot:
-            oauth_token: {{CODEBOT_ROBOT_GITHUB_TOKEN}}
-    git_protocol: https
-    oauth_token: {{CODEBOT_ROBOT_GITHUB_TOKEN}}
-    user: codebot-robot
-`
-
-		codebotRobotToken := os.Getenv("CODEBOT_ROBOT_GITHUB_TOKEN")
-		if codebotRobotToken == "" {
-			return fmt.Errorf("CODEBOT_ROBOT_GITHUB_TOKEN environment variable is not set")
-		}
-
-		config = strings.ReplaceAll(config, "{{CODEBOT_ROBOT_GITHUB_TOKEN}}", codebotRobotToken)
-
-		opts := ExecOptions{
-			Command: []string{"mkdir", "-p", "/root/.config/gh"},
-		}
-		if err := s.executor.Exec(ctx, opts); err != nil {
-			return fmt.Errorf("creating /root/.config/gh directory: %w", err)
-		}
-
-		if err := s.executor.WriteFile(ctx, "/root/.config/gh/hosts.yml", []byte(config)); err != nil {
-			return fmt.Errorf("writing gh config: %w", err)
-		}
-	}
-
-	// Run git config
-	{
-		opts := ExecOptions{
-			Command: []string{"git", "config", "--global", "user.email", "codebot-robot@google.com"},
-		}
-		if err := s.executor.Exec(ctx, opts); err != nil {
-			return fmt.Errorf("running git config user.email: %w", err)
-		}
-		opts = ExecOptions{
-			Command: []string{"git", "config", "--global", "user.name", "codebot-robot"},
-		}
-		if err := s.executor.Exec(ctx, opts); err != nil {
-			return fmt.Errorf("running git config user.name: %w", err)
-		}
-	}
-
-	// Run gh auth setup-git
-	{
-		opts := ExecOptions{
-			Command: []string{"gh", "auth", "setup-git"},
-		}
-		if err := s.executor.Exec(ctx, opts); err != nil {
-			return fmt.Errorf("running gh auth setup-git: %w", err)
-		}
-	}
-
-	return nil
-}
-
-func (s *InteractiveSandbox) SetupGitRepos(ctx context.Context) error {
+func (s *IssueSandbox) CheckoutExistingBranch(ctx context.Context, branchName string) error {
 	log := klog.FromContext(ctx)
 
-	workdir := fmt.Sprintf("/workspaces/%s", s.repo.FilesystemName())
+	workdir := fmt.Sprintf("/workspaces/%s", s.repo.Name())
 
-	// Run gh repo fork
-	log.Info("Forking repository", "pod", s.podID.Name, "repo", s.repo.GitCloneURL())
-	{
-		// TODO: Does gh support -C ?
-		opts := ExecOptions{
-			Command: []string{"sh", "-c", fmt.Sprintf("cd %s && gh repo fork --remote", workdir)},
-		}
-		if err := s.executor.Exec(ctx, opts); err != nil {
-			return fmt.Errorf("running gh repo fork: %w", err)
-		}
-	}
-
-	// Setup default remote
-	{
-		defaultRepo := s.repo.GitCloneURL()
-
-		// TODO: Does gh support -C ?
-		opts := ExecOptions{
-			Command: []string{"sh", "-c", fmt.Sprintf("cd %s && gh repo set-default %s", workdir, defaultRepo)},
-		}
-		if err := s.executor.Exec(ctx, opts); err != nil {
-			return fmt.Errorf("running gh repo fork: %w", err)
-		}
-
-	}
-
-	// Wait for checkout to complete
-	{
-		timeoutAt := time.Now().Add(time.Minute)
-		for {
-			log.Info("Waiting for checkout to be ready")
-
-			var stdout bytes.Buffer
-			opts := ExecOptions{
-				Command: []string{"git", "-C", workdir, "branch", "--show-current"},
-				Stdout:  &stdout,
-			}
-			if err := s.executor.Exec(ctx, opts); err != nil {
-				klog.Infof("stdout: %v", stdout.String())
-				if time.Now().After(timeoutAt) {
-					return fmt.Errorf("timed out waiting for initial checkout to complete: %w", err)
-				}
-			} else {
-				klog.Infof("current branch: %v", stdout.String())
-				break
-			}
-
-			time.Sleep(2 * time.Second)
-		}
-	}
-
-	return nil
-}
-
-func (s *InteractiveSandbox) CheckoutNewBranch(ctx context.Context) error {
-	log := klog.FromContext(ctx)
-
-	workdir := fmt.Sprintf("/workspaces/%s", s.repo.FilesystemName())
-
-	branchName := fmt.Sprintf("issue_%d", s.issue.IssueNumber)
-
-	// Create a new branch
-	log.Info("Creating new branch", "pod", s.podID.Name, "branch", branchName)
-
-	opts := ExecOptions{
-		Command: []string{"git", "-C", workdir, "checkout", "-b", branchName},
-	}
-	if err := s.executor.Exec(ctx, opts); err != nil {
-		return fmt.Errorf("creating new branch: %w", err)
-	}
-
-	return nil
-}
-
-func (s *InteractiveSandbox) CheckoutExistingBranch(ctx context.Context, branchName string) error {
-	log := klog.FromContext(ctx)
-
-	workdir := fmt.Sprintf("/workspaces/%s", s.repo.FilesystemName())
-
-	log.Info("Fetching from fork", "pod", s.podID.Name)
+	log.Info("Fetching from fork", "pod", s.GetPodID().Name)
 
 	opts := ExecOptions{
 		Command: []string{"git", "-C", workdir, "fetch", "origin"},
 	}
-	if err := s.executor.Exec(ctx, opts); err != nil {
+	if err := s.executor.Exec(opts); err != nil {
 		return fmt.Errorf("fetching from fork: %w", err)
 	}
 
 	opts = ExecOptions{
 		Command: []string{"git", "-C", workdir, "checkout", branchName},
 	}
-	if err := s.executor.Exec(ctx, opts); err != nil {
+	if err := s.executor.Exec(opts); err != nil {
 		return fmt.Errorf("checking out branch %q: %w", branchName, err)
 	}
 
 	return nil
 }
 
-func (s *InteractiveSandbox) ListThreads(ctx context.Context) ([]ThreadInfo, error) {
-	return ListThreads(ctx, s.executor)
+func (s *IssueSandbox) ListThreads() ([]ThreadInfo, error) {
+	return ListThreads(s.executor)
 }
 
-func ListThreads(ctx context.Context, executor Executor) ([]ThreadInfo, error) {
+func ListThreads(executor Executor) ([]ThreadInfo, error) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 
@@ -394,7 +298,7 @@ func ListThreads(ctx context.Context, executor Executor) ([]ThreadInfo, error) {
 		Stderr:  &stderr,
 	}
 
-	if err := executor.Exec(ctx, opts); err != nil {
+	if err := executor.Exec(opts); err != nil {
 		return nil, fmt.Errorf("failed to list threads via agent: %w, stderr: %s", err, stderr.String())
 	}
 
@@ -405,11 +309,11 @@ func ListThreads(ctx context.Context, executor Executor) ([]ThreadInfo, error) {
 	return threads, nil
 }
 
-func (s *InteractiveSandbox) GetThreadMessages(ctx context.Context, threadID string) ([]ThreadMessage, error) {
-	return GetThreadMessages(ctx, s.executor, threadID)
+func (s *IssueSandbox) GetThreadMessages(threadID string) ([]ThreadMessage, error) {
+	return GetThreadMessages(s.executor, threadID)
 }
 
-func GetThread(ctx context.Context, executor Executor, threadID string, includeMessages bool) (*ThreadInfo, error) {
+func GetThread(executor Executor, threadID string, includeMessages bool) (*ThreadInfo, error) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 
@@ -424,7 +328,7 @@ func GetThread(ctx context.Context, executor Executor, threadID string, includeM
 		Stderr:  &stderr,
 	}
 
-	if err := executor.Exec(ctx, opts); err != nil {
+	if err := executor.Exec(opts); err != nil {
 		return nil, fmt.Errorf("failed to get thread via agent: %w, stderr: %s", err, stderr.String())
 	}
 
@@ -440,15 +344,15 @@ func GetThread(ctx context.Context, executor Executor, threadID string, includeM
 	return &threads[0], nil
 }
 
-func GetThreadMessages(ctx context.Context, executor Executor, threadID string) ([]ThreadMessage, error) {
-	thread, err := GetThread(ctx, executor, threadID, true)
+func GetThreadMessages(executor Executor, threadID string) ([]ThreadMessage, error) {
+	thread, err := GetThread(executor, threadID, true)
 	if err != nil {
 		return nil, err
 	}
 	return thread.Messages, nil
 }
 
-func ConfigureGemini(ctx context.Context, sandbox *InteractiveSandbox) error {
+func (s *IssueSandbox) ConfigureGemini(ctx context.Context) error {
 	log := klog.FromContext(ctx)
 
 	// Configure gemini
@@ -482,7 +386,7 @@ func ConfigureGemini(ctx context.Context, sandbox *InteractiveSandbox) error {
 			return fmt.Errorf("marshaling gemini config: %w", err)
 		}
 
-		log.Info("Writing gemini config in pod", "pod", sandbox.podID)
+		log.Info("Writing gemini config in pod", "sandbox", s.GetSandboxID())
 
 		// if b0, err := sandbox.ReadFile(ctx, "/root/.gemini/settings.json"); err != nil {
 		// 	return fmt.Errorf("reading gemini config in pod: %w", err)
@@ -490,11 +394,11 @@ func ConfigureGemini(ctx context.Context, sandbox *InteractiveSandbox) error {
 		// 	klog.Infof("Existing gemini config: %s", string(b0))
 		// }
 
-		if err := sandbox.MkdirAll(ctx, "/root/.gemini"); err != nil {
+		if err := s.MkdirAll("/root/.gemini"); err != nil {
 			return fmt.Errorf("creating /root/.gemini directory in pod: %w", err)
 		}
 
-		if err := sandbox.WriteFile(ctx, "/root/.gemini/settings.json", b); err != nil {
+		if err := s.WriteFile("/root/.gemini/settings.json", b); err != nil {
 			return fmt.Errorf("writing gemini config in pod: %w", err)
 		}
 	}


### PR DESCRIPTION
- **pkg/github**: Create domain wrappers (`Issue`, `Repository`, `IssueComment`, `User`) around `go-github` types to encapsulate logic and simplify usage. Move issue URL parsing logic to `client.go`.
- **pkg/sandbox**:
    - Rename `InteractiveSandbox` to `IssueSandbox`.
    - Update `Executor` interface to hold `context.Context`, removing it from method signatures for cleaner call sites.
    - Add `ID()` method to `Executor`.
    - Update `IssueSandbox` to use new `github` domain types.
- **pkg/commands**:
    - Update `github-fix-issue` to use `IssueSandbox` and new `github` models.
    - Update `threads` commands (`list`, `get`, `append`) to match new `Executor` interface.
- **pkg/prompts**: Update `FixIssuePrompt` to use `FixIssueModel` with domain types.