### PR TITLE
Revert "[repo-agent] Add gemini-cli agent.md"

### DIFF
--- a/repo-agent/GEMINI.md
+++ b/repo-agent/GEMINI.md
@@ -10,10 +10,3 @@ that builds the cobra.Command and binds the FooOptions fields to flags.
 Avoid adding new dependencies on libraries that are not already in go.mod.
 
 Prefer `sigs.k8s.io/yaml` for yaml.
-
-## Verification
-
-After making code changes, run the following commands to verify your changes and fix any errors:
-
-*   **Linting:** `cd repo-agent ; make lint-go`
-*   **Build:** `cd repo-agent; make build`


### PR DESCRIPTION
Reverts gke-labs/gemini-for-kubernetes-development#479

lint and build checks are timing out in sandbox 