### PR TITLE
Revert "No in-pod flag for rollback"

### DIFF
--- a/repo-agent/pkg/taskrunner/runner.go
+++ b/repo-agent/pkg/taskrunner/runner.go
@@ -222,7 +222,7 @@ func (tr *TaskRunner) executeTask(ctx context.Context, task *sandboxtaskv1alpha1
 		}
 
 	case "rollback":
-		cmd = exec.Command(sandbox.RepoSandboxBinary, "rollback")
+		cmd = exec.Command(sandbox.RepoSandboxBinary, "rollback", "--in-pod=true")
 		// Map params to env vars
 		cmd.Env = os.Environ()
 		// Inject params into env


### PR DESCRIPTION
Reverts gke-labs/gemini-for-kubernetes-development#746

We switched to bash based task which takes inpod flag