### PR TITLE
refactor: extract fix-issue logic into Task abstraction

### DIFF
--- a/repo-agent/pkg/commands/github-fix-issue.go
+++ b/repo-agent/pkg/commands/github-fix-issue.go
@@ -1,19 +1,15 @@
 package commands
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
-	"time"
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/github"
-	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/prompts"
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/sandbox"
+	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/tasks"
 	"github.com/spf13/cobra"
-	"k8s.io/klog/v2"
 )
 
 // GithubFixIssueCommand holds options for the RunCode function.
@@ -128,149 +124,8 @@ func (c *GithubFixIssueCommand) loadSandbox(ctx context.Context) error {
 	return nil
 }
 
-func (c *GithubFixIssueCommand) SetupGit() error {
-	//log := klog.FromContext(ctx)
-
-	{
-		config := `github.com:
-    users:
-        {{UserID}}:
-            oauth_token: {{Token}}
-    git_protocol: https
-    oauth_token: {{Token}}
-    user: {{UserID}}
-`
-
-		if c.user.Token == "" {
-			return fmt.Errorf("user token is not set")
-		}
-
-		config = strings.ReplaceAll(config, "{{Token}}", c.user.Token)
-		config = strings.ReplaceAll(config, "{{UserID}}", c.user.UserID)
-
-		opts := sandbox.ExecOptions{
-			Command: []string{"mkdir", "-p", "/root/.config/gh"},
-		}
-		if err := c.sandbox.Exec(opts); err != nil {
-			return fmt.Errorf("creating /root/.config/gh directory: %w", err)
-		}
-
-		if err := c.sandbox.WriteFile("/root/.config/gh/hosts.yml", []byte(config)); err != nil {
-			return fmt.Errorf("writing gh config: %w", err)
-		}
-	}
-
-	// Run git config
-	{
-		opts := sandbox.ExecOptions{
-			Command: []string{"git", "config", "--global", "user.email", c.user.Email},
-		}
-		if err := c.sandbox.Exec(opts); err != nil {
-			return fmt.Errorf("running git config user.email: %w", err)
-		}
-		opts = sandbox.ExecOptions{
-			Command: []string{"git", "config", "--global", "user.name", c.user.Name},
-		}
-		if err := c.sandbox.Exec(opts); err != nil {
-			return fmt.Errorf("running git config user.name: %w", err)
-		}
-	}
-
-	// Run gh auth setup-git
-	{
-		opts := sandbox.ExecOptions{
-			Command: []string{"gh", "auth", "setup-git"},
-		}
-		if err := c.sandbox.Exec(opts); err != nil {
-			return fmt.Errorf("running gh auth setup-git: %w", err)
-		}
-	}
-
-	return nil
-}
-
-func (c *GithubFixIssueCommand) SetupGitRepos(ctx context.Context) error {
-	log := klog.FromContext(ctx)
-
-	workdir := fmt.Sprintf("/workspaces/%s", c.repo.Name())
-
-	// Run gh repo fork
-	log.Info("Forking repository", "sandbox", c.sandboxID, "repo", c.repo.CloneURL())
-	{
-		// TODO: Does gh support -C ?
-		opts := sandbox.ExecOptions{
-			Command: []string{"sh", "-c", fmt.Sprintf("cd %s && gh repo fork --remote", workdir)},
-		}
-		if err := c.sandbox.Exec(opts); err != nil {
-			return fmt.Errorf("running gh repo fork: %w", err)
-		}
-	}
-
-	// Setup default remote
-	{
-		defaultRepo := c.repo.CloneURL()
-
-		// TODO: Does gh support -C ?
-		opts := sandbox.ExecOptions{
-			Command: []string{"sh", "-c", fmt.Sprintf("cd %s && gh repo set-default %s", workdir, defaultRepo)},
-		}
-		if err := c.sandbox.Exec(opts); err != nil {
-			return fmt.Errorf("running gh repo fork: %w", err)
-		}
-
-	}
-
-	// Wait for checkout to complete
-	{
-		timeoutAt := time.Now().Add(time.Minute)
-		for {
-			log.Info("Waiting for checkout to be ready")
-
-			var stdout bytes.Buffer
-			opts := sandbox.ExecOptions{
-				Command: []string{"git", "-C", workdir, "branch", "--show-current"},
-				Stdout:  &stdout,
-			}
-			if err := c.sandbox.Exec(opts); err != nil {
-				klog.Infof("stdout: %v", stdout.String())
-				if time.Now().After(timeoutAt) {
-					return fmt.Errorf("timed out waiting for initial checkout to complete: %w", err)
-				}
-			} else {
-				klog.Infof("current branch: %v", stdout.String())
-				break
-			}
-
-			time.Sleep(2 * time.Second)
-		}
-	}
-
-	return nil
-}
-
-func (c *GithubFixIssueCommand) CheckoutNewBranch(ctx context.Context) error {
-	log := klog.FromContext(ctx)
-
-	workdir := fmt.Sprintf("/workspaces/%s", c.repo.Name())
-
-	branchName := fmt.Sprintf("issue_%d", c.issue.Number())
-
-	// Create a new branch
-	log.Info("Creating new branch", "sandbox", c.sandboxID, "branch", branchName)
-
-	opts := sandbox.ExecOptions{
-		Command: []string{"git", "-C", workdir, "checkout", "-b", branchName},
-	}
-	if err := c.sandbox.Exec(opts); err != nil {
-		return fmt.Errorf("creating new branch: %w", err)
-	}
-
-	return nil
-}
-
 // RunGithubFixIssue launches VS Code connected to the specified dev sandbox.
 func (c *GithubFixIssueCommand) Run(ctx context.Context) error {
-	log := klog.FromContext(ctx)
 
 	// Load data from github.com
 	err := c.loadGithubObjects(ctx)
@@ -284,63 +139,27 @@ func (c *GithubFixIssueCommand) Run(ctx context.Context) error {
 		return err
 	}
 
-	// setup git repo clone in sandbox
-	if err := c.SetupGit(); err != nil {
-		return fmt.Errorf("setting up git in sandbox: %w", err)
-	}
-
-	if err := c.SetupGitRepos(ctx); err != nil {
-		return fmt.Errorf("setting up git branches in sandbox: %w", err)
-	}
-
-	// HACK: Avoid git lock issues
-	time.Sleep(5 * time.Second)
-
-	if err := c.CheckoutNewBranch(ctx); err != nil {
-		return fmt.Errorf("checking out branch: %w", err)
-	}
-
-	// Prepare prompt
-	model := prompts.FixIssueModel{
-		Issue:         c.issue,
-		IssueComments: c.issue.IssueComments,
-		Repo:          c.repo,
-	}
-	prompt, err := prompts.FixIssuePrompt(model)
-	if err != nil {
-		return fmt.Errorf("failed to generate prompt for issue: %w", err)
-	}
-
-	log.Info("copying prompt into sandbox", "sandbox", c.sandboxID)
-
 	promptPath := c.taskPath("agent-prompt.txt")
-	if err := c.sandbox.WriteFile(promptPath, prompt); err != nil {
-		return fmt.Errorf("copying prompt into sandbox: %w", err)
-	}
-
-	log.Info("Copied prompt into sandbox", "sandbox", c.sandboxID, "path", promptPath)
-
-	if err := c.sandbox.ConfigureGemini(ctx); err != nil {
-		return fmt.Errorf("configuring gemini in sandbox: %w", err)
+	task := tasks.FixIssueModel{
+		Issue:         c.issue,
+		Repo:          c.repo,
+		User:          c.user,
+		IssueComments: c.issue.IssueComments,
+		PromptFile:    promptPath,
 	}
 
 	apikey, err := GetGeminiAPIKey(c.sandboxID)
 	if err != nil {
 		return err
 	}
-	log.Info("Running gemini in sandbox", "sandbox", c.sandboxID)
 
-	workdir := fmt.Sprintf("/workspaces/%s", c.repo.Name())
-
-	opts := sandbox.ExecOptions{
-		Command: []string{"sh", "-c", fmt.Sprintf("cd %s && export GEMINI_API_KEY=%s && gemini --yolo --model gemini-3-pro-preview < %s", workdir, apikey, promptPath)},
-		Stdout:  os.Stdout,
-		Stderr:  os.Stderr,
+	env := map[string]string{
+		"GEMINI_API_KEY":    apikey,
+		"GITHUB_USER_TOKEN": c.GithubUserToken,
 	}
-	opts.Secrets = []string{apikey}
-
-	if err := c.sandbox.Exec(opts); err != nil {
-		return fmt.Errorf("running gemini: %w", err)
+	err = tasks.RunTask(ctx, &task, c.sandbox, c.TaskDir, env)
+	if err != nil {
+		return fmt.Errorf("running fix-issue task: %w", err)
 	}
 
 	return nil

--- a/repo-agent/pkg/sandbox/exec.go
+++ b/repo-agent/pkg/sandbox/exec.go
@@ -33,10 +33,10 @@ type Executor interface {
 type ExecOptions struct {
 	Command []string
 	Secrets []string
-
-	Stdin  []byte
-	Stdout io.Writer
-	Stderr io.Writer
+	Stdin   []byte
+	Stdout  io.Writer
+	Stderr  io.Writer
+	Env     map[string]string
 }
 
 // PodExecutor implements Executor for running commands in a Kubernetes pod.
@@ -92,6 +92,13 @@ func (e *LocalExecutor) Exec(opts ExecOptions) error {
 		cmd.Dir = e.WorkDir
 	}
 
+	if len(opts.Env) > 0 {
+		env := os.Environ()
+		for k, v := range opts.Env {
+			env = append(env, fmt.Sprintf("%s=%s", k, v))
+		}
+		cmd.Env = env
+	}
 	if opts.Stdin != nil {
 		cmd.Stdin = bytes.NewReader(opts.Stdin)
 	}
@@ -114,7 +121,7 @@ func (e *LocalExecutor) Exec(opts ExecOptions) error {
 		redactedCommand = strings.ReplaceAll(redactedCommand, v, "****")
 	}
 
-	log.Info("Executing local command", "command", redactedCommand, "dir", e.WorkDir)
+	log.Info("Executing local command", "command", redactedCommand, "dir", cmd.Dir)
 
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("executing local command %q: %w", redactedCommand, err)
@@ -152,9 +159,22 @@ func ExecInPod(ctx context.Context, kube *clients.KubernetesClient, podID types.
 		redactedCommand = strings.ReplaceAll(redactedCommand, v, "****")
 	}
 
+	command := opts.Command
+	if len(opts.Env) > 0 {
+		envCommands := []string{}
+		for k, v := range opts.Env {
+			envCommands = append(envCommands, fmt.Sprintf("export %s=%q", k, v))
+		}
+		// Prepend the env commands to the original command
+		shellCommand := strings.Join(envCommands, " && ") + " && " + strings.Join(command, " ")
+		command = []string{"sh", "-c", shellCommand}
+	}
+
+	log.Info("Executing command in pod", "pod", podID, "command", redactedCommand)
+
 	podExecOptions := &v1.PodExecOptions{
 		// Container: containerName,
-		Command: opts.Command,
+		Command: command,
 		Stdin:   true,
 		Stdout:  true,
 		Stderr:  true,
@@ -163,7 +183,6 @@ func ExecInPod(ctx context.Context, kube *clients.KubernetesClient, podID types.
 	if opts.Stdin == nil {
 		podExecOptions.Stdin = false
 	}
-
 	req := kube.Clientset.CoreV1().RESTClient().Post().
 		Resource("pods").
 		Name(podID.Name).

--- a/repo-agent/pkg/tasks/fix_issue.go
+++ b/repo-agent/pkg/tasks/fix_issue.go
@@ -1,0 +1,49 @@
+package tasks
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/github"
+	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/prompts"
+)
+
+var _ Task = &FixIssueModel{}
+
+type FixIssueModel struct {
+	Issue         *github.Issue
+	Repo          *github.Repository
+	IssueComments []github.IssueComment
+	User          *github.User
+	PromptFile    string
+}
+
+func (m *FixIssueModel) Name() string {
+	return "fix-issue"
+}
+
+func (m *FixIssueModel) PreScript() ([]byte, error) {
+	tmpl, err := getTemplate("fix_issue.sh")
+	if err != nil {
+		return nil, err
+	}
+	var w bytes.Buffer
+	if err := tmpl.Execute(&w, m); err != nil {
+		return nil, fmt.Errorf("failed to execute prompt template: %w", err)
+	}
+	return w.Bytes(), nil
+}
+
+func (m *FixIssueModel) Prompt() ([]byte, error) {
+	return prompts.FixIssuePrompt(
+		prompts.FixIssueModel{
+			Issue:         m.Issue,
+			Repo:          m.Repo,
+			IssueComments: m.IssueComments,
+		},
+	)
+}
+
+func (m *FixIssueModel) PostScript() ([]byte, error) {
+	return nil, nil
+}

--- a/repo-agent/pkg/tasks/fix_issue.sh
+++ b/repo-agent/pkg/tasks/fix_issue.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+set -e
+
+# It expects the following environment variables to be set:
+# - GEMINI_API_KEY
+# - GITHUB_USER_TOKEN
+
+export REPO_NAME="{{ .Repo.Name }}"
+export CLONE_URL={{ .Repo.CloneURL }}
+export ISSUE_NUMBER={{ .Issue.Number }}
+export PROMPT_FILE="{{ .PromptFile }}""
+export GITHUB_USER_ID={{ .User.UserID }}
+export GITHUB_USER_EMAIL={{ .User.Email }}
+export GITHUB_USER_NAME="{{ .User.Name }}"
+
+function setupGit() {
+    echo "Running setupGit..."
+    echo "creating /root/.config/gh directory"
+    mkdir -p /root/.config/gh
+
+    echo "writing gh config"
+    cat <<EOF > /root/.config/gh/hosts.yml
+github.com:
+    users:
+        ${GITHUB_USER_ID}:
+            oauth_token: ${GITHUB_USER_TOKEN}
+    git_protocol: https
+    oauth_token: ${GITHUB_USER_TOKEN}
+    user: ${GITHUB_USER_ID}
+EOF
+
+    echo "running git config user.email"
+    git config --global user.email ${GITHUB_USER_EMAIL}
+
+    echo "running git config user.name"
+    git config --global user.name ${GITHUB_USER_NAME}
+
+    echo "running gh auth setup-git"
+    gh auth setup-git
+}
+
+function setupGitRepos() {
+    echo "Running setupGitRepos..."
+    
+    echo "running gh repo fork"
+    (cd "/workspaces/${REPO_NAME}" && gh repo fork --remote)
+
+    echo "running gh repo set-default"
+    (cd "/workspaces/${REPO_NAME}" && gh repo set-default "${CLONE_URL}")
+
+    echo "waiting for checkout to be ready (branch check)"
+    (cd "/workspaces/${REPO_NAME}" && git branch --show-current)
+}
+
+function checkoutNewBranch() {
+    echo "Running checkoutNewBranch..."
+    echo "creating new branch"
+    (cd "/workspaces/${REPO_NAME}" && git checkout -b "issue_${ISSUE_NUMBER}")
+}
+
+function configureGemini() {
+    echo "Running configureGemini..."
+    echo "creating /root/.gemini directory"
+    mkdir -p /root/.gemini
+
+    echo "writing gemini config"
+    cat <<EOF > /root/.gemini/settings.json
+{
+  "general": {
+    "enableAutoUpdate": false,
+    "retryFetchErrors": true
+  }
+}
+EOF
+}
+
+function runGemini() {
+    echo "Running runGemini..."
+    echo "running gemini in yolo mode"
+    (cd "/workspaces/${REPO_NAME}" && export GEMINI_API_KEY="${GEMINI_API_KEY}" && gemini --yolo --model gemini-3-pro-preview < ${PROMPT_FILE})
+}
+
+# Main execution
+setupGit
+setupGitRepos
+# HACK: Avoid git lock issues
+sleep 5
+checkoutNewBranch
+configureGemini
+runGemini

--- a/repo-agent/pkg/tasks/tasks.go
+++ b/repo-agent/pkg/tasks/tasks.go
@@ -1,0 +1,96 @@
+package tasks
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/sandbox"
+	"k8s.io/klog/v2"
+)
+
+type Task interface {
+	PreScript() ([]byte, error)
+	Prompt() ([]byte, error)
+	PostScript() ([]byte, error)
+}
+
+func taskPath(taskDir string, name string, args ...interface{}) string {
+	// Ensure the task path is correctly joined
+	file := fmt.Sprintf(name, args...)
+	return filepath.Join(taskDir, file)
+}
+
+func RunTask(ctx context.Context, t Task, sb *sandbox.IssueSandbox, taskDir string, env map[string]string) error {
+	log := klog.FromContext(ctx)
+	// Implementation of task execution logic would go here.
+	taskScript, err := t.PreScript()
+	if err != nil {
+		return err
+	}
+
+	prompt, err := t.Prompt()
+	if err != nil {
+		return err
+	}
+
+	postScript, err := t.PostScript()
+	if err != nil {
+		return err
+	}
+
+	log.Info("copying prompt into sandbox", "sandbox", sb.GetSandboxID())
+	promptPath := taskPath(taskDir, "agent-prompt.txt")
+	if err := sb.WriteFile(promptPath, prompt); err != nil {
+		return fmt.Errorf("copying prompt into sandbox: %w", err)
+	}
+	log.Info("Copied prompt into sandbox", "sandbox", sb.GetSandboxID(), "path", promptPath)
+
+	log.Info("copying pre-script into sandbox", "sandbox", sb.GetSandboxID())
+	preScriptPath := taskPath(taskDir, "pre-script.sh")
+	if err := sb.WriteFile(preScriptPath, taskScript); err != nil {
+		return fmt.Errorf("copying pre-script into sandbox: %w", err)
+	}
+	log.Info("Copied pre-script into sandbox", "sandbox", sb.GetSandboxID(), "path", preScriptPath)
+
+	postScriptPath := ""
+	if postScript != nil {
+		log.Info("copying post-script into sandbox", "sandbox", sb.GetSandboxID())
+		postScriptPath = taskPath(taskDir, "post-script.sh")
+		if err := sb.WriteFile(postScriptPath, postScript); err != nil {
+			return fmt.Errorf("copying post-script into sandbox: %w", err)
+		}
+		log.Info("Copied post-script into sandbox", "sandbox", sb.GetSandboxID(), "path", postScriptPath)
+	}
+
+	// Run the pre-script
+	log.Info("running pre-script in sandbox", "sandbox", sb.GetSandboxID())
+	opts := sandbox.ExecOptions{
+		Command: []string{"sh", preScriptPath},
+		Stdout:  os.Stdout,
+		Stderr:  os.Stderr,
+		Env:     env,
+	}
+	if err := sb.Exec(opts); err != nil {
+		return fmt.Errorf("running gemini: %w", err)
+	}
+	log.Info("Completed pre-script in sandbox", "sandbox", sb.GetSandboxID())
+
+	// Run the post-script if it exists
+	if postScriptPath != "" {
+		log.Info("running post-script in sandbox", "sandbox", sb.GetSandboxID())
+		opts := sandbox.ExecOptions{
+			Command: []string{"sh", postScriptPath},
+			Stdout:  os.Stdout,
+			Stderr:  os.Stderr,
+			Env:     env,
+		}
+		if err := sb.Exec(opts); err != nil {
+			return fmt.Errorf("running post-script: %w", err)
+		}
+		log.Info("Completed post-script in sandbox", "sandbox", sb.GetSandboxID())
+	}
+
+	return nil
+}

--- a/repo-agent/pkg/tasks/templates.go
+++ b/repo-agent/pkg/tasks/templates.go
@@ -1,0 +1,31 @@
+package tasks
+
+import (
+	"embed"
+	_ "embed"
+	"text/template"
+)
+
+//go:embed *.sh
+var templatesFS embed.FS
+
+var templates = make(map[string]*template.Template)
+
+func getTemplate(name string) (*template.Template, error) {
+	if t, ok := templates[name]; ok {
+		return t, nil
+	}
+
+	data, err := templatesFS.ReadFile(name)
+	if err != nil {
+		return nil, err
+	}
+
+	t, err := template.New(name).Parse(string(data))
+	if err != nil {
+		return nil, err
+	}
+
+	templates[name] = t
+	return t, nil
+}


### PR DESCRIPTION
Refactors the GithubFixIssueCommand to utilize a new Task interface, moving orchestration logic out of the command handler.

Key changes:
- Introduced pkg/tasks with a Task interface and RunTask helper to manage prompt/script lifecycle in the sandbox.
- Implemented FixIssueModel (in pkg/tasks/fix_issue.go) to encapsulate the fix-issue logic.
- Moved shell commands for git setup and Gemini execution into a template fix_issue.sh.
- Updated sandbox.ExecOptions to support environment variables (Env) for secure secret passing.