### PR TITLE
fix: Improve github-fix-issue task and sandbox execution

### DIFF
--- a/repo-agent/cmd/repo-sandbox/issue-sandbox-rgd.yaml
+++ b/repo-agent/cmd/repo-sandbox/issue-sandbox-rgd.yaml
@@ -116,6 +116,8 @@ spec:
                       value: ${schema.spec.destination.branch}
                     - name: GIT_HTML_URL
                       value: ${schema.spec.source.htmlURL}
+                    - name: ISSUE_URL
+                      value: ${schema.spec.source.htmlURL}
                     - name: GITHUB_USER_ORIGIN
                       value: ${schema.spec.destination.origin}
                     - name: GITHUB_USER_LOGIN

--- a/repo-agent/k8s/issue-sandbox-rgd.yaml
+++ b/repo-agent/k8s/issue-sandbox-rgd.yaml
@@ -116,6 +116,8 @@ spec:
                       value: ${schema.spec.destination.branch}
                     - name: GIT_HTML_URL
                       value: ${schema.spec.source.htmlURL}
+                    - name: ISSUE_URL
+                      value: ${schema.spec.source.htmlURL}
                     - name: GITHUB_USER_ORIGIN
                       value: ${schema.spec.destination.origin}
                     - name: GITHUB_USER_LOGIN

--- a/repo-agent/pkg/commands/geminikey.go
+++ b/repo-agent/pkg/commands/geminikey.go
@@ -12,6 +12,13 @@ import (
 func GetGeminiAPIKey(seed string) (string, error) {
 	s := os.Getenv("GEMINI_API_KEY")
 	if s == "" {
+		// read from /tokens/gemini file if it exists
+		data, err := os.ReadFile("/tokens/gemini")
+		if err == nil {
+			s = strings.TrimSpace(string(data))
+		}
+	}
+	if s == "" {
 		return "", fmt.Errorf("GEMINI_API_KEY environment variable is not set")
 	}
 	if suffix, ok := strings.CutPrefix(s, "exec:"); ok {

--- a/repo-agent/pkg/commands/github-fix-issue.go
+++ b/repo-agent/pkg/commands/github-fix-issue.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/sandbox"
 	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/tasks"
 	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
 )
 
 // GithubFixIssueCommand holds options for the RunCode function.
@@ -76,9 +77,6 @@ func (c *GithubFixIssueCommand) InitDefaults() {
 	if c.TaskDir == "" {
 		c.TaskDir = c.WorkspaceDir
 	}
-	if c.GithubUserToken == "" {
-		c.GithubUserToken = os.Getenv("GITHUB_USER_TOKEN")
-	}
 }
 
 func (c *GithubFixIssueCommand) taskPath(name string, args ...interface{}) string {
@@ -88,6 +86,13 @@ func (c *GithubFixIssueCommand) taskPath(name string, args ...interface{}) strin
 }
 
 func (c *GithubFixIssueCommand) loadGithubObjects(ctx context.Context) error {
+	// Get github token
+	token, err := github.GetGithubToken(ctx)
+	if err != nil {
+		return err
+	}
+	c.GithubUserToken = token
+
 	githubAPI, err := github.NewClient(context.Background())
 	if err != nil {
 		return err
@@ -126,7 +131,8 @@ func (c *GithubFixIssueCommand) loadSandbox(ctx context.Context) error {
 
 // RunGithubFixIssue launches VS Code connected to the specified dev sandbox.
 func (c *GithubFixIssueCommand) Run(ctx context.Context) error {
-
+	log := klog.FromContext(ctx)
+	log.Info("Starting github-fix-issue task", "taskdir", c.TaskDir)
 	// Load data from github.com
 	err := c.loadGithubObjects(ctx)
 	if err != nil {

--- a/repo-agent/pkg/github/client.go
+++ b/repo-agent/pkg/github/client.go
@@ -13,16 +13,33 @@ import (
 	githubv39 "github.com/google/go-github/v39/github"
 )
 
-func NewClient(ctx context.Context) (*Client, error) {
-	githubCommand := exec.CommandContext(ctx, "gh", "auth", "token")
-	var stdout bytes.Buffer
-	githubCommand.Stdout = &stdout
-	githubCommand.Stderr = os.Stderr
-	if err := githubCommand.Run(); err != nil {
-		return nil, fmt.Errorf("unable to get github credentials (with gh auth token command): %w", err)
+func GetGithubToken(ctx context.Context) (string, error) {
+	token := os.Getenv("MANUAL_PAT")
+	if token == "" {
+		token = os.Getenv("GITHUB_TOKEN")
 	}
+	if token == "" {
+		token = os.Getenv("OAUTH_PAT")
+	}
+	if token == "" {
+		githubCommand := exec.CommandContext(ctx, "gh", "auth", "token")
+		var stdout bytes.Buffer
+		githubCommand.Stdout = &stdout
+		githubCommand.Stderr = os.Stderr
+		if err := githubCommand.Run(); err != nil {
+			return "", fmt.Errorf("unable to get github credentials (with gh auth token command): %w", err)
+		}
 
-	token := strings.TrimSpace(stdout.String())
+		token = strings.TrimSpace(stdout.String())
+	}
+	return token, nil
+}
+
+func NewClient(ctx context.Context) (*Client, error) {
+	token, err := GetGithubToken(ctx)
+	if err != nil {
+		return nil, err
+	}
 	return &Client{
 		Client: clients.NewGitHubClient(ctx, token),
 	}, nil

--- a/repo-agent/pkg/sandbox/exec.go
+++ b/repo-agent/pkg/sandbox/exec.go
@@ -25,6 +25,7 @@ import (
 type Executor interface {
 	Exec(opts ExecOptions) error
 	WriteFile(path string, data []byte) error
+	WriteXFile(path string, data []byte) error
 	ReadFile(path string) ([]byte, error)
 	ID() string
 }
@@ -58,6 +59,24 @@ func (e *PodExecutor) WriteFile(path string, data []byte) error {
 	return WriteFileInPod(e.Ctx, e.Kube, e.PodID, path, data)
 }
 
+func (e *PodExecutor) WriteXFile(path string, data []byte) error {
+	err := WriteFileInPod(e.Ctx, e.Kube, e.PodID, path, data)
+	if err != nil {
+		return err
+	}
+
+	// Set executable permissions
+	chmodCmd := []string{"chmod", "0755", path}
+	execOpts := ExecOptions{
+		Command: chmodCmd,
+	}
+	if err := e.Exec(execOpts); err != nil {
+		return fmt.Errorf("setting executable permissions on file %q in pod: %w", path, err)
+	}
+	return nil
+
+}
+
 func (e *PodExecutor) ReadFile(path string) ([]byte, error) {
 	var stdout bytes.Buffer
 	opts := ExecOptions{
@@ -72,9 +91,8 @@ func (e *PodExecutor) ReadFile(path string) ([]byte, error) {
 
 // LocalExecutor implements Executor for running commands locally.
 type LocalExecutor struct {
-	Ctx     context.Context
-	WorkDir string
-	Name    string
+	Ctx  context.Context
+	Name string
 }
 
 func (e *LocalExecutor) ID() string {
@@ -88,17 +106,16 @@ func (e *LocalExecutor) Exec(opts ExecOptions) error {
 	args := opts.Command[1:]
 
 	cmd := exec.CommandContext(e.Ctx, name, args...)
-	if e.WorkDir != "" {
-		cmd.Dir = e.WorkDir
-	}
 
+	// Environment variables
+	env := os.Environ()
 	if len(opts.Env) > 0 {
-		env := os.Environ()
 		for k, v := range opts.Env {
 			env = append(env, fmt.Sprintf("%s=%s", k, v))
 		}
-		cmd.Env = env
 	}
+	cmd.Env = env
+
 	if opts.Stdin != nil {
 		cmd.Stdin = bytes.NewReader(opts.Stdin)
 	}
@@ -113,8 +130,6 @@ func (e *LocalExecutor) Exec(opts ExecOptions) error {
 		cmd.Stderr = os.Stderr
 	}
 
-	// Environment? We might want to inherit or set.
-	cmd.Env = os.Environ()
 	// Filter secrets from logging?
 	redactedCommand := strings.Join(opts.Command, " ")
 	for _, v := range opts.Secrets {
@@ -129,11 +144,20 @@ func (e *LocalExecutor) Exec(opts ExecOptions) error {
 	return nil
 }
 
+func (e *LocalExecutor) WriteXFile(path string, data []byte) error {
+	err := e.WriteFile(path, data)
+	if err != nil {
+		return err
+	}
+
+	// Set executable permissions
+	if err := os.Chmod(path, 0755); err != nil {
+		return fmt.Errorf("setting executable permissions on file %q: %w", path, err)
+	}
+	return nil
+}
+
 func (e *LocalExecutor) WriteFile(path string, data []byte) error {
-	// If path is absolute, use it? Or relative to WorkDir?
-	// The paths in our code are often absolute container paths like /workspaces/...
-	// For local execution, we might need to map these or just assume user knows what they are doing.
-	// For now, let's just write to the path.
 
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0755); err != nil {

--- a/repo-agent/pkg/sandbox/interactive.go
+++ b/repo-agent/pkg/sandbox/interactive.go
@@ -43,9 +43,8 @@ func NewIssueSandbox(ctx context.Context, local bool, repo *github.Repository, i
 			repo:  repo,
 			issue: issue,
 			executor: &LocalExecutor{
-				Ctx:     ctx,
-				Name:    fmt.Sprintf("local-%s/issue/%d", repo.Name(), issue.Number()),
-				WorkDir: fmt.Sprintf("/workspaces/%s", repo.Name()),
+				Ctx:  ctx,
+				Name: fmt.Sprintf("local-%s/issue/%d", repo.Name(), issue.Number()),
 			},
 			user: user,
 		}, nil
@@ -104,6 +103,13 @@ func (s *IssueSandbox) MkdirAll(path string) error {
 func (s *IssueSandbox) WriteFile(path string, data []byte) error {
 	if err := s.executor.WriteFile(path, data); err != nil {
 		return fmt.Errorf("writing file %q: %w", path, err)
+	}
+	return nil
+}
+
+func (s *IssueSandbox) WriteXFile(path string, data []byte) error {
+	if err := s.executor.WriteXFile(path, data); err != nil {
+		return fmt.Errorf("writing executable script %q: %w", path, err)
 	}
 	return nil
 }

--- a/repo-agent/pkg/taskrunner/runner.go
+++ b/repo-agent/pkg/taskrunner/runner.go
@@ -151,6 +151,18 @@ func (tr *TaskRunner) executeTask(ctx context.Context, task *unstructured.Unstru
 			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", strings.ToUpper(k), v))
 		}
 
+	case "github-fix-issue":
+		cmd = exec.Command("/opt/repo-agent/repo-sandbox", "github-fix-issue", "--in-pod=true")
+		// Map params to env vars
+		cmd.Env = os.Environ()
+		cmd.Env = append(cmd.Env, "AGENT_OUTPUT_GVR_RESOURCE=sandboxtasks")
+		cmd.Env = append(cmd.Env, "AGENT_OUTPUT_GVR_GROUP=custom.agents.x-k8s.io")
+		cmd.Env = append(cmd.Env, "AGENT_OUTPUT_GVR_VERSION=v1alpha1")
+		// Inject params into env
+		for k, v := range params {
+			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", strings.ToUpper(k), v))
+		}
+
 	case "issue":
 		cmd = exec.Command("/opt/repo-agent/repo-sandbox", "dev")
 		// Map params to env vars
@@ -163,6 +175,7 @@ func (tr *TaskRunner) executeTask(ctx context.Context, task *unstructured.Unstru
 			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", strings.ToUpper(k), v))
 		}
 
+	// TODO (barney-s): Pending decision: Should we support script tasks ?
 	case "script":
 		if command, ok := params["command"]; ok {
 			cmd = exec.Command("/bin/sh", "-c", command)

--- a/repo-agent/pkg/tasks/fix_issue.sh
+++ b/repo-agent/pkg/tasks/fix_issue.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -x
 
 # It expects the following environment variables to be set:
 # - GEMINI_API_KEY
@@ -8,12 +9,12 @@ set -e
 export REPO_NAME="{{ .Repo.Name }}"
 export CLONE_URL={{ .Repo.CloneURL }}
 export ISSUE_NUMBER={{ .Issue.Number }}
-export PROMPT_FILE="{{ .PromptFile }}""
+export PROMPT_FILE="{{ .PromptFile }}"
 export GITHUB_USER_ID={{ .User.UserID }}
 export GITHUB_USER_EMAIL={{ .User.Email }}
 export GITHUB_USER_NAME="{{ .User.Name }}"
 
-function setupGit() {
+function setupGit {
     echo "Running setupGit..."
     echo "creating /root/.config/gh directory"
     mkdir -p /root/.config/gh
@@ -39,9 +40,13 @@ EOF
     gh auth setup-git
 }
 
-function setupGitRepos() {
+function setupGitRepos {
     echo "Running setupGitRepos..."
     
+    echo "cloning repository"
+    (cd /workspaces/ && git clone ${CLONE_URL})
+
+    (cd "/workspaces/${REPO_NAME}" && gh repo fork --remote)
     echo "running gh repo fork"
     (cd "/workspaces/${REPO_NAME}" && gh repo fork --remote)
 
@@ -52,13 +57,13 @@ function setupGitRepos() {
     (cd "/workspaces/${REPO_NAME}" && git branch --show-current)
 }
 
-function checkoutNewBranch() {
+function checkoutNewBranch {
     echo "Running checkoutNewBranch..."
     echo "creating new branch"
     (cd "/workspaces/${REPO_NAME}" && git checkout -b "issue_${ISSUE_NUMBER}")
 }
 
-function configureGemini() {
+function configureGemini {
     echo "Running configureGemini..."
     echo "creating /root/.gemini directory"
     mkdir -p /root/.gemini
@@ -74,7 +79,7 @@ function configureGemini() {
 EOF
 }
 
-function runGemini() {
+function runGemini {
     echo "Running runGemini..."
     echo "running gemini in yolo mode"
     (cd "/workspaces/${REPO_NAME}" && export GEMINI_API_KEY="${GEMINI_API_KEY}" && gemini --yolo --model gemini-3-pro-preview < ${PROMPT_FILE})

--- a/repo-agent/pkg/tasks/tasks.go
+++ b/repo-agent/pkg/tasks/tasks.go
@@ -49,7 +49,7 @@ func RunTask(ctx context.Context, t Task, sb *sandbox.IssueSandbox, taskDir stri
 
 	log.Info("copying pre-script into sandbox", "sandbox", sb.GetSandboxID())
 	preScriptPath := taskPath(taskDir, "pre-script.sh")
-	if err := sb.WriteFile(preScriptPath, taskScript); err != nil {
+	if err := sb.WriteXFile(preScriptPath, taskScript); err != nil {
 		return fmt.Errorf("copying pre-script into sandbox: %w", err)
 	}
 	log.Info("Copied pre-script into sandbox", "sandbox", sb.GetSandboxID(), "path", preScriptPath)
@@ -58,7 +58,7 @@ func RunTask(ctx context.Context, t Task, sb *sandbox.IssueSandbox, taskDir stri
 	if postScript != nil {
 		log.Info("copying post-script into sandbox", "sandbox", sb.GetSandboxID())
 		postScriptPath = taskPath(taskDir, "post-script.sh")
-		if err := sb.WriteFile(postScriptPath, postScript); err != nil {
+		if err := sb.WriteXFile(postScriptPath, postScript); err != nil {
 			return fmt.Errorf("copying post-script into sandbox: %w", err)
 		}
 		log.Info("Copied post-script into sandbox", "sandbox", sb.GetSandboxID(), "path", postScriptPath)
@@ -67,7 +67,7 @@ func RunTask(ctx context.Context, t Task, sb *sandbox.IssueSandbox, taskDir stri
 	// Run the pre-script
 	log.Info("running pre-script in sandbox", "sandbox", sb.GetSandboxID())
 	opts := sandbox.ExecOptions{
-		Command: []string{"sh", preScriptPath},
+		Command: []string{preScriptPath},
 		Stdout:  os.Stdout,
 		Stderr:  os.Stderr,
 		Env:     env,
@@ -81,7 +81,7 @@ func RunTask(ctx context.Context, t Task, sb *sandbox.IssueSandbox, taskDir stri
 	if postScriptPath != "" {
 		log.Info("running post-script in sandbox", "sandbox", sb.GetSandboxID())
 		opts := sandbox.ExecOptions{
-			Command: []string{"sh", postScriptPath},
+			Command: []string{postScriptPath},
 			Stdout:  os.Stdout,
 			Stderr:  os.Stderr,
 			Env:     env,

--- a/repo-agent/pkg/templates/data/repo-agent.yaml
+++ b/repo-agent/pkg/templates/data/repo-agent.yaml
@@ -28,58 +28,22 @@ spec:
 
         Read @.gemini/user-instructions.json for specific review instructions tuned for this repository.
 
-    maxActiveSandboxes: 3
-    maxSandboxes: 5
+    maxActiveSandboxes: 1
+    maxSandboxes: 1
   issue:
     maxActiveSandboxes: 1
     maxSandboxes: 3
-    issueShutdownAfterMinutes: 30
+    issueShutdownAfterMinutes: 300
     image: ghcr.io/gke-labs/gemini-for-kubernetes-development/generic-golang:latest
     llm:
         apiKeySecretRef: gemini-vscode-tokens
     handlers:
-    - prompt: >-
-          You are a helpful assistant that triages GitHub issues for a
-          Kubernetes-related open source project. Your task is to categorize
-          incoming issues based on their content and assign appropriate labels.
-          Analyze the issue title and body to determine the most relevant
-          category from the following options: 1. bug: Issues that describe
-          unexpected behavior, errors, or malfunctions in the software. 2.
-          feature: Suggestions for new features, enhancements, or improvements
-          to existing functionality. 2. cleanup: Suggestions for cleaning up
-          code, removing deprecated features, or improving code quality. 3.
-          document: Issues related to documentation errors, omissions, or
-          requests for clarification. 4. support: Questions or requests for help
-          regarding the use of the software. 5. other: Any issue that does not
-          fit into the above categories.
-
-          Start the response with "/kind <Category>" where <Category> is one of
-          bug , feature , document, support, cleanup or other In the next line,
-          provide a concise explanation of your reasoning for the assigned
-          category.
-
-          Issue Title: "{{.Title}}" Issue Body: "{{.Body}}" HTML URL:
-          "{{.HTMLURL}}"
-      name: triage
-    - name: fixes
-      pushEnabled: true
+    - name: issue-fixer
+      taskType: github-fix-issue
       labels:
-        - ""
+        - "fixme"
       prompt: |
-          You are an expert software engineer specializing in debugging and fixing issues in Kubernetes-related open source projects.
-          This repo you are working on Gemini for Kubernetes development is a kubernetes sigs project to help run review and issue agents on a repo.
-          Read the README to understand the architecture.
-          Your task is to analyze the issue and provide a detailed plan to fix the reported problems.
-          The repo code is available locally for reference. Please look at the code as well as git history to understand the context of the issue. 
-          Review the issue title and body to understand the problem, then outline the steps needed to resolve it, including any code changes, documentation updates required.
-          Then go ahead and make those changes in the local folder.
-          Commit the changes with a meaningful commit message.
-          Do not attempt to push any changes.
-          So plan and the implement the changes.
-          If needed look at the comments on the issue linked here for more context: {{.HTMLURL}}
-          Issue Title: "{{.Title}}"
-          Issue Body: "{{.Body}}"
-          HTML URL: "{{.HTMLURL}}"
+          Fix this issue
 ---
 apiVersion: configdir.gke.io/v1alpha1
 kind: ConfigDir


### PR DESCRIPTION
Running github-fix-issue built in command 

With this fix we are able to generate a PR: #371 << generated by repo-agent

- Add WriteXFile to Executor to support writing executable files.
- Refactor GitHub token resolution to prioritize env vars over 'gh auth token'.
- Update fix_issue.sh with better git setup and model selection.
- Configure repo-agent example to use github-fix-issue task for 'fixme' label.
- Enhance LocalExecutor and PodExecutor environment handling.