### PR TITLE
Add SIG API Machinery issue triage skill

### DIFF
--- a/skills/apimachinery_issue_triage/SKILL.md
+++ b/skills/apimachinery_issue_triage/SKILL.md
@@ -15,31 +15,20 @@ Triage Kubernetes issues for SIG API Machinery. Produce triage recommendations t
 ## SIG API Machinery Scope
 
 ### Core Domain Areas
-| Area | Description | Key Directories |
-|------|-------------|-----------------|
-| **API Server** | Request handling, admission control, API discovery, OpenAPI | `staging/src/k8s.io/apiserver/`, `pkg/controlplane/` |
-| **CRDs** | CRD lifecycle, validation, conversion webhooks, structural schemas | `staging/src/k8s.io/apiextensions-apiserver/` |
-| **Server-Side Apply (SSA)** | Field management, merge strategies, field ownership | `staging/src/k8s.io/apimachinery/pkg/util/managedfields/` |
-| **Admission Control** | VAP, MAP, webhooks | `plugin/pkg/admission/`, `staging/src/k8s.io/apiserver/pkg/admission/` |
-| **CEL** | CEL in validation rules, admission policies, authorization | `staging/src/k8s.io/apiserver/pkg/cel/` |
-| **API Machinery Libraries** | Types, serialization, conversion, defaulting, scheme | `staging/src/k8s.io/apimachinery/` |
-| **client-go** | Informers, caches, reflectors, work queues, dynamic client | `staging/src/k8s.io/client-go/` |
-| **Code Generators** | deepcopy-gen, conversion-gen, validation-gen, openapi-gen, etc. | `staging/src/k8s.io/code-generator/` |
-| **API Aggregation** | Aggregated API servers, APIService resources | `staging/src/k8s.io/kube-aggregator/` |
-| **Storage / Watch** | etcd backend, watch cache, WatchList, storage version migration | `staging/src/k8s.io/apiserver/pkg/storage/` |
-| **APF** | Flow control, priority levels, flow schemas | `staging/src/k8s.io/apiserver/pkg/util/flowcontrol/` |
-| **Feature Gates** | Feature gate framework, versioned feature gates, emulation versions | `staging/src/k8s.io/component-base/featuregate/` |
-| **CLE** | LeaseCandidate, coordinated leader election | `staging/src/k8s.io/client-go/tools/leaderelection/` |
-| **Declarative Validation** | validation-gen, +k8s:* tags, migration from handwritten validation | `staging/src/k8s.io/code-generator/cmd/validation-gen/` |
-| **OpenAPI** | OpenAPI v2/v3 spec generation, publishing, aggregation | `staging/src/k8s.io/kube-openapi/` |
 
-### Active Initiatives (2025-2026)
-- **Declarative Validation (KEP-5073)**: Migrating ~15k lines of hand-written validation to IDL tags
-- **WatchList / Streaming (KEP-3157)**: Streaming initial object sets via WATCH instead of LIST
-- **Coordinated Leader Election**: Multi-candidate leader election with strategy-based selection
-- **MutatingAdmissionPolicy**: CEL-based admission mutation (companion to VAP)
-- **Compatibility Versions / Emulation Versioning**: Running newer binaries with older API behavior
-- **Storage Version Migration**: Automated migration of stored resource versions
+API Server, CRDs, Server-Side Apply, Admission Control (VAP/MAP/webhooks), CEL, API Machinery Libraries (types/serialization/conversion), client-go, Code Generators, API Aggregation, Storage/Watch, APF, Feature Gates, Coordinated Leader Election, Declarative Validation, OpenAPI.
+
+To determine which directories and OWNERS files are relevant for a given issue, check the OWNERS files in the kubernetes/kubernetes repo. The top-level SIG API Machinery OWNERS files are at:
+- `staging/src/k8s.io/apiserver/OWNERS`
+- `staging/src/k8s.io/apimachinery/OWNERS`
+- `staging/src/k8s.io/client-go/OWNERS`
+- `staging/src/k8s.io/apiextensions-apiserver/OWNERS`
+- `staging/src/k8s.io/kube-aggregator/OWNERS`
+- `staging/src/k8s.io/code-generator/OWNERS`
+
+### Active Initiatives
+
+For current active KEPs and initiatives, check the kubernetes/enhancements repo filtered by SIG API Machinery: https://github.com/kubernetes/enhancements/issues?q=is%3Aissue+is%3Aopen+label%3Asig%2Fapi-machinery
 
 ## Triage Decision Framework
 
@@ -47,19 +36,9 @@ Triage Kubernetes issues for SIG API Machinery. Produce triage recommendations t
 
 ### Step 1: Classify the Issue Type
 
-| Kind | When to Use |
-|------|-------------|
-| `kind/bug` | Something is broken, not working as documented, incorrect results, panics, crashes. Most common. |
-| `kind/feature` | New functionality, API changes, enhancements. Includes KEP proposals. |
-| `kind/flake` | Test passes sometimes and fails other times. Should include CI links and triage board. |
-| `kind/failing-test` | Test consistently failing (not intermittent). |
-| `kind/cleanup` | Code hygiene, deprecated API removal, refactoring. No user-visible change. |
-| `kind/regression` | Behavior that worked in a previous version but is now broken. |
-| `kind/support` | User questions, confusion about expected behavior. |
-| `kind/documentation` | Missing, incorrect, or unclear documentation. |
-| `kind/api-change` | Proposed changes to the Kubernetes API surface. |
+Apply a `kind/*` label using `/kind <type>`. For the full list of available kinds, see https://prow.k8s.io/command-help#kind.
 
-**Heuristics:**
+**Heuristics for common cases:**
 - Title starts with "[Flaking Test]" → `kind/flake`
 - Title starts with "[Failing test]" → `kind/failing-test`
 - "What would you like to be added?" → `kind/feature`
@@ -69,29 +48,28 @@ Triage Kubernetes issues for SIG API Machinery. Produce triage recommendations t
 
 ### Step 2: Determine SIG Ownership
 
-Every issue needs at least `/sig api-machinery`. Add co-owning SIGs when the issue spans multiple domains. Do NOT remove `sig/api-machinery` when adding other SIGs.
+Every issue needs at least one SIG label. If the issue belongs to API Machinery, ensure `/sig api-machinery` is present. If the issue is mis-assigned and does not belong to API Machinery, remove it with `/remove-sig api-machinery` and assign the correct SIG (see "When to Remove sig/api-machinery" below). For cross-cutting issues, multiple SIGs can co-own.
 
-| Co-SIG | When to Add |
-|--------|-------------|
-| `sig/auth` | Admission policies, RBAC, authentication, TLS, EgressSelector |
-| `sig/cli` | kubectl behavior related to API machinery (apply, diff, SSA) |
-| `sig/instrumentation` | Metrics, tracing, logging from apiserver components |
-| `sig/scalability` | Performance, memory, watch cache contention, APF tuning |
-| `sig/network` | APIService connectivity, network-level API issues |
-| `sig/testing` | Test infrastructure, integration test framework |
-| `sig/apps` | Workload APIs when the issue is on the API machinery side |
-| `sig/node` | kubelet API interactions, node-level field selectors |
-| `sig/etcd` | etcd integration, storage backend, etcd version compatibility |
-| `sig/scheduling` | Scheduler API interactions |
-| `sig/storage` | StorageClass/PV APIs when on the API machinery side |
+**Commands:**
+- `/sig api-machinery` — adds the `sig/api-machinery` label. Also clears `do-not-merge/needs-sig` if present.
+- `/remove-sig api-machinery` — removes the `sig/api-machinery` label. Use when the issue does not belong to API Machinery.
+- Multiple SIGs are fine: use `/sig api-machinery` + `/sig auth` in the same comment to co-own.
 
-### Step 3: Evaluate for Acceptance
+When the issue spans multiple domains, add co-owning SIGs. To determine the correct SIG, check the OWNERS files in the relevant code paths or refer to https://github.com/kubernetes/community/blob/master/sig-list.md.
 
-**Accept** (`/triage accepted`) when the issue has a clear bug with version info, a concrete technical proposal, real technical debt with defined scope, test flake/failure with CI links, or is filed by a known contributor with sufficient context.
+### Step 3: Evaluate and Route
+
+`/triage accepted` means "triage is done." Never mark an issue accepted without also routing it — otherwise it gets orphaned. Every accepted issue must have one of: (a) an assignee or `/cc` to a domain expert, (b) redirection to another SIG, or (c) a `/help wanted` label for community pickup.
+
+**Accept and route** (`/triage accepted` + `/cc @<owner>`) when the issue has a clear bug with version info, a concrete technical proposal, real technical debt with defined scope, test flake/failure with CI links, or is filed by a known contributor with sufficient context.
 
 **Request more info** when bug reports lack reproduction steps or version info, feature scope is unclear, or it's unclear which component is responsible.
 
 **Close or redirect** when behavior is working-as-designed, issue is a duplicate, belongs to a different project, needs a KEP (redirect to kubernetes/enhancements), or is a support question for Slack/Stack Overflow.
+
+**Routing:** To find the right reviewer, identify the relevant code path and check its OWNERS file in the kubernetes/kubernetes repo. Use `/cc @<reviewer>` to route.
+
+Mark well-scoped issues with `/help wanted` or `/good-first-issue` for community contribution.
 
 ### Step 4: Set Priority
 
@@ -105,29 +83,7 @@ Most issues rely on `triage/accepted` alone. Apply priority labels selectively:
 | `priority/backlog` | Nice-to-have, minor cleanup |
 | `priority/awaiting-more-evidence` | Feature requests without sufficient demand |
 
-### Step 5: Assign Owners
-
-| Domain Area | Key Maintainers |
-|-------------|-----------------|
-| CEL, Validation Rules, CRD Formats | @jpbetz, @cici37 |
-| ValidatingAdmissionPolicy, MutatingAdmissionPolicy | @jpbetz, @cici37 |
-| Server-Side Apply (SSA) | @jpbetz |
-| Declarative Validation | @jpbetz, @thockin, @yongruilin |
-| OpenAPI v2/v3 | @jpbetz, @Jefftree |
-| Coordinated Leader Election | @Jefftree, @Henrywu573 |
-| Compatibility Versions, Emulation | @Jefftree, @jpbetz |
-| Code Generators | @Jefftree |
-| API Aggregation | @Jefftree |
-| Feature Gates, Versioned Feature Gates | @siyuanfoundation |
-| Watch Cache, WatchList, Streaming | @serathius, @p0lyn0mial |
-| Storage, etcd integration | @serathius |
-| API Priority and Fairness (APF) | @MikeSpreworst |
-| General API Server, Core Framework | @liggitt, @deads2k, @sttts |
-| client-go, Informers | @deads2k |
-
-Mark well-scoped issues with `/help wanted` or `/good-first-issue` for community contribution.
-
-### Step 6: Manage Issue Lifecycle
+### Step 5: Manage Issue Lifecycle
 
 - `/remove-lifecycle stale` — keep important issues from going stale
 - `/lifecycle frozen` — protect umbrella issues and long-running discussions from auto-closure
@@ -135,25 +91,13 @@ Mark well-scoped issues with `/help wanted` or `/good-first-issue` for community
 
 ## Slash Command Reference
 
-```
-/kind bug|feature|flake|failing-test|cleanup|regression|support|documentation
-/sig api-machinery|auth|cli|instrumentation|...
-/triage accepted|needs-information
-/priority critical-urgent|important-soon|important-longterm|backlog|awaiting-more-evidence
-/area apiserver|custom-resources|code-generation|client-libraries|admission-control|test
-/assign [@username]
-/cc @username
-/help wanted
-/good-first-issue
-/lifecycle frozen|active
-/remove-lifecycle stale|rotten
-/remove-sig <sig-name>
-/close
-```
+Full command documentation: https://prow.k8s.io/command-help
+
+Commands most used during triage: `/kind`, `/sig`, `/remove-sig`, `/triage`, `/priority`, `/cc`, `/assign`, `/close`, `/lifecycle`, `/remove-lifecycle`, `/help wanted`, `/good-first-issue`.
 
 ## Triage Comment Templates
 
-**Accept:**
+**Accept and route:**
 ```
 /kind bug
 /triage accepted
@@ -167,24 +111,7 @@ Could you provide [specific missing details]?
 /triage needs-information
 ```
 
-**Cross-SIG routing:**
-```
-This issue touches both API machinery and [other SIG].
-
-/sig api-machinery
-/sig <other-sig>
-/cc @<other-sig-lead>
-/triage accepted
-```
-
-**Close:**
-```
-This is working-as-designed because [explanation].
-
-/close
-```
-
-**Remove sig/api-machinery:**
+**Reassign to another SIG:**
 ```
 This issue is about [specific domain] rather than API server infrastructure. The [component] is owned by [other SIG].
 
@@ -192,11 +119,61 @@ This issue is about [specific domain] rather than API server infrastructure. The
 /sig <correct-sig>
 ```
 
+**Co-own with another SIG (rare):**
+```
+This issue touches both API machinery and [other SIG].
+
+/sig <other-sig>
+/cc @<other-sig-lead>
+/triage accepted
+```
+
+**Close — working as designed:**
+```
+This is working-as-designed because [explanation].
+
+/close
+```
+
+**Close — duplicate:**
+```
+Duplicate of #<number>.
+
+/close
+```
+
+**Close — stale / not reproducible:**
+```
+This issue has not been reproducible on recent versions. Closing — please reopen if you can still reproduce on v1.XX.
+
+/close
+```
+
+**Close — support question:**
+```
+This is a usage question rather than a bug or feature request. Please ask on the #sig-api-machinery Slack channel or Stack Overflow.
+
+/close
+```
+
+**Close — needs KEP:**
+```
+This feature request needs a KEP. Please file a KEP in kubernetes/enhancements and link it here.
+
+/close
+```
+
 ## When to Remove sig/api-machinery
 
 > **SIG API Machinery owns API server infrastructure, conventions, serialization, and generic mechanisms — not every issue that involves a Kubernetes API resource or mentions the API server.**
 
 The SIG that owns the **code path where the bug lives** is the correct SIG, not the SIG whose domain the symptom superficially resembles.
+
+### sig/api-machinery vs. API Review
+
+- **sig/api-machinery** owns the infrastructure: the API server, request handling, admission, storage, serialization, code generators, client-go, CRD engine, and generic mechanisms that all APIs depend on.
+- **API review** is a cross-cutting process. Any SIG proposing Kubernetes API changes (new fields, new resources, new versions) must go through API review, which is led by @thockin and @jpbetz. API review issues/PRs get the `api-review` label but do **not** necessarily belong to `sig/api-machinery` — the owning SIG is whichever SIG owns the API being changed (e.g., `sig/node` for Node API changes, `sig/apps` for Deployment API changes).
+- Only add `sig/api-machinery` when the issue is about the API infrastructure itself, not simply because an API is involved.
 
 ### Removal Patterns
 
@@ -216,7 +193,7 @@ The SIG that owns the **code path where the bug lives** is the correct SIG, not 
 ### Decision Checklist
 
 Remove `sig/api-machinery` if ALL of these are true:
-1. The buggy code lives outside api-machinery owned directories (`staging/src/k8s.io/{apiserver,apimachinery,client-go,apiextensions-apiserver,kube-aggregator}/`)
+1. The relevant code lives outside api-machinery owned directories (`staging/src/k8s.io/{apiserver,apimachinery,client-go,apiextensions-apiserver,kube-aggregator}/`)
 2. The fix would be made in code owned by another SIG
 3. The issue is about a specific resource's behavior, not generic API mechanisms
 4. The API server is just the surface where the symptom appears, not the root cause


### PR DESCRIPTION
Covers SIG scope, triage decision framework (classify, SIG ownership, acceptance, priority, owner routing, lifecycle), slash command reference, comment templates, and when to remove sig/api-machinery with 10 removal patterns and a decision checklist.