### PR TITLE
feat: add configurable severity threshold to RepoWatch CRD

### DIFF
--- a/repo-agent/api/repowatch/v1alpha1/repowatch_types.go
+++ b/repo-agent/api/repowatch/v1alpha1/repowatch_types.go
@@ -104,6 +104,12 @@ type PRReviewSpec struct {
 	// +kubebuilder:validation:Optional
 	IgnoreFiles []string `json:"ignoreFiles,omitempty"`
 
+	// SeverityThreshold sets the minimum severity level for review comments to be posted.
+	// Comments below this threshold will be filtered out. Valid values: "LOW", "MEDIUM", "HIGH".
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum=LOW;MEDIUM;HIGH;CRITICAL
+	SeverityThreshold string `json:"severityThreshold,omitempty"`
+
 	// The time in minutes after which a review sandbox will be scaled down to 0 replicas.
 	// +kubebuilder:validation:Optional
 	ReviewShutdownAfterMinutes int `json:"reviewShutdownAfterMinutes,omitempty"`

--- a/repo-agent/k8s/crds/review.gemini.google.com_repowatches.yaml
+++ b/repo-agent/k8s/crds/review.gemini.google.com_repowatches.yaml
@@ -283,6 +283,13 @@ spec:
                     type: integer
                   robotAccount:
                     type: string
+                  severityThreshold:
+                    enum:
+                    - LOW
+                    - MEDIUM
+                    - HIGH
+                    - CRITICAL
+                    type: string
                   workspaceDiskSize:
                     default: 10Gi
                     type: string

--- a/repo-agent/pkg/commands/review.go
+++ b/repo-agent/pkg/commands/review.go
@@ -467,6 +467,19 @@ func (c *ReviewCommand) Run(ctx context.Context) error {
 			// Restore/Merge labels
 			accumulatedAgentOutput.Labels = append(accumulatedAgentOutput.Labels, existingLabels...)
 			accumulatedAgentOutput.Labels = uniqueStrings(accumulatedAgentOutput.Labels)
+
+			// Filter comments by severity threshold on the first run too
+			if c.SeverityThreshold != "" && accumulatedAgentOutput.Review != nil {
+				var filtered []*models.DraftReviewComment
+				for _, comment := range accumulatedAgentOutput.Review.Comments {
+					if getSeverityLevel(comment.Severity) >= getSeverityLevel(c.SeverityThreshold) {
+						filtered = append(filtered, comment)
+					} else if comment.Path != nil {
+						log.Info("Filtering out comment below severity threshold", "file", *comment.Path, "severity", comment.Severity, "threshold", c.SeverityThreshold)
+					}
+				}
+				accumulatedAgentOutput.Review.Comments = filtered
+			}
 		} else {
 			for _, newComment := range agentOutput.Review.Comments {
 				if newComment == nil || newComment.Path == nil || newComment.Line == nil || newComment.Body == nil {
@@ -839,6 +852,8 @@ func filterDiffFiles(repoDir string, diffFiles []*gitdiff.File, ignoreFiles []st
 
 func getSeverityLevel(severity string) int {
 	switch strings.ToLower(severity) {
+	case "critical":
+		return 4
 	case "high":
 		return 3
 	case "medium":

--- a/repo-agent/pkg/commands/severity_test.go
+++ b/repo-agent/pkg/commands/severity_test.go
@@ -11,6 +11,8 @@ func TestGetSeverityLevel(t *testing.T) {
 		severity string
 		want     int
 	}{
+		{"CRITICAL", 4},
+		{"Critical", 4},
 		{"HIGH", 3},
 		{"High", 3},
 		{"medium", 2},
@@ -38,12 +40,14 @@ func TestFilterComments(t *testing.T) {
 		return filtered
 	}
 
+	critical := "CRITICAL"
 	high := "HIGH"
 	medium := "MEDIUM"
 	low := "LOW"
 	empty := ""
 
 	comments := []*models.DraftReviewComment{
+		{Severity: critical},
 		{Severity: high},
 		{Severity: medium},
 		{Severity: low},
@@ -54,10 +58,11 @@ func TestFilterComments(t *testing.T) {
 		threshold string
 		want      int
 	}{
-		{"HIGH", 1},
-		{"MEDIUM", 3},
-		{"LOW", 4},
-		{"", 3},
+		{"CRITICAL", 1},
+		{"HIGH", 2},
+		{"MEDIUM", 4},
+		{"LOW", 5},
+		{"", 4},
 	}
 
 	for _, tt := range tests {

--- a/repo-agent/pkg/controllers/repowatch/repowatch_controller.go
+++ b/repo-agent/pkg/controllers/repowatch/repowatch_controller.go
@@ -1245,6 +1245,7 @@ func (r *Reconciler) createReviewSandboxForPR(ctx context.Context, repoWatch *re
 									map[string]interface{}{"name": "PRID", "value": fmt.Sprintf("%d", *pr.Number)},
 									map[string]interface{}{"name": "MAX_REVIEW_FILES", "value": strconv.Itoa(repoWatch.Spec.Review.MaxReviewFiles)},
 									map[string]interface{}{"name": "IGNORE_FILES", "value": strings.Join(repoWatch.Spec.Review.IgnoreFiles, ",")},
+									map[string]interface{}{"name": "SEVERITY_THRESHOLD", "value": repoWatch.Spec.Review.SeverityThreshold},
 									map[string]interface{}{"name": "AGENT_NAME", "value": repoWatch.Spec.Review.LLM.Provider},
 									map[string]interface{}{
 										"name": "AGENT_LLM_EXTENSIONS",

--- a/repo-agent/pkg/prompts/review_system.txt
+++ b/repo-agent/pkg/prompts/review_system.txt
@@ -88,7 +88,7 @@ class DraftReviewComment(BaseModel):
     line: int = Field(description="line no where the comment is anchored. should be within the line range in the diff")
     body: str = Field(description="detailed review comment for the line")
     side: str = Field(description="RIGHT|LEFT. RIGHT if commenting on additions starting with '+', LEFT if commenting on deletions starting with '-'.")
-    severity: str = Field(description="severity of the comment. one of [LOW, MEDIUM, HIGH]")
+    severity: str = Field(description="severity of the comment. one of [LOW, MEDIUM, HIGH, CRITICAL]. LOW: style, naming, minor suggestions — nice-to-have improvements. MEDIUM: missing edge cases, maintainability concerns — should fix. HIGH: bugs, security vulnerabilities, data loss risks — must fix before merge. CRITICAL: breaking changes, security exploits, production outages — blocks merge.")
 
 class PullRequestReviewRequest(BaseModel):
     body: str = Field(description="The body text of the pull request review.")


### PR DESCRIPTION
Add severityThreshold field to PRReviewSpec so users can configure the minimum severity level for review comments from the RepoWatch. Also add CRITICAL severity level and define all severity levels (LOW, MEDIUM, HIGH, CRITICAL) with clear descriptions in the prompt. Fix severity filtering to apply on the first review run as well.