### PR TITLE
feat(review-api): Add task logs proxy endpoint and UI viewer

### DIFF
--- a/repo-agent/cmd/repo-sandbox/review-sandbox-rgd.yaml
+++ b/repo-agent/cmd/repo-sandbox/review-sandbox-rgd.yaml
@@ -160,6 +160,7 @@ spec:
                       mountPath: /opt/repo-agent
                   ports:
                     - containerPort: 13337
+                    - containerPort: 13339
               volumes:
               - name: agent-bin
                 emptyDir: {}
@@ -190,11 +191,16 @@ spec:
           selector:
             sandbox: devc-${schema.metadata.name}
           ports:
-            - protocol: TCP
+            - name: code-server
+              protocol: TCP
               port: 13338
               targetPort: 13337
               appProtocol: kubernetes.io/ws
               #appProtocol: kubernetes.io/h2c
+            - name: agent-server
+              protocol: TCP
+              port: 13339
+              targetPort: 13339
     - id: nwpolicy
       includeWhen:
         - ${schema.spec.networkPolicy.enabled}

--- a/repo-agent/k8s/review-sandbox-rgd.yaml
+++ b/repo-agent/k8s/review-sandbox-rgd.yaml
@@ -160,6 +160,7 @@ spec:
                       mountPath: /opt/repo-agent
                   ports:
                     - containerPort: 13337
+                    - containerPort: 13339
               volumes:
               - name: agent-bin
                 emptyDir: {}
@@ -190,11 +191,16 @@ spec:
           selector:
             sandbox: devc-${schema.metadata.name}
           ports:
-            - protocol: TCP
+            - name: code-server
+              protocol: TCP
               port: 13338
               targetPort: 13337
               appProtocol: kubernetes.io/ws
               #appProtocol: kubernetes.io/h2c
+            - name: agent-server
+              protocol: TCP
+              port: 13339
+              targetPort: 13339
     - id: nwpolicy
       includeWhen:
         - ${schema.spec.networkPolicy.enabled}

--- a/repo-agent/pkg/api/handlers_pr.go
+++ b/repo-agent/pkg/api/handlers_pr.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
 	"sort"
 	"strconv"
 	"time"
@@ -504,4 +506,43 @@ func (s *Server) getPRDetails(c *gin.Context) {
 		"title":   pr.GetTitle(),
 		"htmlURL": pr.GetHTMLURL(),
 	})
+}
+
+func (s *Server) getTaskLogs(c *gin.Context) {
+	log := klog.FromContext(c.Request.Context())
+	namespace := c.MustGet(auth.UserKey).(string)
+	repo := c.Param("repo")
+	prID := c.Param("id")
+	taskID := c.Param("taskID")
+
+	sandboxName := fmt.Sprintf("%s-pr-%s", repo, prID)
+	// Service name logic must match KRO's RGD: devc-${schema.metadata.name}-lb
+	serviceName := fmt.Sprintf("devc-%s-lb", sandboxName)
+
+	targetURL := fmt.Sprintf("http://%s.%s.svc.cluster.local:13339", serviceName, namespace)
+
+	proxyURL, err := url.Parse(targetURL)
+	if err != nil {
+		log.Error(err, "Failed to parse target URL", "url", targetURL)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid target URL"})
+		return
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(proxyURL)
+	originalDirector := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		originalDirector(req)
+		req.URL.Path = fmt.Sprintf("/logs/%s", taskID)
+		// Clear query params if any, or keep them if agentserver supports them?
+		// agentserver just serves file, so query params might not matter.
+	}
+
+	// Custom error handler for proxy
+	proxy.ErrorHandler = func(w http.ResponseWriter, _ *http.Request, err error) {
+		log.Error(err, "Proxy error", "target", targetURL)
+		// If connection refused, it might mean the pod is not ready or port not exposed yet
+		http.Error(w, "Failed to connect to agent server logs (pod might be starting or scaled down)", http.StatusBadGateway)
+	}
+
+	proxy.ServeHTTP(c.Writer, c.Request)
 }

--- a/repo-agent/pkg/api/server.go
+++ b/repo-agent/pkg/api/server.go
@@ -64,6 +64,7 @@ func (s *Server) RegisterRoutes(router *gin.Engine) {
 
 		api.GET("/repo/:repo/prs", s.getPRs)
 		api.GET("/repo/:repo/prs/:id/tasks", s.getPRTasks)
+		api.GET("/repo/:repo/prs/:id/tasks/:taskID/logs", s.getTaskLogs)
 		api.GET("/repo/:repo/prs/:id/details", s.getPRDetails)
 		api.POST("/repo/:repo/prs/:id/tasks", s.createPRTask)
 		api.POST("/repo/:repo/tasks/:taskID/draft", s.saveTaskDraft)

--- a/repo-agent/review-ui/ui/src/PrReviewCard.js
+++ b/repo-agent/review-ui/ui/src/PrReviewCard.js
@@ -30,9 +30,12 @@ function TaskReviewCard({
     curlCommand,
     handleSubmitTask,
     handleSaveTaskDraft,
-    prUrl
+    prUrl,
+    repoName
 }) {
     const [taskCollapsed, setTaskCollapsed] = useState(false);
+    const [showLogs, setShowLogs] = useState(false);
+    const [logs, setLogs] = useState('');
     const [reviewFlairText, setReviewFlairText] = useState('');
     const [localYaml, setLocalYaml] = useState(task.userDraft || task.agentDraft || '');
     // Parse initial YAML to structured object for Diff/Form views
@@ -43,6 +46,39 @@ function TaskReviewCard({
             return {};
         }
     });
+
+    useEffect(() => {
+        let isMounted = true;
+        let timeoutId;
+
+        if (showLogs && repoName) {
+            const fetchLogs = () => {
+                fetch(`/api/repo/${encodeURIComponent(repoName)}/prs/${encodeURIComponent(prId)}/tasks/${encodeURIComponent(task.name)}/logs`)
+                .then(res => {
+                    if (res.ok) return res.text();
+                    throw new Error("Failed to load logs");
+                })
+                .then(text => {
+                    if (isMounted) {
+                        setLogs(text);
+                        timeoutId = setTimeout(fetchLogs, 5000);
+                    }
+                })
+                .catch(err => {
+                    if (isMounted) {
+                        setLogs(`Error loading logs: ${err.message}`);
+                        timeoutId = setTimeout(fetchLogs, 5000);
+                    }
+                });
+            };
+            fetchLogs();
+        }
+        
+        return () => {
+            isMounted = false;
+            clearTimeout(timeoutId);
+        };
+    }, [showLogs, repoName, prId, task.name]);
 
     // Update local state when task prop updates (e.g. re-fetch)
     useEffect(() => {
@@ -462,11 +498,19 @@ function TaskReviewCard({
             
             {!taskCollapsed && (
                 <div style={{padding: '15px'}}>
-                     <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '10px 0' }}>
+                     <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '10px 0', gap: '10px' }}>
+                        <button className="btn" onClick={() => setShowLogs(!showLogs)}>
+                            {showLogs ? 'Hide Logs' : 'View Logs'}
+                        </button>
                         <button className="btn" onClick={() => toggleReviewView(prId)}>
                         {reviewViewModes[prId] === 'structured' ? 'View as YAML' : 'View as Structured'}
                         </button>
                     </div>
+                     {showLogs && (
+                        <div className="logs-display" style={{backgroundColor: '#333', color: '#fff', padding: '10px', borderRadius: '5px', marginBottom: '10px', maxHeight: '300px', overflowY: 'auto'}}>
+                            <pre style={{margin: 0, whiteSpace: 'pre-wrap', fontFamily: 'monospace'}}>{logs || 'Loading logs...'}</pre>
+                        </div>
+                     )}
                      {isSubmitted ? (
                         reviewViewModes[prId] === 'structured' ? (
                         <div className="review-display">
@@ -797,6 +841,7 @@ function PrReviewCard({
                     key={task.name}
                     task={task}
                     prId={pr.id}
+                    repoName={repoName}
                     drafts={drafts} // kept for backward compatibility if needed, but local draft is used
                     reviewViewModes={reviewViewModes}
                     yamlDrafts={yamlDrafts} // kept for backward compatibility


### PR DESCRIPTION
- repo-agent/pkg/api/handlers_pr.go: Add getTaskLogs to proxy agentserver logs
- repo-agent/pkg/api/server.go: Register /repo/:repo/prs/:id/tasks/:taskID/logs
- repo-agent/k8s/review-sandbox-rgd.yaml: Expose port 13339 for agentserver
- repo-agent/cmd/repo-sandbox/review-sandbox-rgd.yaml: Expose port 13339
- repo-agent/review-ui/ui/src/PrReviewCard.js: Add LogViewer to TaskReviewCard

Summary of the changes:
1. Backend (Review API):
  * Added a new endpoint GET /repo/:repo/prs/:id/tasks/:taskID/logs in review-api.
  * This endpoint proxies requests to the agentserver running on port 13339 inside the corresponding sandbox pod.
  * It uses the ReviewSandbox resource naming convention (devc-<sandboxName>-lb) to locate the target Service.

2. Infrastructure (KRO/RGD):
  * Updated ReviewSandbox ResourceGraphDefinition (both in k8s/ and cmd/repo-sandbox/) to expose port 13339 (AgentServer) in both the Container and the Service.
  * K8s requires named ports when multiple ports are defined in a Service.

3. Frontend (Review UI):
  * Updated PrReviewCard.js to include a "View Logs" button in the TaskReviewCard.
  * Implemented a simple polling mechanism to fetch and display the logs when the section is expanded.


<img width="3584" height="1522" alt="image" src="https://github.com/user-attachments/assets/3ec3e17f-eeb8-4682-b1f3-fcc40e247c42" />
