### PR TITLE
Surface github access errors as status conditions in UI

### DIFF
--- a/repo-agent/pkg/api/handlers_common.go
+++ b/repo-agent/pkg/api/handlers_common.go
@@ -8,8 +8,11 @@ import (
 
 	"github.com/gin-gonic/gin"
 	pkgk8s "github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/k8s"
+	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/models"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 )
 
@@ -45,6 +48,33 @@ func (s *Server) proxy(c *gin.Context) {
 	}
 
 	c.String(resp.StatusCode, string(body))
+}
+
+// extractConditions converts unstructured Kubernetes conditions to the API model format.
+func extractConditions(obj *unstructured.Unstructured) []models.Condition {
+	conditionsSlice, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if err != nil || !found {
+		return nil
+	}
+	var conditions []models.Condition
+	for _, item := range conditionsSlice {
+		condMap, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		var k8sCond v1.Condition
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(condMap, &k8sCond); err != nil {
+			continue
+		}
+		conditions = append(conditions, models.Condition{
+			Type:               k8sCond.Type,
+			Status:             string(k8sCond.Status),
+			Reason:             k8sCond.Reason,
+			Message:            k8sCond.Message,
+			LastTransitionTime: k8sCond.LastTransitionTime.Format("2006-01-02T15:04:05Z07:00"),
+		})
+	}
+	return conditions
 }
 
 func (s *Server) ensureGeminiKeySet(c *gin.Context, namespace string) bool {

--- a/repo-agent/pkg/api/handlers_repo.go
+++ b/repo-agent/pkg/api/handlers_repo.go
@@ -619,9 +619,10 @@ func (s *Server) getRepos(c *gin.Context) {
 		}
 
 		repo := models.Repo{
-			Name:      repoName,
-			Namespace: namespace,
-			URL:       repoURL,
+			Name:       repoName,
+			Namespace:  namespace,
+			URL:        repoURL,
+			Conditions: extractConditions(&repoWatch),
 		}
 
 		// Extract review config
@@ -811,9 +812,10 @@ func (s *Server) getRepo(c *gin.Context) {
 	}
 
 	repo := models.Repo{
-		Name:      repoName,
-		Namespace: namespace,
-		URL:       repoURL,
+		Name:       repoName,
+		Namespace:  namespace,
+		URL:        repoURL,
+		Conditions: extractConditions(repoWatch),
 	}
 
 	// Extract review config

--- a/repo-agent/pkg/controllers/repowatch/repowatch_controller.go
+++ b/repo-agent/pkg/controllers/repowatch/repowatch_controller.go
@@ -36,6 +36,7 @@ import (
 	githuboauth "golang.org/x/oauth2/github"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -282,9 +283,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		// Instead, requeue with a fixed delay to avoid log spam.
 		if strings.Contains(err.Error(), "waiting for user login") {
 			log.Info("Waiting for user login to populate github token")
+			r.setAuthCondition(ctx, repoWatch, metav1.ConditionFalse, "WaitingForLogin", err.Error())
 			return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
 		}
 		log.Error(err, "unable to create github client")
+		r.setAuthCondition(ctx, repoWatch, metav1.ConditionFalse, "TokenMissing", err.Error())
 		return ctrl.Result{}, err
 	}
 
@@ -307,9 +310,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			}
 		} else {
 			log.Error(err, "unable to get current user")
+			r.setAuthCondition(ctx, repoWatch, metav1.ConditionFalse, "TokenInvalid", err.Error())
 			return ctrl.Result{}, err
 		}
 	}
+
+	// GitHub auth succeeded — clear any previous auth failure condition
+	r.setAuthCondition(ctx, repoWatch, metav1.ConditionTrue, "Authenticated", "GitHub authentication successful")
 	if githubConfig["name"] != "" {
 		user.Name = github.String(githubConfig["name"])
 	}
@@ -349,6 +356,27 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	return ctrl.Result{RequeueAfter: time.Second * time.Duration(repoWatch.Spec.PollIntervalSeconds)}, reconcileErr
+}
+
+// setAuthCondition sets the GitHubAuthentication condition on the RepoWatch status.
+func (r *Reconciler) setAuthCondition(ctx context.Context, repoWatch *reviewv1alpha1.RepoWatch, status metav1.ConditionStatus, reason, message string) {
+	log := log.FromContext(ctx)
+
+	condition := metav1.Condition{
+		Type:               "GitHubAuthentication",
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: repoWatch.Generation,
+	}
+
+	changed := apimeta.SetStatusCondition(&repoWatch.Status.Conditions, condition)
+	if !changed {
+		return
+	}
+	if err := r.Status().Update(ctx, repoWatch); err != nil {
+		log.Error(err, "unable to update RepoWatch auth condition")
+	}
 }
 
 func (r *Reconciler) reconcileReviews(ctx context.Context, repoWatch *reviewv1alpha1.RepoWatch, ghClient *github.Client, owner string, repo string, user *github.User) error {

--- a/repo-agent/pkg/models/models.go
+++ b/repo-agent/pkg/models/models.go
@@ -54,6 +54,15 @@ func (r *PullRequestReviewRequest) ToGitHubReviewRequest() *github.PullRequestRe
 	}
 }
 
+// Condition represents a Kubernetes-style status condition
+type Condition struct {
+	Type               string `json:"type"`
+	Status             string `json:"status"`
+	Reason             string `json:"reason,omitempty"`
+	Message            string `json:"message,omitempty"`
+	LastTransitionTime string `json:"lastTransitionTime,omitempty"`
+}
+
 // Task represents a sandbox task
 type Task struct {
 	Name              string `json:"name"`
@@ -118,6 +127,7 @@ type Repo struct {
 	ExcludeBranches     []string      `json:"excludeBranches,omitempty"`
 	PendingIssues       []int64       `json:"pendingIssues,omitempty"`
 	ExcludeIssues       []int64       `json:"excludeIssues,omitempty"`
+	Conditions          []Condition   `json:"conditions,omitempty"`
 }
 
 // ReviewConfig holds configuration for PR reviews

--- a/repo-agent/review-ui/ui/src/App.js
+++ b/repo-agent/review-ui/ui/src/App.js
@@ -1413,7 +1413,13 @@ function App() {
           <strong>⚠️ Gemini API Key Missing:</strong> Please configure your Gemini API Key in <a href="#" onClick={(e) => { e.preventDefault(); setView('settings'); }}>Settings</a> to enable code reviews and issue handling.
         </div>
       )}
-      
+
+      {activeRepo && activeRepo.conditions && activeRepo.conditions.filter(c => c.status === 'False').map((c, i) => (
+        <div key={i} className="warning-banner" style={{ backgroundColor: '#fdecea', color: '#721c24', borderColor: '#f5c6cb' }}>
+          <strong>⚠️ {c.type}:</strong> {c.message} <span style={{ opacity: 0.7, fontSize: 'small' }}>({c.reason}{c.lastTransitionTime ? ` — ${new Date(c.lastTransitionTime).toLocaleString()}` : ''})</span>
+        </div>
+      ))}
+
       {view === 'dashboard' && renderDashboard()}
       {view === 'settings' && <Settings onBack={() => setView('dashboard')} />}
       {view === 'add_repo' && <AddRepo onCancel={() => setView('dashboard')} onRepoAdded={() => { fetchRepos(); setView('dashboard'); }} />}


### PR DESCRIPTION
When the RepoWatch controller fails to authenticate with GitHub (expired PAT, revoked token, missing secret, or pending OAuth login), the failure was only visible in controller logs. Now it is tracked as a standard Kubernetes status condition on the RepoWatch, making it visible via kubectl and the web UI.

If I put in an invalid Github PAT, for example, I see:

<img width="980" height="328" alt="Screenshot From 2026-02-12 21-16-22" src="https://github.com/user-attachments/assets/6a933bf1-ff84-4dd2-8e44-8b672f1f6a06" />

Which shows up in the UI as:

<img width="950" height="391" alt="Screenshot From 2026-02-12 21-16-15" src="https://github.com/user-attachments/assets/1ac3cb85-016c-4345-b05b-666405c2a4df" />

And if I fix the PAT, the UI returns to normal and the RepoWatch status changes to:


<img width="980" height="328" alt="Screenshot From 2026-02-12 21-19-59" src="https://github.com/user-attachments/assets/b37a24c5-e347-4433-b863-c3632272bb9d" />

