### PR TITLE
feat: Support Robot Accounts for RepoWatch actions

### DIFF
--- a/repo-agent/Makefile
+++ b/repo-agent/Makefile
@@ -167,6 +167,15 @@ create-secrets: bin/tls.crt bin/key.json
 			--from-literal=token=${GITHUB_PAT} \
 			--dry-run=client -o yaml | kubectl apply -f -; \
 	fi
+	# Create robot account secret if ROBOT1_GH_PAT is set
+	@if [ -n "${ROBOT1_GH_PAT}" ]; then \
+		kubectl create secret -n repo-agent-system generic ${ROBOT1_GH_USERID} \
+			--from-literal=pat="${ROBOT1_GH_PAT}" \
+			--from-literal=name="${ROBOT1_GH_NAME}" \
+			--from-literal=userid="${ROBOT1_GH_USERID}" \
+			--from-literal=email="${ROBOT1_GH_EMAIL}" \
+			--dry-run=client -o yaml | kubectl apply -f -; \
+	fi
 
 bin/configdir-cli: configdir/
 	../dev/tools/build-go-binaries --working-dir .

--- a/repo-agent/api/repowatch/v1alpha1/repowatch_types.go
+++ b/repo-agent/api/repowatch/v1alpha1/repowatch_types.go
@@ -106,6 +106,10 @@ type PRReviewSpec struct {
 	// Assignees to filter PRs for this handler
 	// +kubebuilder:validation:Optional
 	Assignees []string `json:"assignees,omitempty"`
+
+	// RobotAccount to use for this handler.
+	// +kubebuilder:validation:Optional
+	RobotAccount string `json:"robotAccount,omitempty"`
 }
 
 // DevSpec defines the configuration for development sandboxes.
@@ -192,6 +196,10 @@ type IssueSpec struct {
 	// The time in minutes after which a issue sandbox will be scaled down to 0 replicas.
 	// +kubebuilder:validation:Optional
 	IssueShutdownAfterMinutes int `json:"issueShutdownAfterMinutes,omitempty"`
+
+	// RobotAccount to use for this handler.
+	// +kubebuilder:validation:Optional
+	RobotAccount string `json:"robotAccount,omitempty"`
 
 	// Handlers configuration for Bugs
 	// +kubebuilder:validation:Optional

--- a/repo-agent/k8s/crds/review.gemini.google.com_repowatches.yaml
+++ b/repo-agent/k8s/crds/review.gemini.google.com_repowatches.yaml
@@ -125,6 +125,8 @@ spec:
                     type: integer
                   maxSandboxes:
                     type: integer
+                  robotAccount:
+                    type: string
                 required:
                 - maxActiveSandboxes
                 type: object
@@ -187,6 +189,8 @@ spec:
                     type: array
                   reviewShutdownAfterMinutes:
                     type: integer
+                  robotAccount:
+                    type: string
                 required:
                 - maxActiveSandboxes
                 type: object

--- a/repo-agent/k8s/rbac.generated.yaml
+++ b/repo-agent/k8s/rbac.generated.yaml
@@ -9,6 +9,7 @@ rules:
   resources:
   - secrets
   verbs:
+  - create
   - get
   - list
   - patch

--- a/repo-agent/pkg/controllers/repowatch/repowatch_controller.go
+++ b/repo-agent/pkg/controllers/repowatch/repowatch_controller.go
@@ -244,7 +244,7 @@ type Reconciler struct {
 //+kubebuilder:rbac:groups=custom.agents.x-k8s.io,resources=reviewsandboxes,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=custom.agents.x-k8s.io,resources=issuesandboxes,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=custom.agents.x-k8s.io,resources=sandboxtasks,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
@@ -859,6 +859,15 @@ func (r *Reconciler) createIssueSandbox(ctx context.Context, user *github.User, 
 		apiKeySecretName = "gemini-vscode-tokens"
 	}
 
+	githubSecretName := repoWatch.Spec.GithubSecretName
+	if repoWatch.Spec.Issue.RobotAccount != "" {
+		githubSecretName = repoWatch.Spec.Issue.RobotAccount
+		if err := r.ensureRobotSecret(ctx, repoWatch.Namespace, githubSecretName); err != nil {
+			log.Error(err, "failed to ensure robot secret", "secret", githubSecretName)
+			return err
+		}
+	}
+
 	sandbox := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "custom.agents.x-k8s.io/v1alpha1",
@@ -903,7 +912,8 @@ func (r *Reconciler) createIssueSandbox(ctx context.Context, user *github.User, 
 				"gateway": map[string]interface{}{
 					"httpEnabled": true,
 				},
-				"replicas": int64(1),
+				"replicas":         int64(1),
+				"githubSecretName": githubSecretName,
 			},
 		},
 	}
@@ -984,6 +994,15 @@ func (r *Reconciler) createReviewSandboxForPR(ctx context.Context, repoWatch *re
 
 	prompt := repoWatch.Spec.Review.LLM.Prompt
 
+	githubSecretName := repoWatch.Spec.GithubSecretName
+	if repoWatch.Spec.Review.RobotAccount != "" {
+		githubSecretName = repoWatch.Spec.Review.RobotAccount
+		if err := r.ensureRobotSecret(ctx, repoWatch.Namespace, githubSecretName); err != nil {
+			log.Error(err, "failed to ensure robot secret", "secret", githubSecretName)
+			return err
+		}
+	}
+
 	log.Info("Generated sandbox for PR", "pr", *pr, "llm.provider", repoWatch.Spec.Review.LLM.Provider)
 	sandbox := &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -1020,8 +1039,9 @@ func (r *Reconciler) createReviewSandboxForPR(ctx context.Context, repoWatch *re
 				"gateway": map[string]interface{}{
 					"httpEnabled": true,
 				},
-				"maxReviewFiles": int64(repoWatch.Spec.Review.MaxReviewFiles),
-				"replicas":       int64(1),
+				"maxReviewFiles":   int64(repoWatch.Spec.Review.MaxReviewFiles),
+				"replicas":         int64(1),
+				"githubSecretName": githubSecretName,
 			},
 		},
 	}
@@ -1397,6 +1417,43 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, concurrency int) error {
 		WithOptions(controller.Options{MaxConcurrentReconciles: concurrency}).
 		// Owns(&reviewv1alpha1.ReviewSandbox{}).
 		Complete(r)
+}
+
+func (r *Reconciler) ensureRobotSecret(ctx context.Context, namespace, secretName string) error {
+	// Check if secret exists in namespace
+	secret := &corev1.Secret{}
+	err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret)
+	if err == nil {
+		return nil // Secret exists
+	}
+	if !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	// Secret not found, try to copy from system namespace
+	systemNamespace := os.Getenv("REPO_AGENT_SYSTEM_NAMESPACE")
+	if systemNamespace == "" {
+		systemNamespace = "repo-agent-system"
+	}
+
+	sourceSecret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: systemNamespace}, sourceSecret); err != nil {
+		return fmt.Errorf("failed to find robot secret %s in %s: %w", secretName, systemNamespace, err)
+	}
+
+	// Create secret in target namespace
+	newSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        secretName,
+			Namespace:   namespace,
+			Labels:      sourceSecret.Labels,
+			Annotations: sourceSecret.Annotations,
+		},
+		Data: sourceSecret.Data,
+		Type: sourceSecret.Type,
+	}
+
+	return r.Create(ctx, newSecret)
 }
 
 func (r *Reconciler) unpauseSandboxIfPendingTasks(ctx context.Context, sandbox *unstructured.Unstructured) (bool, error) {


### PR DESCRIPTION
This change introduces support for specifying a "Robot Account" (e.g., a shared GitHub App bot) in RepoWatch to handle automated actions like reviews, issue comments, and git pushes.

https://github.com/gke-labs/gemini-for-kubernetes-development/pull/380 was created by this

- API: Added RobotAccount field to PRReviewSpec and IssueSpec in RepoWatch CRD.
- Controller: Implemented logic to automatically copy the specified robot account secret from the system namespace to the user's namespace if it doesn't exist.
- Controller: Updated ReviewSandbox and IssueSandbox creation to use the robot account credentials when configured.
- RBAC: Granted create permission on Secrets to the repowatch-controller to enable secret copying.
- Add make target for creating robot account secret

<img width="2648" height="1116" alt="image" src="https://github.com/user-attachments/assets/0a9ec51d-5a8c-4f34-9cef-3c9de7335762" />

<img width="1656" height="1534" alt="image" src="https://github.com/user-attachments/assets/c8c1dc3a-96e3-41ca-957d-bfa659839686" />


<img width="1670" height="432" alt="image" src="https://github.com/user-attachments/assets/61225d2b-a324-4771-8281-efae83f4a9ad" />
