### PR TITLE
[repo-agent] Fix review YAML unmarshal error caused by quoted line numbers

### DIFF
--- a/repo-agent/pkg/prompts/review_system.txt
+++ b/repo-agent/pkg/prompts/review_system.txt
@@ -85,7 +85,7 @@ Output:
 ---------------------
 class DraftReviewComment(BaseModel):
     path: str = Field(description="The file path of the relevant file")
-    line: str = Field(description="line no where the comment is anchored. should be within the line range in the diff")
+    line: int = Field(description="line no where the comment is anchored. should be within the line range in the diff")
     body: str = Field(description="detailed review comment for the line")
     side: str = Field(description="RIGHT|LEFT. RIGHT if commenting on additions starting with '+', LEFT if commenting on deletions starting with '-'.")
     severity: str = Field(description="severity of the comment. one of [LOW, MEDIUM, HIGH]")


### PR DESCRIPTION
Fixes #696

The Pydantic schema in the review prompt (`review_system.txt`) defined the `line` field as `str: line: str = Field(description="line no where the comment is anchored...")`

But the Go struct expects *int:
```go
  Line *int `yaml:"line,omitempty" json:"line,omitempty"`
```

Previously this mismatch was harmless because the model output raw YAML directly, where `159` without quotes is a valid scalar regardless of the schema type. After the addition of `--output-format json` (for LLM stats tracking), the model operates in a JSON-aware mode where string-typed fields are consistently quoted — producing line: "159" instead of line: 159, which Go's YAML parser rejects.