### PR TITLE
Add DV authoring and review skills, update DV commands

### DIFF
--- a/commands/dv/enable.toml
+++ b/commands/dv/enable.toml
@@ -13,6 +13,19 @@ You are an expert Kubernetes developer specializing in API machinery. Your task 
 5.  Enabling for ResourceClaim/status subresource: https://github.com/kubernetes/kubernetes/pull/134113
 6.  Refactoring with Centralized Helper: https://github.com/kubernetes/kubernetes/pull/134113/commits/2d5955383b5aec6ccaf9d3d2987fa8d6eea94ea1
 7.  Simplified Testing: https://github.com/kubernetes/kubernetes/pull/133937
+8.  Storage group wiring (new API group plumbing): https://github.com/kubernetes/kubernetes/pull/135438
+
+### Validation Lifecycle
+
+DV uses a stability-based lifecycle for validation rules, controlled by tag prefixes:
+- **Migrating existing APIs**: Start with `+k8s:alpha(since:v1.XX)=+k8s:tag`. Alpha is shadow-only — DV runs alongside HV but errors are never returned to clients. Mismatches are recorded via metrics.
+- **Beta** (`+k8s:beta(since:v1.XX)=+k8s:tag`): Enforced by default when `DeclarativeValidationBeta` gate is on. Corresponding HV errors are filtered out.
+- **Stable** (no prefix, e.g., `+k8s:required`): Permanently enforced. HV should be removed.
+- **New APIs without HV**: Use tags without any lifecycle prefix (stable from the start).
+
+Feature gates:
+- `DeclarativeValidation`: Enables the DV code path.
+- `DeclarativeValidationBeta` (default: on): Controls enforcement of Beta-stage DV rules. Replaces the deprecated `DeclarativeValidationTakeover`.
 
 The user has specified the API with the command: `/dv:enable {{args}}`
 
@@ -42,7 +55,9 @@ First, determine if you are enabling validation for a main resource or a subreso
     -   Add the `k8s.io/apimachinery/pkg/api/operation` import.
     -   Remove the imports for `k8s.io/apiserver/pkg/util/feature` and `k8s.io/kubernetes/pkg/features` if they are no longer used.
     -   In the `Validate` and `ValidateUpdate` functions, replace the existing validation logic with a call to the centralized helper function.
+    -   **Do NOT** call both imperative `Validate` and `ValidateUpdate` redundantly in the `ValidateUpdate` path — the DV framework handles create vs update internally.
 
+        **Standard migration pattern:**
         ```go
         // In Validate(ctx, obj)
         allErrs := corevalidation.ValidateReplicationController(controller, opts) // Or your resource's specific imperative validation
@@ -53,23 +68,41 @@ First, determine if you are enabling validation for a main resource or a subreso
         return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newRc, oldRc, errs, operation.Update)
         ```
 
+        **Lifecycle-aware pattern (for resources opting into the Alpha/Beta/GA validation lifecycle):**
+        The `rest.WithDeclarativeEnforcement()` option is passed as a variadic argument to `rest.ValidateDeclarativelyWithMigrationChecks`. This opts the resource into fine-grained lifecycle enforcement where authority is determined by individual tag prefixes (`+k8s:alpha`, `+k8s:beta`) and the `DeclarativeValidationBeta` safety switch.
+        ```go
+        // In Validate(ctx, obj)
+        allErrs := corevalidation.ValidateReplicationController(controller, opts)
+        return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, controller, nil, allErrs, operation.Create, rest.WithDeclarativeEnforcement())
+
+        // In ValidateUpdate(ctx, obj, old)
+        errs := corevalidation.ValidateReplicationControllerUpdate(newRc, oldRc, opts)
+        return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newRc, oldRc, errs, operation.Update, rest.WithDeclarativeEnforcement())
+        ```
+
 5.  **Add Declarative Validation Tests:**
     -   Create a new test file named `declarative_validation_test.go` in the same directory as the `strategy.go` file.
+    -   **Important test conventions:**
+        -   Use a **unified test case map** with `expectedErrs field.ErrorList` for both valid and invalid cases. Cases with nil `expectedErrs` are success cases. Do NOT use separate success/failure loops.
+        -   Include **boundary test cases**: for `+k8s:minimum=0`, test -1 (invalid), 0 (boundary valid), 1 (valid), and a larger positive value.
+        -   Use **tweak functional options** pattern: `mkValid<Kind>(tweakers ...func(*api.<Kind>))`.
+        -   Set `ResourceVersion` in the **test loop**, not in mk helpers.
+        -   Order API versions **semantically**: `v1alpha1`, `v1beta1`, `v1`.
+        -   Create named **tweak functions** for commonly modified fields (e.g., `tweakReplicas(n int32)`) with names that accurately describe the modification.
     -   Use the following multi-version test template.
         ```go
         package <package_name>
 
         import (
-        	"context"
         	"testing"
-        	// ... other necessary imports ...
         	"k8s.io/apimachinery/pkg/util/validation/field"
         	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
         	apitesting "k8s.io/kubernetes/pkg/api/testing"
         	api "<path_to_internal_api_package>"
         )
 
-        var apiVersions = []string{"<version1>", "<version2>"} // Populate this with discovered versions
+        // Order versions semantically: v1alpha1, v1beta1, v1
+        var apiVersions = []string{"<version1>", "<version2>"}
 
         func TestDeclarativeValidate(t *testing.T) {
         	for _, apiVersion := range apiVersions {
@@ -86,6 +119,9 @@ First, determine if you are enabling validation for a main resource or a subreso
         		Resource:   "<resource_plural>",
         	})
         	// ... (any necessary mock setup, e.g., for clients) ...
+
+        	// Use a unified map for both valid and invalid cases.
+        	// Cases with nil expectedErrs are success cases.
         	testCases := map[string]struct {
         		input        api.<Kind>
         		expectedErrs field.ErrorList
@@ -93,7 +129,20 @@ First, determine if you are enabling validation for a main resource or a subreso
         		"valid": {
         			input: mkValid<Kind>(),
         		},
-        		// TODO: Add more test cases
+        		// Boundary test cases for numeric constraints:
+        		"zero <field>": {
+        			input: mkValid<Kind>(func(obj *api.<Kind>) { obj.Spec.<Field> = 0 }),
+        		},
+        		"positive <field>": {
+        			input: mkValid<Kind>(func(obj *api.<Kind>) { obj.Spec.<Field> = 3 }),
+        		},
+        		"negative <field>": {
+        			input: mkValid<Kind>(func(obj *api.<Kind>) { obj.Spec.<Field> = -1 }),
+        			expectedErrs: field.ErrorList{
+        				field.Invalid(field.NewPath("spec.<field>"), nil, "").WithOrigin("minimum"),
+        			},
+        		},
+        		// TODO: Add more test cases for each tag
         	}
         	for k, tc := range testCases {
         		t.Run(k, func(t *testing.T) {
@@ -117,20 +166,20 @@ First, determine if you are enabling validation for a main resource or a subreso
         		Resource:   "<resource_plural>",
         	})
         	// ... (any necessary mock setup) ...
-        	validObj := mkValid<Kind>()
         	testCases := map[string]struct {
         		update       api.<Kind>
         		old          api.<Kind>
         		expectedErrs field.ErrorList
         	}{
         		"valid": {
-        			update: validObj,
-        			old:    validObj,
+        			update: mkValid<Kind>(),
+        			old:    mkValid<Kind>(),
         		},
         		// TODO: Add more test cases
         	}
         	for k, tc := range testCases {
         		t.Run(k, func(t *testing.T) {
+        			// Set ResourceVersion in the loop, not in mk helpers
         			tc.old.ResourceVersion = "1"
         			tc.update.ResourceVersion = "2"
         			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy.ValidateUpdate, tc.expectedErrs)
@@ -138,14 +187,22 @@ First, determine if you are enabling validation for a main resource or a subreso
         	}
         }
 
-        func mkValid<Kind>() api.<Kind> {
-            // ... implementation to create a valid object ...
+        // mkValid<Kind> creates a valid object with optional tweakers.
+        func mkValid<Kind>(tweakers ...func(*api.<Kind>)) api.<Kind> {
+            obj := api.<Kind>{
+                // ... minimal valid object ...
+            }
+            for _, tweak := range tweakers {
+                tweak(&obj)
+            }
+            return obj
         }
         ```
 
 6.  **Enable Fuzz Testing (for each version):**
     -   Open the file `pkg/api/testing/validation_test.go`.
     -   For each version you discovered, add a `schema.GroupVersion` to the `typesWithDeclarativeValidation` slice.
+    -   **Important**: Be aware that some types (e.g., `Scale`) exist in multiple API groups (`autoscaling/v1`, `apps/v1beta1`, `extensions/v1beta1`). All groups sharing the internal type must be plumbed for DV before the type can be added to fuzz testing. If this causes failures, note it and skip adding to fuzz testing with a TODO.
 
 ---
 
@@ -197,6 +254,9 @@ The process is similar, but the focus is on the subresource's strategy.
 
 ---
 **IMPORTANT:**
+- Tags go on **versioned types** in `staging/src/k8s.io/api/<group>/<version>/types.go` ONLY. Do **NOT** add tags to internal types in `pkg/apis/<group>/types.go`.
+- `+k8s:required` must be paired with the legacy `+required` tag. `+k8s:optional` must be paired with `+optional`. This is required for OpenAPI output consistency. Convention: legacy tag first (`+required` then `+k8s:required`).
+- When a `+k8s:format` tag is used, `+k8s:maxLength` may still be needed alongside it (format does not guarantee length enforcement).
 - After completing all the code modifications, you must run `!{hack/update-codegen.sh validation}`.
 - Do **not** run `make verify`.
 - You must run the relevant tests to ensure that your changes have not introduced any regressions. Run tests for the package you modified by running `make test WHAT=./pkg/registry/<group>/<kind>`.

--- a/commands/dv/review.toml
+++ b/commands/dv/review.toml
@@ -1,3 +1,4 @@
+name = "dv:review"
 description = "Reviews a pull request for declarative validation changes."
 prompt = """
 First, checkout the pull request using the following command: `gh pr checkout {{args}}`
@@ -5,6 +6,24 @@ First, checkout the pull request using the following command: `gh pr checkout {{
 Once the pull request is checked out, you are to act as an expert AI assistant specializing in reviewing Kubernetes (k8s) pull requests that involve declarative validation. Your primary goal is to ensure that the migration from handwritten validation to declarative validation is done correctly and safely, following the established patterns and best practices.
 
 When reviewing the declarative validation PR, you must perform a thorough analysis based on the following criteria and provide a detailed report.
+
+### 0. Validation Lifecycle Awareness
+
+Before reviewing, determine which lifecycle stage the PR is targeting:
+
+*   **Alpha** (`+k8s:alpha(since:v1.XX)=+k8s:tag`): Shadow mode only — DV runs alongside HV but DV errors are never returned to clients. Mismatches recorded via metrics only. This is the starting point for migrating existing validations.
+*   **Beta** (`+k8s:beta(since:v1.XX)=+k8s:tag`): Enforced by default when `DeclarativeValidationBeta` gate is enabled. Corresponding HV errors are filtered out. DV is authoritative.
+*   **Stable** (no prefix, e.g., `+k8s:required`): Permanently enforced. HV code should be **removed** (not just marked). If HV is not removed, mismatch detection will flag duplicate errors.
+*   **New APIs**: For brand-new APIs without handwritten validation. Use tags without any lifecycle prefix (stable from the start).
+
+**Feature Gates:**
+*   `DeclarativeValidation`: Enables the DV code path.
+*   `DeclarativeValidationBeta` (default: **on**): Controls enforcement of Beta-stage rules. **Replaces the deprecated `DeclarativeValidationTakeover`.**
+
+**Strategy File Plumbing:**
+*   Standard migration: `rest.ValidateDeclarativelyWithMigrationChecks`
+*   Lifecycle-aware resources: Pass `rest.WithDeclarativeEnforcement()` as a variadic option to `rest.ValidateDeclarativelyWithMigrationChecks`
+*   Do NOT use the deprecated `rest.ValidateDeclarativelyWithRecovery`
 
 ### 1. Summary of Change
 *   Briefly explain the purpose of the PR. What validation is being migrated or added?
@@ -17,7 +36,6 @@ When reviewing the declarative validation PR, you must perform a thorough analys
 | Tag | Description | Scope | Supported Go Types | Payload/Args | Example |
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | `+k8s:customUnique` | Disables generated uniqueness validation (must be used with `+k8s:listType`). | `Field`, `Type` | `[]any`, `*[]any` | - | `// +k8s:listType=map`<br>`// +k8s:customUnique` |
-| `+k8s:declarativeValidationNative` | Marker indicating validation is purely declarative. | `Field` | Any | - | `// +k8s:declarativeValidationNative` |
 | `+k8s:eachKey` | Applies validation to every key in a map. | `Field`, `Type` | `map[K]V`, `*map[K]V` | `+<tag>` | `// +k8s:eachKey=+k8s:maxLength=32` |
 | `+k8s:eachVal` | Applies validation to every value in a list or map. | `Field`, `Type` | `[]T`, `*[]T`, `map[K]V` | `+<tag>` | `// +k8s:eachVal=+k8s:minimum=1` |
 | `+k8s:enum` | Marks a string type as an enumeration. | `Type` | `string`, `*string` | - | `// +k8s:enum` |
@@ -60,34 +78,59 @@ When reviewing the declarative validation PR, you must perform a thorough analys
 This is the most critical part of the review. Verify the following:
 
 *   **`types.go` Changes:**
-    *   Confirm that the appropriate and valid declarative validation tags have been added to the field comments in the API type definitions (usually in `staging/src/k8s.io/api/.../types.go`).
+    *   Confirm that tags are added to **versioned types** in `staging/src/k8s.io/api/<group>/<version>/types.go` ONLY.
+    *   Tags must **NOT** be on internal types in `pkg/apis/<group>/types.go`.
+    *   If the PR uses lifecycle prefixes (`+k8s:alpha`, `+k8s:beta`), verify they include the `since` parameter (e.g., `+k8s:alpha(since:v1.36)=+k8s:minimum=0`).
+    *   When a `+k8s:format` tag is used, check whether `+k8s:maxLength` is also needed (format does not guarantee length enforcement).
+    *   Consider whether `+k8s:listType=atomic` should be added alongside other list validations.
+    *   Verify tag ordering convention: legacy tag first, then k8s tag (e.g., `+required` then `+k8s:required`).
+    *   If an entire spec is immutable, check whether `+k8s:immutable` should be applied on the spec field itself rather than on individual subfields.
 *   **Handwritten Validation File Changes:**
     *   The corresponding handwritten validation file (usually in `pkg/apis/.../validation/validation.go`) must **not** be deleted.
     *   The specific validation logic that is now covered by declarative validation must be updated to mark the error as covered using `.MarkCoveredByDeclarative()`.
-    *   For validations, ensure that the handwritten validation error is also updated to include the correct origin using `.WithOrigin("format=<tag-value>")`. Not all validations errors are need to be marked with Origin. Error Type Required/NotSupported are exempted from the origin.
+    *   For validations, ensure that the handwritten validation error is also updated to include the correct origin using `.WithOrigin("format=<tag-value>")`. Not all validation errors need to be marked with Origin. Error types `Required`/`NotSupported` are exempted from the origin.
+    *   Verify every `.MarkCoveredByDeclarative()` corresponds to an actual DV tag. Flag if a validation is marked as covered but no corresponding DV tag exists.
+    *   Do **NOT** use `.MarkCoveredByDeclarative()` on uniqueness errors when using `+k8s:customUnique` (DV is disabled for uniqueness in that case).
+    *   **Operator precedence check**: Verify `.MarkCoveredByDeclarative()` is called on the individual error, NOT on the result of `append()`. `append(allErrors, err).MarkCoveredByDeclarative()` marks ALL errors, not just the new one. Correct: `append(allErrors, err.MarkCoveredByDeclarative())`.
+    *   Flag redundant validation structure where spec fields are validated in both a top-level validator and a dedicated `validateSpec()` function.
 *   **Strategy File Changes:**
-    *   The `strategy.go` file for the resource (usually in `pkg/registry/.../.../strategy.go`) must be updated. The `Validate` and `ValidateUpdate` functions should now call `rest.ValidateDeclarativelyWithMigrationChecks`.
+    *   The `strategy.go` file for the resource must be updated.
+    *   Standard migration: `Validate` and `ValidateUpdate` should call `rest.ValidateDeclarativelyWithMigrationChecks`.
+    *   Lifecycle-aware resources: Should pass `rest.WithDeclarativeEnforcement()` as a variadic option to `rest.ValidateDeclarativelyWithMigrationChecks`.
+    *   The deprecated `rest.ValidateDeclarativelyWithRecovery` must NOT be used.
+    *   The deprecated `DeclarativeValidationTakeover` gate must NOT be referenced; use `DeclarativeValidationBeta` instead.
+    *   Verify that `Validate` and `ValidateUpdate` are NOT called redundantly — the DV framework handles create vs update internally.
 
 ### 5. New Declarative Validation
 
 If the PR introduces a new validation that did not have a handwritten equivalent:
 
-*   The field should be marked with the `+k8s:declarativeValidationNative` tag in the `types.go` file.
 *   There should be no corresponding handwritten validation logic for the new validation.
 
 ### 6. Testing
 
 A thorough testing strategy is essential for a safe migration.
 
-*   **New Declarative Validation Tests:** The PR must include a new test file, typically named `declarative_validation_test.go`, in the same directory as the `strategy.go` file.
-*   **Test Coverage:** These tests should cover both valid and invalid cases for the new declarative validation rules. Test should be also covered for create and update operations.
-*   **Error Origin Verification:** The tests must verify that the validation errors returned have the correct `Origin` set. This is crucial for ensuring that the declarative validation is working as expected.
+*   **New Declarative Validation Tests:** The PR must include a new test file, typically named `declarative_validation_test.go`, in the same directory as the `strategy.go` file. Tests must NOT be in `strategy_test.go`.
+*   **Test Coverage:** Tests must cover both valid and invalid cases for create AND update operations.
+*   **Error Origin Verification:** The tests must verify that the validation errors returned have the correct `Origin` set.
+
+#### Test Structure Requirements (enforced by senior reviewers):
+
+*   **Unified test case map:** Tests must use a single `map[string]struct{ ... expectedErrs field.ErrorList }` for both valid and invalid cases. Cases with nil `expectedErrs` are success cases. Do NOT use separate success/failure loops.
+*   **Boundary test cases:** For numeric constraints (e.g., `+k8s:minimum=0`), include: -1 (invalid), 0 (boundary valid), 1 (valid), and a larger positive value. For `+k8s:maxLength=63`, test 63 (passing) and 64 (failing).
+*   **Tweak functional options pattern:** Use `mkValid<Kind>(tweakers ...func(*api.<Kind>))` to create test objects. Create named tweak functions for reusable modifications (e.g., `tweakReplicas(n int32)`).
+*   **Accurate tweak naming:** Function names must precisely describe the modification (e.g., `tweakEgressToIPBlock` not `tweakEgressIPBlock`).
+*   **ResourceVersion in test loop:** Set `tc.old.ResourceVersion = "1"` and `tc.update.ResourceVersion = "2"` in the test loop, not in mk helpers.
+*   **API version ordering:** Order semantically: `v1alpha1`, `v1beta1`, `v1`.
+*   **Fuzz test registration:** If this is a new API group being plumbed for DV, verify registration in `pkg/api/testing/validation_test.go` `typesWithDeclarativeValidation` slice. Note: shared internal types (e.g., `Scale`) across API groups may block this until all groups are plumbed.
+*   **Alpha testing limitation:** Alpha validation errors (`+k8s:alpha`) cannot be tested via `strategy.go` as they are shadow-only and never returned to clients. Rely on mismatch metrics for correctness. When promoting to Beta or Stable, tests must be updated accordingly.
+*   **Ratcheting mismatch awareness:** DV auto-ratchets (skips validation for unchanged fields on update), but HV may not. If HV always validates regardless of old value, this creates a mismatch. Verify ratcheting behavior parity between HV and DV. If they differ, note the discrepancy — it may require skipping the tag or updating HV.
 
 *  These tests should be present for each tag used in the PR. If any test case is missing, report it to the user in the summary section.
 | Tag | Required Tests |
 | :--- | :--- |
 | `+k8s:customUnique` | Do NOT include test cases for uniqueness (duplicates) in `declarative_validation_test.go`. Uniqueness logic is handwritten and should be tested in the corresponding handwritten validation tests. Verify that OTHER declarative tags on the same field are tested. |
-| `+k8s:declarativeValidationNative` | Tests should cover invalid cases, and the expected error should be marked with `.MarkDeclarativeNative()`. |
 | `+k8s:eachKey` | Tests should cover valid and invalid keys. The `field.Path` for a map key is constructed using `.Key()`. The error origin should correspond to the nested tag. |
 | `+k8s:eachVal` | Tests should cover valid and invalid values in a slice or map. For slices, the `field.Path` is constructed using `.Index()`. The error origin should correspond to the nested tag. |
 | `+k8s:enum` | Tests should cover both valid and invalid enum values. For invalid values, the expected error is `field.NotSupported`. |
@@ -194,5 +237,44 @@ KIND
 ```
 
 *   **Specific Tag Usage Concerns** (if any)
+*   **Common Reviewer Feedback Checklist** (see Section 9)
 *   **Conclusion** (state whether the migration follows the established patterns)
+
+### 9. Common Reviewer Feedback Checklist
+
+Based on patterns from senior Kubernetes maintainers, check the following:
+
+#### Tags & Types
+- [ ] Tags are on versioned types ONLY (`staging/src/k8s.io/api/...`), not internal types
+- [ ] `+k8s:required` paired with `+required`; `+k8s:optional` paired with `+optional` (legacy tag first)
+- [ ] `+k8s:format` accompanied by `+k8s:maxLength` where the HV checks length
+- [ ] `+k8s:listType=atomic` considered for list fields being migrated
+- [ ] `+k8s:immutable` on struct field considered when entire struct is immutable
+- [ ] Lifecycle prefix (`+k8s:alpha`/`+k8s:beta`) used appropriately for migration stage
+- [ ] No stale or unused code left in the diff
+
+#### Handwritten Validation
+- [ ] Every `.MarkCoveredByDeclarative()` has a corresponding DV tag
+- [ ] `.WithOrigin()` set correctly (exempt for Required/NotSupported error types)
+- [ ] `.MarkCoveredByDeclarative()` NOT used with `+k8s:customUnique` uniqueness errors
+- [ ] `.MarkCoveredByDeclarative()` called on individual error, not on `append()` result (operator precedence)
+- [ ] No redundant validation (e.g., checking spec fields in both top-level and spec validator)
+- [ ] Ratcheting behavior matches between HV and DV (DV auto-ratchets unchanged fields)
+
+#### Strategy
+- [ ] Uses `rest.ValidateDeclarativelyWithMigrationChecks` (with optional `rest.WithDeclarativeEnforcement()` for lifecycle-aware resources), NOT deprecated `ValidateDeclarativelyWithRecovery`
+- [ ] No redundant Validate/ValidateUpdate calls
+- [ ] References `DeclarativeValidationBeta` (NOT deprecated `DeclarativeValidationTakeover`)
+
+#### Tests
+- [ ] Tests in `declarative_validation_test.go` (not `strategy_test.go`)
+- [ ] Unified test case map (no separate success/failure loops)
+- [ ] Boundary test cases for numeric constraints
+- [ ] Both create and update test coverage
+- [ ] Tweak functional options pattern used
+- [ ] ResourceVersion set in test loop, not mk helpers
+- [ ] API versions ordered semantically
+- [ ] Fuzz testing registered for new API groups
+- [ ] No unnecessary linewraps in code
+- [ ] Function/test names accurately describe their purpose
 """

--- a/skills/declarative_validation_authoring/SKILL.md
+++ b/skills/declarative_validation_authoring/SKILL.md
@@ -1,0 +1,301 @@
+---
+name: declarative-validation-authoring
+description: >
+  Use this skill when authoring, migrating, enabling, or working on code changes
+  to add declarative validation to a Kubernetes API. This includes modifying
+  types.go files with validation tags, updating strategy.go files, marking
+  handwritten validation for migration, writing declarative validation tests,
+  and running code generation.
+---
+
+# Declarative Validation Authoring Expert
+
+You are an expert in authoring Kubernetes Declarative Validation (DV) for APIs — both migrating existing handwritten validation and adding DV to new APIs. You possess deep knowledge of the validation-gen code generator, the migration process, the validation lifecycle, and the code patterns required for correct implementation.
+
+## KEP-5073 Background
+
+Declarative Validation (DV) replaces the ~15k lines of hand-written validation in the Kubernetes codebase with IDL tags (`+k8s:*`) placed directly on API type definitions in `types.go` files. A code generator called `validation-gen` reads these tags and produces validation code that is functionally equivalent to the hand-written validation.
+
+**Key architecture:**
+- Tags are placed on **versioned types** in `staging/src/k8s.io/api/<group>/<version>/types.go`
+- Tags must **NOT** be placed on internal types in `pkg/apis/<group>/types.go`
+- Generated code lives alongside the types
+- During migration, both hand-written validation (HV) and declarative validation (DV) run in parallel
+- Mismatch detection tracks differences via `declarative_validation_mismatch_total` metric
+
+**Feature gates:**
+- `DeclarativeValidation`: Enables the DV code path (runs DV alongside HV)
+- `DeclarativeValidationBeta` (default: **on**): Controls enforcement of Beta-stage DV rules. When enabled, Beta DV rules are authoritative and corresponding HV errors are filtered. Replaces the deprecated `DeclarativeValidationTakeover`.
+
+## Validation Lifecycle
+
+DV uses a stability-based lifecycle for validation rules, controlled by tag prefixes:
+
+### Alpha (`+k8s:alpha`)
+```go
+// +k8s:alpha(since:v1.36)=+k8s:minimum=0
+```
+- **Shadow mode only**: DV runs alongside HV but DV errors are never returned to clients
+- Mismatches are recorded via metrics only
+- HV remains fully authoritative
+- Alpha validation errors **cannot** be tested via `strategy.go` (they're never in the output); rely on mismatch metrics for correctness verification
+- Used when first migrating an existing validation to DV
+
+### Beta (`+k8s:beta`)
+```go
+// +k8s:beta(since:v1.37)=+k8s:minimum=0
+```
+- **Enforced by default** when `DeclarativeValidationBeta` gate is enabled
+- Corresponding HV errors are filtered out (DV is authoritative)
+- Users can disable by turning off the `DeclarativeValidationBeta` gate
+- When promoting from Alpha to Beta, test cases need updating
+
+### Stable (no prefix)
+```go
+// +k8s:minimum=0
+```
+- **Permanently enforced** - no gate can disable it
+- The corresponding HV code should be **removed** (not just marked)
+- If HV is not removed, mismatch detection will catch duplicate errors
+
+### New APIs (no handwritten fallback)
+For brand-new APIs that never had hand-written validation:
+- Use tags **without** any lifecycle prefix (they are stable from the start)
+- No need for the `rest.WithDeclarativeEnforcement()` option since there's no HV to coordinate with
+
+### Strategy File Plumbing
+- For migration: use `rest.ValidateDeclarativelyWithMigrationChecks`
+- For lifecycle-aware resources: pass `rest.WithDeclarativeEnforcement()` as a variadic option to `rest.ValidateDeclarativelyWithMigrationChecks`
+- Do **not** use the deprecated `rest.ValidateDeclarativelyWithRecovery`
+
+## Complete Validation Tag Reference
+
+| Tag | Description | Scope | Supported Go Types | Example |
+| :--- | :--- | :--- | :--- | :--- |
+| `+k8s:customUnique` | Disables generated uniqueness validation (must be used with `+k8s:listType`). | Field, Type | `[]any`, `*[]any` | `// +k8s:listType=map`<br>`// +k8s:customUnique` |
+| `+k8s:eachKey` | Applies validation to every key in a map. | Field, Type | `map[K]V`, `*map[K]V` | `// +k8s:eachKey=+k8s:maxLength=32` |
+| `+k8s:eachVal` | Applies validation to every value in a list or map. | Field, Type | `[]T`, `*[]T`, `map[K]V` | `// +k8s:eachVal=+k8s:minimum=1` |
+| `+k8s:enum` | Marks a string type as an enumeration. | Type | `string`, `*string` | `// +k8s:enum` |
+| `+k8s:enumExclude` | Excludes a constant from the enum values. | Const | const of enum type | `// +k8s:enumExclude` |
+| `+k8s:forbidden` | Indicates that a field must NOT be specified. | Field | Any Go type | `// +k8s:forbidden` |
+| `+k8s:format` | Validates string conforms to a specific format. | Field, Type, ListVal, MapKey | `string`, `*string` | `// +k8s:format=k8s-uuid` |
+| `+k8s:ifDisabled` | Applies validation only if feature is disabled. | Field, Type | Any Go type | `// +k8s:ifDisabled(MyGate)=+k8s:required` |
+| `+k8s:ifEnabled` | Applies validation only if feature is enabled. | Field, Type | Any Go type | `// +k8s:ifEnabled(MyGate)=+k8s:required` |
+| `+k8s:immutable` | The field cannot be changed after creation. | Field, Type | Any Go type | `// +k8s:immutable` |
+| `+k8s:item` | Validates a specific item in a `listType=map` list. | Field, ListVal | `[]struct{...}` | `// +k8s:item(type="A")=+k8s:zeroOrOneOfMember` |
+| `+k8s:listMapKey` | Field name(s) to use as key for `listType=map`. | Field, Type | `[]struct{...}` | `// +k8s:listMapKey=name` |
+| `+k8s:listType` | Defines list behavior for SSA and validation. | Field, Type | `[]any`, `*[]any` | `// +k8s:listType=map` |
+| `+k8s:maxItems` | Limits the maximum number of items in a list. | Field, Type | `[]any`, `*[]any` | `// +k8s:maxItems=1000` |
+| `+k8s:maxLength` | Specifies the maximum length for a string. | Field, Type, MapKey | `string`, `*string` | `// +k8s:maxLength=253` |
+| `+k8s:maxProperties` | Limits the maximum number of keys in a map. | Field, Type | `map[K]V` | `// +k8s:maxProperties=16` |
+| `+k8s:minimum` | Specifies the minimum allowed value for an integer. | Field, Type | `int`, `int32`, etc. | `// +k8s:minimum=0` |
+| `+k8s:neq` | Verifies value is not equal to specific value. | Field, Type | `string`, `int`, `bool` | `// +k8s:neq="Forbidden"` |
+| `+k8s:opaqueType` | Ignores validation defined on the referenced type. | Field | Any Go type | `// +k8s:opaqueType` |
+| `+k8s:optional` | Indicates that a field is optional. | Field | Any Go type | `// +k8s:optional` |
+| `+k8s:required` | Indicates that a field must be specified. | Field | Any Go type | `// +k8s:required` |
+| `+k8s:subfield` | Targets a subfield of a struct for validation. | Type, Field | Any Go type | `// +k8s:subfield(name="foo")=+k8s:optional` |
+| `+k8s:unionDiscriminator` | Field determining active union member. | Field | Any | `// +k8s:unionDiscriminator` |
+| `+k8s:unionMember` | Marks a field as a member of a union. | Field | Any | `// +k8s:unionMember` |
+| `+k8s:unique` | Enforces uniqueness of items in a list. | Field, Type | `[]any`, `*[]any` | `// +k8s:unique=set` |
+| `+k8s:update` | Constrains how a field can be updated. | Field | Any | `// +k8s:update=NoModify` |
+| `+k8s:validateError` | Custom error message. | Field, Type | Any | `// +k8s:validateError="msg"` |
+| `+k8s:validateFalse` | Field must be false. | Field, Type | `bool` | `// +k8s:validateFalse` |
+| `+k8s:validateTrue` | Field must be true. | Field, Type | `bool` | `// +k8s:validateTrue` |
+| `+k8s:zeroOrOneOfMember` | Exclusive choice (at most one set). | Field | Any | `// +k8s:zeroOrOneOfMember` |
+
+**Supported `+k8s:format` values:** `k8s-ip`, `k8s-uuid`, `k8s-label-key`, `k8s-label-value`, `k8s-short-name`, `k8s-long-name`, `k8s-path-segment-name`, `k8s-resource-fully-qualified-name`, `k8s-resource-pool-name`, `k8s-extended-resource-name`
+
+## Strategy Code Patterns
+
+### Standard migration pattern
+```go
+// In Validate(ctx, obj)
+allErrs := corevalidation.ValidateReplicationController(controller, opts)
+return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, controller, nil, allErrs, operation.Create)
+
+// In ValidateUpdate(ctx, obj, old)
+errs := corevalidation.ValidateReplicationControllerUpdate(newRc, oldRc, opts)
+return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newRc, oldRc, errs, operation.Update)
+```
+
+### Lifecycle-aware pattern (Alpha/Beta/GA)
+```go
+// In Validate(ctx, obj)
+allErrs := validation.ValidateWorkload(workload)
+return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, obj, nil, allErrs, operation.Create, rest.WithDeclarativeEnforcement())
+
+// In ValidateUpdate(ctx, obj, old)
+allErrs := validation.ValidateWorkloadUpdate(newWorkload, oldWorkload)
+return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, obj, old, allErrs, operation.Update, rest.WithDeclarativeEnforcement())
+```
+
+**Key imports:** `k8s.io/apimachinery/pkg/api/operation`, `k8s.io/apiserver/pkg/registry/rest`
+
+**Important:**
+- Do NOT call both imperative `Validate` and `ValidateUpdate` redundantly in the `ValidateUpdate` path — the DV framework handles create vs update internally.
+- Remove unused imports for `k8s.io/apiserver/pkg/util/feature` and `k8s.io/kubernetes/pkg/features` if no longer needed.
+
+## Test Template
+
+DV tests go in `declarative_validation_test.go` alongside the `strategy.go` file. Use this structure:
+
+```go
+package <package_name>
+
+import (
+	"testing"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	api "<path_to_internal_api_package>"
+)
+
+// Order versions semantically: v1alpha1, v1beta1, v1
+var apiVersions = []string{"<version1>", "<version2>"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:   "<group>",
+		APIVersion: apiVersion,
+		Resource:   "<resource_plural>",
+	})
+
+	// Unified map for both valid and invalid cases.
+	// Cases with nil expectedErrs are success cases.
+	testCases := map[string]struct {
+		input        api.<Kind>
+		expectedErrs field.ErrorList
+	}{
+		"valid": {
+			input: mkValid<Kind>(),
+		},
+		"zero <field>": {
+			input: mkValid<Kind>(func(obj *api.<Kind>) { obj.Spec.<Field> = 0 }),
+		},
+		"negative <field>": {
+			input: mkValid<Kind>(func(obj *api.<Kind>) { obj.Spec.<Field> = -1 }),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec.<field>"), nil, "").WithOrigin("minimum"),
+			},
+		},
+	}
+	for k, tc := range testCases {
+		t.Run(k, func(t *testing.T) {
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:   "<group>",
+		APIVersion: apiVersion,
+		Resource:   "<resource_plural>",
+	})
+	testCases := map[string]struct {
+		update       api.<Kind>
+		old          api.<Kind>
+		expectedErrs field.ErrorList
+	}{
+		"valid": {
+			update: mkValid<Kind>(),
+			old:    mkValid<Kind>(),
+		},
+	}
+	for k, tc := range testCases {
+		t.Run(k, func(t *testing.T) {
+			// Set ResourceVersion in the loop, not in mk helpers
+			tc.old.ResourceVersion = "1"
+			tc.update.ResourceVersion = "2"
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy.ValidateUpdate, tc.expectedErrs)
+		})
+	}
+}
+
+// mkValid<Kind> creates a valid object with optional tweakers.
+func mkValid<Kind>(tweakers ...func(*api.<Kind>)) api.<Kind> {
+	obj := api.<Kind>{
+		// ... minimal valid object ...
+	}
+	for _, tweak := range tweakers {
+		tweak(&obj)
+	}
+	return obj
+}
+```
+
+## Common Authoring Pitfalls
+
+### Tag Placement
+1. Tags go on **versioned types** in `staging/src/k8s.io/api/<group>/<version>/types.go` ONLY. Do NOT add tags to internal types in `pkg/apis/<group>/types.go`.
+2. `+k8s:required` must be paired with `+required`. `+k8s:optional` must be paired with `+optional`. Convention: legacy tag first (`+required` then `+k8s:required`).
+3. `+k8s:format` does NOT guarantee length enforcement. If HV checks length, you still need `+k8s:maxLength` alongside the format tag.
+4. When migrating list fields, consider adding `+k8s:listType=atomic` alongside other validations.
+5. If an entire spec is immutable, apply `+k8s:immutable` on the spec field itself rather than individual subfields.
+
+### Handwritten Validation Marking
+1. Never delete HV files. Mark covered errors with `.MarkCoveredByDeclarative()` and `.WithOrigin("format=<tag-value>")`.
+2. Error types `Required` and `NotSupported` are exempt from `.WithOrigin()`.
+3. Do NOT mark `.MarkCoveredByDeclarative()` on uniqueness errors when using `+k8s:customUnique`.
+4. **Operator precedence**: `append(allErrors, err).MarkCoveredByDeclarative()` marks ALL errors. Correct: `append(allErrors, err.MarkCoveredByDeclarative())`.
+5. Avoid redundant validation structure (spec fields in both top-level validator and `validateSpec()`).
+
+### Test Conventions
+1. Use unified test case maps with `expectedErrs field.ErrorList` (nil = success). No separate loops.
+2. Include boundary cases: for `+k8s:minimum=0`, test -1, 0, 1, and a larger positive value.
+3. Use tweak functional options: `mkValid<Kind>(tweakers ...func(*api.<Kind>))`.
+4. Set ResourceVersion in the test loop, not mk helpers.
+5. Order API versions semantically: `v1alpha1`, `v1beta1`, `v1`.
+6. Both create and update test coverage for every migrated field.
+7. Accurate function/test names (e.g., `tweakEgressToIPBlock` not `tweakEgressIPBlock`).
+8. No unnecessary linewraps.
+
+### Ratcheting
+- DV auto-ratchets unchanged fields on update, but HV may not. Verify behavior parity.
+- If HV always validates regardless of old value, this creates a mismatch. Skip the tag or update HV.
+
+### Fuzz Testing
+- Register new API groups in `pkg/api/testing/validation_test.go` `typesWithDeclarativeValidation` slice.
+- Shared internal types (e.g., `Scale`) across API groups may block registration until all groups are plumbed.
+
+### Code Generation
+- After completing code modifications, run `hack/update-codegen.sh validation`.
+- Do NOT run `make verify`.
+- Run tests: `make test WHAT=./pkg/registry/<group>/<kind>`.
+
+## Reference PRs
+
+When reviewing or authoring DV changes, these PRs serve as exemplars:
+
+| PR | Description | Key Pattern |
+| :--- | :--- | :--- |
+| [#130724](https://github.com/kubernetes/kubernetes/pull/130724) | Enable DV for ReplicationController | Original exemplar, test structure |
+| [#132361](https://github.com/kubernetes/kubernetes/pull/132361) | Enable DV for CertificateSigningRequest | Multi-version pattern |
+| [#133068](https://github.com/kubernetes/kubernetes/pull/133068) | CSR/status subresource | Subresource pattern |
+| [#134072](https://github.com/kubernetes/kubernetes/pull/134072) | Enable DV for ResourceClaim | Complex resource |
+| [#134113](https://github.com/kubernetes/kubernetes/pull/134113) | ResourceClaim/status + centralized helper | Refactored helper pattern |
+| [#133937](https://github.com/kubernetes/kubernetes/pull/133937) | Simplified testing | Simplified test framework |
+| [#135412](https://github.com/kubernetes/kubernetes/pull/135412) | Enable DV for HorizontalPodAutoscaler | Feature-gated validation, shared types in fuzz |
+| [#135438](https://github.com/kubernetes/kubernetes/pull/135438) | Storage group wiring | New API group plumbing, `+k8s:immutable` on struct |
+| [#135761](https://github.com/kubernetes/kubernetes/pull/135761) | DV for ValidatingAdmissionPolicyBinding | MarkCoveredByDeclarative precedence pitfall |
+| [#135763](https://github.com/kubernetes/kubernetes/pull/135763) | Wire admissionregistration for DV | API group plumbing, fuzz test registration |
+| [#135951](https://github.com/kubernetes/kubernetes/pull/135951) | DV for CronJob Schedule | Ratcheting mismatch awareness, tag ordering |
+| [#136793](https://github.com/kubernetes/kubernetes/pull/136793) | DV Framework: Validation Lifecycle | Alpha/Beta/GA lifecycle, `WithDeclarativeEnforcement()` option |
+
+**For structured PR review workflows and test coverage analysis, use the `/dv:review` command.**

--- a/skills/declarative_validation_review/SKILL.md
+++ b/skills/declarative_validation_review/SKILL.md
@@ -1,0 +1,318 @@
+---
+name: declarative-validation-review
+description: >
+  Use this skill when reviewing or triaging pull requests, issues, or code changes
+  related to Kubernetes declarative validation (validation-gen, validation tags like
+  +k8s:required, +k8s:minimum, +k8s:format, etc.), the DeclarativeValidation or
+  DeclarativeValidationBeta feature gates, or migration from handwritten validation
+  to declarative validation.
+---
+
+# Declarative Validation Review Expert
+
+You are an expert in reviewing Kubernetes Declarative Validation (DV) pull requests. You possess deep knowledge of the validation-gen code generator, the migration process, the validation lifecycle, and the review standards enforced by senior Kubernetes maintainers.
+
+## KEP-5073 Background
+
+Declarative Validation (DV) replaces the ~15k lines of hand-written validation in the Kubernetes codebase with IDL tags (`+k8s:*`) placed directly on API type definitions in `types.go` files. A code generator called `validation-gen` reads these tags and produces validation code that is functionally equivalent to the hand-written validation.
+
+**Key architecture:**
+- Tags are placed on **versioned types** in `staging/src/k8s.io/api/<group>/<version>/types.go`
+- Tags must **NOT** be placed on internal types in `pkg/apis/<group>/types.go`
+- Generated code lives alongside the types
+- During migration, both hand-written validation (HV) and declarative validation (DV) run in parallel
+- Mismatch detection tracks differences via `declarative_validation_mismatch_total` metric
+
+**Feature gates:**
+- `DeclarativeValidation`: Enables the DV code path (runs DV alongside HV)
+- `DeclarativeValidationBeta` (default: **on**): Controls enforcement of Beta-stage DV rules. When enabled, Beta DV rules are authoritative and corresponding HV errors are filtered. Replaces the deprecated `DeclarativeValidationTakeover`.
+
+## Validation Lifecycle
+
+DV uses a stability-based lifecycle for validation rules, controlled by tag prefixes:
+
+### Alpha (`+k8s:alpha`)
+```go
+// +k8s:alpha(since:v1.36)=+k8s:minimum=0
+```
+- **Shadow mode only**: DV runs alongside HV but DV errors are never returned to clients
+- Mismatches are recorded via metrics only
+- HV remains fully authoritative
+- Alpha validation errors **cannot** be tested via `strategy.go` (they're never in the output); rely on mismatch metrics for correctness verification
+- Used when first migrating an existing validation to DV
+
+### Beta (`+k8s:beta`)
+```go
+// +k8s:beta(since:v1.37)=+k8s:minimum=0
+```
+- **Enforced by default** when `DeclarativeValidationBeta` gate is enabled
+- Corresponding HV errors are filtered out (DV is authoritative)
+- Users can disable by turning off the `DeclarativeValidationBeta` gate
+- When promoting from Alpha to Beta, test cases need updating
+
+### Stable (no prefix)
+```go
+// +k8s:minimum=0
+```
+- **Permanently enforced** - no gate can disable it
+- The corresponding HV code should be **removed** (not just marked)
+- If HV is not removed, mismatch detection will catch duplicate errors
+
+### New APIs (no handwritten fallback)
+For brand-new APIs that never had hand-written validation:
+- Use tags **without** any lifecycle prefix (they are stable from the start)
+- No need for the `rest.WithDeclarativeEnforcement()` option since there's no HV to coordinate with
+
+### Strategy File Plumbing
+- For migration: use `rest.ValidateDeclarativelyWithMigrationChecks`
+- For lifecycle-aware resources: pass `rest.WithDeclarativeEnforcement()` as a variadic option to `rest.ValidateDeclarativelyWithMigrationChecks`
+- Do **not** use the deprecated `rest.ValidateDeclarativelyWithRecovery`
+
+## Complete Validation Tag Reference
+
+| Tag | Description | Scope | Supported Go Types | Example |
+| :--- | :--- | :--- | :--- | :--- |
+| `+k8s:customUnique` | Disables generated uniqueness validation (must be used with `+k8s:listType`). | Field, Type | `[]any`, `*[]any` | `// +k8s:listType=map`<br>`// +k8s:customUnique` |
+| `+k8s:eachKey` | Applies validation to every key in a map. | Field, Type | `map[K]V`, `*map[K]V` | `// +k8s:eachKey=+k8s:maxLength=32` |
+| `+k8s:eachVal` | Applies validation to every value in a list or map. | Field, Type | `[]T`, `*[]T`, `map[K]V` | `// +k8s:eachVal=+k8s:minimum=1` |
+| `+k8s:enum` | Marks a string type as an enumeration. | Type | `string`, `*string` | `// +k8s:enum` |
+| `+k8s:enumExclude` | Excludes a constant from the enum values. | Const | const of enum type | `// +k8s:enumExclude` |
+| `+k8s:forbidden` | Indicates that a field must NOT be specified. | Field | Any Go type | `// +k8s:forbidden` |
+| `+k8s:format` | Validates string conforms to a specific format. | Field, Type, ListVal, MapKey | `string`, `*string` | `// +k8s:format=k8s-uuid` |
+| `+k8s:ifDisabled` | Applies validation only if feature is disabled. | Field, Type | Any Go type | `// +k8s:ifDisabled(MyGate)=+k8s:required` |
+| `+k8s:ifEnabled` | Applies validation only if feature is enabled. | Field, Type | Any Go type | `// +k8s:ifEnabled(MyGate)=+k8s:required` |
+| `+k8s:immutable` | The field cannot be changed after creation. | Field, Type | Any Go type | `// +k8s:immutable` |
+| `+k8s:item` | Validates a specific item in a `listType=map` list. | Field, ListVal | `[]struct{...}` | `// +k8s:item(type="A")=+k8s:zeroOrOneOfMember` |
+| `+k8s:listMapKey` | Field name(s) to use as key for `listType=map`. | Field, Type | `[]struct{...}` | `// +k8s:listMapKey=name` |
+| `+k8s:listType` | Defines list behavior for SSA and validation. | Field, Type | `[]any`, `*[]any` | `// +k8s:listType=map` |
+| `+k8s:maxItems` | Limits the maximum number of items in a list. | Field, Type | `[]any`, `*[]any` | `// +k8s:maxItems=1000` |
+| `+k8s:maxLength` | Specifies the maximum length for a string. | Field, Type, MapKey | `string`, `*string` | `// +k8s:maxLength=253` |
+| `+k8s:maxProperties` | Limits the maximum number of keys in a map. | Field, Type | `map[K]V` | `// +k8s:maxProperties=16` |
+| `+k8s:minimum` | Specifies the minimum allowed value for an integer. | Field, Type | `int`, `int32`, etc. | `// +k8s:minimum=0` |
+| `+k8s:neq` | Verifies value is not equal to specific value. | Field, Type | `string`, `int`, `bool` | `// +k8s:neq="Forbidden"` |
+| `+k8s:opaqueType` | Ignores validation defined on the referenced type. | Field | Any Go type | `// +k8s:opaqueType` |
+| `+k8s:optional` | Indicates that a field is optional. | Field | Any Go type | `// +k8s:optional` |
+| `+k8s:required` | Indicates that a field must be specified. | Field | Any Go type | `// +k8s:required` |
+| `+k8s:subfield` | Targets a subfield of a struct for validation. | Type, Field | Any Go type | `// +k8s:subfield(name="foo")=+k8s:optional` |
+| `+k8s:unionDiscriminator` | Field determining active union member. | Field | Any | `// +k8s:unionDiscriminator` |
+| `+k8s:unionMember` | Marks a field as a member of a union. | Field | Any | `// +k8s:unionMember` |
+| `+k8s:unique` | Enforces uniqueness of items in a list. | Field, Type | `[]any`, `*[]any` | `// +k8s:unique=set` |
+| `+k8s:update` | Constrains how a field can be updated. | Field | Any | `// +k8s:update=NoModify` |
+| `+k8s:validateError` | Custom error message. | Field, Type | Any | `// +k8s:validateError="msg"` |
+| `+k8s:validateFalse` | Field must be false. | Field, Type | `bool` | `// +k8s:validateFalse` |
+| `+k8s:validateTrue` | Field must be true. | Field, Type | `bool` | `// +k8s:validateTrue` |
+| `+k8s:zeroOrOneOfMember` | Exclusive choice (at most one set). | Field | Any | `// +k8s:zeroOrOneOfMember` |
+
+**Supported `+k8s:format` values:** `k8s-ip`, `k8s-uuid`, `k8s-label-key`, `k8s-label-value`, `k8s-short-name`, `k8s-long-name`, `k8s-path-segment-name`, `k8s-resource-fully-qualified-name`, `k8s-resource-pool-name`, `k8s-extended-resource-name`
+
+## Common Review Feedback Patterns
+
+These patterns are distilled from review comments on recent DV migration PRs (#130724, #135438, #135715, #135028, #135412, #135164, #135763, #135761, #135951, #136793).
+
+### Test Structure
+
+1. **Unified test case maps**: Use a single `map[string]struct{ ... expectedErrs field.ErrorList }` for both valid and invalid cases. Cases with nil/empty `expectedErrs` are success cases. Do NOT use separate success/failure loops.
+
+2. **Boundary test cases**: For numeric constraints like `+k8s:minimum=0`, include test cases for: -1 (invalid), 0 (boundary valid), 1 (valid), and a larger positive value. For `+k8s:maxLength=63`, test 63 (passing boundary) and 64 (failing).
+
+3. **Tweak functional options pattern**: Use `mkValid<Kind>(tweakers ...func(*api.<Kind>))` to create test objects with modifications:
+   ```go
+   mkValidReplicationController(func(rc *api.ReplicationController) { rc.Spec.Replicas = -1 })
+   ```
+
+4. **Tweak methods for reuse**: Create named tweak functions like `tweakEgressToIPBlock(cidr string)` for commonly modified fields. Names must accurately reflect what is being tweaked.
+
+5. **ResourceVersion in update tests**: Set `ResourceVersion` in the test loop (e.g., `tc.old.ResourceVersion = "1"; tc.update.ResourceVersion = "2"`), not in the `mk` helper.
+
+6. **Separate test files**: DV tests go in `declarative_validation_test.go`, not in `strategy_test.go`.
+
+7. **API version ordering**: Order semantically: `v1alpha1`, `v1beta1`, `v1`.
+
+8. **Both create and update tests**: Every migrated field must have both create and update test coverage.
+
+### Tag Usage Rules
+
+1. **Versioned types only**: Tags go on `staging/src/k8s.io/api/<group>/<version>/types.go`, NOT on internal types `pkg/apis/<group>/types.go`.
+
+2. **Legacy tag pairing**: `+k8s:required` must be paired with `+required`. `+k8s:optional` must be paired with `+optional`. This is required for OpenAPI output consistency and will be enforced by a lint rule. Convention: the legacy tag comes first (`+required` then `+k8s:required`).
+
+3. **Format vs maxLength**: `+k8s:format` does NOT guarantee length enforcement. If the hand-written validation checks length, you still need `+k8s:maxLength` alongside the format tag.
+
+4. **List type coverage**: When migrating list fields, consider adding `+k8s:listType=atomic` alongside other validations for completeness.
+
+5. **Feature-gated validation**: When validation behavior depends on a feature gate, use `+k8s:ifEnabled(GateName)=+k8s:tag` or `+k8s:ifDisabled(GateName)=+k8s:tag`.
+
+### Handwritten Validation (HV) Changes
+
+1. **Never delete HV files**: Mark covered errors with `.MarkCoveredByDeclarative()` and add `.WithOrigin("format=<tag-value>")`.
+
+2. **Origin exemptions**: Error types `Required` and `NotSupported` are exempt from `.WithOrigin()` marking.
+
+3. **customUnique exception**: Do NOT use `.MarkCoveredByDeclarative()` on uniqueness errors when using `+k8s:customUnique` (DV is disabled for uniqueness in this case).
+
+4. **Verify coverage**: Check that every `.MarkCoveredByDeclarative()` corresponds to an actual DV tag. Review comments commonly flag: "I don't think this validation is covered by declarative yet. Is it?"
+
+5. **Operator precedence bug**: Watch for `.MarkCoveredByDeclarative()` called on the wrong receiver. This is a common mistake:
+   ```go
+   // WRONG: marks ALL errors in allErrors, not just the new one
+   allErrors = append(allErrors, field.Required(fldPath.Child("name"), "")).MarkCoveredByDeclarative()
+
+   // CORRECT: marks only the new error
+   allErrors = append(allErrors, field.Required(fldPath.Child("name"), "").MarkCoveredByDeclarative())
+   ```
+
+6. **Redundant validation structure**: Flag cases where spec fields are validated in both a top-level validator and a dedicated `validateSpec()` function — this is confusing and leads to duplicate `.MarkCoveredByDeclarative()` calls.
+
+7. **`+k8s:immutable` on struct fields**: If an entire spec is immutable, consider applying `+k8s:immutable` on the spec field itself rather than on individual subfields.
+
+### Strategy File Patterns
+
+1. **Use the correct helper**: `rest.ValidateDeclarativelyWithMigrationChecks` for standard migration. For lifecycle-aware resources, pass `rest.WithDeclarativeEnforcement()` as a variadic option to `rest.ValidateDeclarativelyWithMigrationChecks`.
+
+2. **No redundant validation calls**: Don't call both `Validate` and `ValidateUpdate` in `ValidateUpdate`. The DV framework handles create vs update internally.
+
+3. **Imports**: Add `k8s.io/apimachinery/pkg/api/operation`. Remove unused `k8s.io/apiserver/pkg/util/feature` and feature imports if no longer needed.
+
+### Style & Naming
+
+1. **No unnecessary linewraps**: Keep code concise; don't break lines that fit within reasonable width.
+
+2. **Accurate naming**: Function and test names must precisely describe what they do (e.g., `tweakEgressToIPBlock` not `tweakEgressIPBlock`; `tweakIngressFromIPBlock` not `tweakIngressIPBlock`).
+
+3. **Clean imports**: Follow standard Kubernetes import grouping (stdlib, external, k8s.io).
+
+### Fuzz Testing
+
+1. **Register new API groups**: When plumbing a new API group for DV, add it to `typesWithDeclarativeValidation` in `pkg/api/testing/validation_test.go`.
+
+2. **Shared internal types**: Be aware that some types (e.g., `Scale`) exist in multiple API groups (`autoscaling/v1`, `apps/v1beta1`, `extensions/v1beta1`). All groups must be plumbed before the type can be added to fuzz testing.
+
+### Ratcheting
+
+- DV supports ratcheting via parallel traverse of `obj` and `oldObj` in update validation
+- Only the `ValidateUpdate` call is needed; the `Validate` (create) path is handled within the same DV code when `oldObj` is nil
+- Tags like `+k8s:immutable` use the `oldObj` comparison automatically
+- **Ratcheting mismatch risk**: DV auto-ratchets (skips validation for unchanged fields on update), but HV may not. If HV always validates a field regardless of whether the old value matches, this creates a mismatch. When migrating, verify that HV and DV ratcheting behavior is consistent, or note the discrepancy and skip the tag if necessary.
+
+## Required Tests Per Tag
+
+When reviewing or authoring DV tests, each tag requires specific test coverage:
+
+| Tag | Required Tests |
+| :--- | :--- |
+| `+k8s:required` | Tests should include a case where the required field is not set (or is empty) and expect a `field.Required` error. |
+| `+k8s:minimum` | Tests should cover values that are less than, equal to, and greater than the `minimum` value. For values less than the minimum, expect a `field.Invalid` error. Include boundary cases (e.g., for `minimum=0`: test -1, 0, 1, and a larger positive value). |
+| `+k8s:maxLength` | Tests should cover strings with length less than, equal to, and greater than the `maxLength`. For strings that are too long, expect a `field.TooLong` error. Include boundary (exactly maxLength and maxLength+1). |
+| `+k8s:maxItems` | Tests should cover lists with fewer items than, exactly, and more items than the `maxItems` value. For lists with too many items, expect a `field.TooMany` error. |
+| `+k8s:maxProperties` | Tests should cover maps with fewer properties than, exactly, and more properties than the `maxProperties` value. For maps with too many properties, expect a `field.TooMany` error. |
+| `+k8s:format` | Tests should cover both valid and invalid formats. For invalid formats, expect a `field.Invalid` error. |
+| `+k8s:enum` | Tests should cover both valid and invalid enum values. For invalid values, the expected error is `field.NotSupported`. |
+| `+k8s:enumExclude` | Tests should verify that the excluded enum value is rejected with a `field.NotSupported` error. |
+| `+k8s:forbidden` | Tests should include a case where the forbidden field is set and expect a `field.Forbidden` error. |
+| `+k8s:immutable` | Tests should include an update operation that attempts to change the immutable field and expects a `field.Invalid` error with the message "field is immutable". Use `apitesting.VerifyUpdateValidationEquivalence`. |
+| `+k8s:eachVal` | Tests should cover valid and invalid values in a slice or map. For slices, the `field.Path` is constructed using `.Index()`. The error origin should correspond to the nested tag. |
+| `+k8s:eachKey` | Tests should cover valid and invalid keys. The `field.Path` for a map key is constructed using `.Key()`. The error origin should correspond to the nested tag. |
+| `+k8s:ifEnabled` | Tests should cover both scenarios: when the feature gate is enabled and when it is disabled. Use `featuregatetesting.SetFeatureGateDuringTest` to control the feature gate. |
+| `+k8s:ifDisabled` | Tests should cover both scenarios: when the feature gate is enabled and when it is disabled. Use `featuregatetesting.SetFeatureGateDuringTest` to control the feature gate. |
+| `+k8s:customUnique` | Do NOT include test cases for uniqueness (duplicates) in `declarative_validation_test.go`. Uniqueness logic is handwritten and should be tested in the corresponding handwritten validation tests. Verify that OTHER declarative tags on the same field are tested. |
+| `+k8s:item` | Tests should verify that the validation rule is applied only to the items that match the key-value pair. Also include tests for items that do not match, to ensure the validation is not applied to them. |
+| `+k8s:listMapKey` | This tag is tested indirectly through other tags that rely on it, like `+k8s:unique` and `+k8s:item`. |
+| `+k8s:listType` | This tag is tested indirectly through other tags like `+k8s:unique` and `+k8s:item`. Tests should verify the uniqueness and merging behavior implied by the `listType`. |
+| `+k8s:neq` | Tests should cover both allowed values and the disallowed value. For the disallowed value, expect a `field.Invalid` error. |
+| `+k8s:opaqueType` | Tests should demonstrate that fields of this type are *not* validated, even if they contain data that would otherwise be invalid. Also, test that validation on other fields in the same struct is still enforced. |
+| `+k8s:optional` | If overriding a `+k8s:required` tag on a type, tests should verify that the field can be empty, while other fields of the same type (without the override) cannot. |
+| `+k8s:subfield` | Tests should verify that the validation rule is correctly applied to the specified sub-field by checking the `field.Path` in the returned error. |
+| `+k8s:unionDiscriminator` | Tests should verify that exactly one of the union member fields is set and that the discriminator field is set to the correct value corresponding to the chosen member. Include invalid cases like multiple members set, mismatched discriminator, and no member set. |
+| `+k8s:unionMember` | Same as `+k8s:unionDiscriminator`. |
+| `+k8s:unique` | For `listType=set`, tests should include a list with duplicate items and expect a `field.Duplicate` error. For `listType=map`, see `+k8s:listMapKey`. |
+| `+k8s:update` | Tests should cover the specific update constraints (`NoSet`, `NoUnset`, `NoModify`). For `NoSet`, test nil -> non-nil. For `NoUnset`, test non-nil -> nil. For `NoModify`, test non-nil -> another non-nil. All should be update tests. |
+| `+k8s:validateError` | Tests should trigger the validation rule and verify that the resulting error message contains the custom message. |
+| `+k8s:validateFalse` | Tests should cover both `true` (invalid) and `false` (valid) cases. |
+| `+k8s:validateTrue` | Tests should cover both `true` (valid) and `false` (invalid) cases. |
+| `+k8s:zeroOrOneOfMember` | Tests should cover all valid (zero or one member set) and invalid (more than one member set) combinations. |
+
+## Review Checklist
+
+Based on patterns from senior Kubernetes maintainers, check the following:
+
+### Tags & Types
+- [ ] Tags are on versioned types ONLY (`staging/src/k8s.io/api/...`), not internal types
+- [ ] `+k8s:required` paired with `+required`; `+k8s:optional` paired with `+optional` (legacy tag first)
+- [ ] `+k8s:format` accompanied by `+k8s:maxLength` where the HV checks length
+- [ ] `+k8s:listType=atomic` considered for list fields being migrated
+- [ ] `+k8s:immutable` on struct field considered when entire struct is immutable
+- [ ] Lifecycle prefix (`+k8s:alpha`/`+k8s:beta`) used appropriately for migration stage
+- [ ] No stale or unused code left in the diff
+
+### Handwritten Validation
+- [ ] Every `.MarkCoveredByDeclarative()` has a corresponding DV tag
+- [ ] `.WithOrigin()` set correctly (exempt for Required/NotSupported error types)
+- [ ] `.MarkCoveredByDeclarative()` NOT used with `+k8s:customUnique` uniqueness errors
+- [ ] `.MarkCoveredByDeclarative()` called on individual error, not on `append()` result (operator precedence)
+- [ ] No redundant validation (e.g., checking spec fields in both top-level and spec validator)
+- [ ] Ratcheting behavior matches between HV and DV (DV auto-ratchets unchanged fields)
+
+### Strategy
+- [ ] Uses `rest.ValidateDeclarativelyWithMigrationChecks` (with optional `rest.WithDeclarativeEnforcement()` for lifecycle-aware resources), NOT deprecated `ValidateDeclarativelyWithRecovery`
+- [ ] No redundant Validate/ValidateUpdate calls
+- [ ] References `DeclarativeValidationBeta` (NOT deprecated `DeclarativeValidationTakeover`)
+
+### Tests
+- [ ] Tests in `declarative_validation_test.go` (not `strategy_test.go`)
+- [ ] Unified test case map (no separate success/failure loops)
+- [ ] Boundary test cases for numeric constraints
+- [ ] Both create and update test coverage
+- [ ] Tweak functional options pattern used
+- [ ] ResourceVersion set in test loop, not mk helpers
+- [ ] API versions ordered semantically
+- [ ] Fuzz testing registered for new API groups
+- [ ] No unnecessary linewraps in code
+- [ ] Function/test names accurately describe their purpose
+
+## Review Report Template
+
+Structure your review report with the following sections:
+
+*   **Summary of Changes**: List the fields for which tags have been added and the tags added for each field.
+*   **Validation Tag Correctness**
+*   **Structural and Coupling Requirements**
+*   **Validation Migration Analysis** (covering handwritten validation, strategy files, and new validation)
+*   **Testing Analysis**: List the fields annotated in the PR one by one, with each tag and its test coverage:
+
+KIND
+    FieldName1
+        TagName1
+            Create:
+                Covered
+                    1. Verbose test case 1
+                Missing
+                    1. Verbose missing test case description 1
+            Update:
+                Covered
+                    1. Verbose test case 1
+                Missing
+                    1. Verbose missing test case description 1
+
+*   **Common Reviewer Feedback Checklist** (see Review Checklist above)
+*   **Conclusion** (state whether the migration follows the established patterns)
+
+## Reference PRs
+
+When reviewing or authoring DV changes, these PRs serve as exemplars:
+
+| PR | Description | Key Pattern |
+| :--- | :--- | :--- |
+| [#130724](https://github.com/kubernetes/kubernetes/pull/130724) | Enable DV for ReplicationController | Original exemplar, test structure |
+| [#132361](https://github.com/kubernetes/kubernetes/pull/132361) | Enable DV for CertificateSigningRequest | Multi-version pattern |
+| [#133068](https://github.com/kubernetes/kubernetes/pull/133068) | CSR/status subresource | Subresource pattern |
+| [#134072](https://github.com/kubernetes/kubernetes/pull/134072) | Enable DV for ResourceClaim | Complex resource |
+| [#134113](https://github.com/kubernetes/kubernetes/pull/134113) | ResourceClaim/status + centralized helper | Refactored helper pattern |
+| [#133937](https://github.com/kubernetes/kubernetes/pull/133937) | Simplified testing | Simplified test framework |
+| [#135412](https://github.com/kubernetes/kubernetes/pull/135412) | Enable DV for HorizontalPodAutoscaler | Feature-gated validation, shared types in fuzz |
+| [#135438](https://github.com/kubernetes/kubernetes/pull/135438) | Storage group wiring | New API group plumbing, `+k8s:immutable` on struct |
+| [#135761](https://github.com/kubernetes/kubernetes/pull/135761) | DV for ValidatingAdmissionPolicyBinding | MarkCoveredByDeclarative precedence pitfall |
+| [#135763](https://github.com/kubernetes/kubernetes/pull/135763) | Wire admissionregistration for DV | API group plumbing, fuzz test registration |
+| [#135951](https://github.com/kubernetes/kubernetes/pull/135951) | DV for CronJob Schedule | Ratcheting mismatch awareness, tag ordering |
+| [#136793](https://github.com/kubernetes/kubernetes/pull/136793) | DV Framework: Validation Lifecycle | Alpha/Beta/GA lifecycle, `WithDeclarativeEnforcement()` option |
+
+**For step-by-step migration procedures and code templates, use the `/dv:enable` command.**


### PR DESCRIPTION
Add two gemini-cli skills for declarative validation work:
- declarative_validation_authoring: for migrating/enabling DV on APIs
- declarative_validation_review: for reviewing DV migration PRs

Update both dv:enable and dv:review commands with validation lifecycle model (Alpha/Beta/GA), correct WithDeclarativeEnforcement usage as a variadic option, improved test templates, and patterns from recent PRs.