### PR TITLE
Support pausing and resuming chores from the Overseer UI

### DIFF
--- a/repo-agent/pkg/api/handlers_overseer.go
+++ b/repo-agent/pkg/api/handlers_overseer.go
@@ -8,8 +8,10 @@ import (
 	"net/url"
 
 	"github.com/gin-gonic/gin"
+	"github.com/gke-labs/gemini-for-kubernetes-development/repo-agent/pkg/k8s"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
 )
 
@@ -208,4 +210,100 @@ func (s *Server) getChoreTaskLogs(c *gin.Context) {
 		req.URL.Path = fmt.Sprintf("/logs/%s", taskID)
 	}
 	proxy.ServeHTTP(c.Writer, c.Request)
+}
+
+func (s *Server) pauseChore(c *gin.Context) {
+	overseerName := c.Param("name")
+	choreName := c.Param("choreName")
+	namespace := fmt.Sprintf("overseer-%s", overseerName)
+
+	overseer, err := s.K8sManager.GetOverseer(c.Request.Context(), overseerName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get overseer"})
+		return
+	}
+
+	realChoreName := choreName
+	sandbox, err := s.K8sManager.Client.Resource(k8s.SandboxGVR).Namespace(namespace).Get(c.Request.Context(), choreName, v1.GetOptions{})
+	if err == nil {
+		labelName, found, _ := unstructured.NestedString(sandbox.Object, "metadata", "labels", "chore.gemini.google.com/name")
+		if found && labelName != "" {
+			realChoreName = labelName
+		}
+	}
+
+	excludeList, found, err := unstructured.NestedStringSlice(overseer.Object, "spec", "chores", "exclude")
+	if err != nil || !found {
+		excludeList = []string{}
+	}
+
+	exists := false
+	for _, e := range excludeList {
+		if e == realChoreName {
+			exists = true
+			break
+		}
+	}
+
+	if !exists {
+		excludeList = append(excludeList, realChoreName)
+		if err := unstructured.SetNestedStringSlice(overseer.Object, excludeList, "spec", "chores", "exclude"); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to set exclude list"})
+			return
+		}
+		_, err = s.K8sManager.Client.Resource(k8s.OverseerGVR).Update(c.Request.Context(), overseer, v1.UpdateOptions{})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update overseer"})
+			return
+		}
+	}
+
+	err = s.K8sManager.Client.Resource(k8s.SandboxGVR).Namespace(namespace).Delete(c.Request.Context(), choreName, v1.DeleteOptions{})
+	if err != nil {
+		klog.Errorf("Failed to delete sandbox %s: %v", choreName, err)
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Chore paused"})
+}
+
+func (s *Server) resumeChore(c *gin.Context) {
+	overseerName := c.Param("name")
+	choreName := c.Param("choreName")
+
+	overseer, err := s.K8sManager.GetOverseer(c.Request.Context(), overseerName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get overseer"})
+		return
+	}
+
+	excludeList, found, err := unstructured.NestedStringSlice(overseer.Object, "spec", "chores", "exclude")
+	if !found || err != nil {
+		c.JSON(http.StatusOK, gin.H{"message": "Chore already active"})
+		return
+	}
+
+	newList := make([]string, 0)
+	for _, e := range excludeList {
+		if e != choreName {
+			newList = append(newList, e)
+		}
+	}
+
+	if len(newList) != len(excludeList) {
+		if len(newList) == 0 {
+			unstructured.RemoveNestedField(overseer.Object, "spec", "chores", "exclude")
+		} else {
+			if err := unstructured.SetNestedStringSlice(overseer.Object, newList, "spec", "chores", "exclude"); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to set exclude list"})
+				return
+			}
+		}
+		_, err = s.K8sManager.Client.Resource(k8s.OverseerGVR).Update(c.Request.Context(), overseer, v1.UpdateOptions{})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update overseer"})
+			return
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Chore resumed"})
 }

--- a/repo-agent/pkg/api/server.go
+++ b/repo-agent/pkg/api/server.go
@@ -111,6 +111,8 @@ func (s *Server) RegisterRoutes(router *gin.Engine) {
 			overseer.GET("/:name/logs", s.getOverseerLogs)
 			overseer.GET("/:name/chores/:choreName/logs", s.getChoreLogs)
 			overseer.GET("/:name/chores/:choreName/tasks", s.getChoreTasks)
+			overseer.POST("/:name/chores/:choreName/pause", s.pauseChore)
+			overseer.POST("/:name/chores/:choreName/resume", s.resumeChore)
 		}
 	}
 

--- a/repo-agent/review-ui/ui/src/Overseer.js
+++ b/repo-agent/review-ui/ui/src/Overseer.js
@@ -33,7 +33,7 @@ const Overseer = ({ onBack, getSandboxStatusClass, namespace: userNamespace }) =
 
     const logIntervalRef = useRef(null);
 
-    const fetchOverseers = useCallback(() => {
+        const fetchOverseers = useCallback(() => {
         fetch('/api/overseers')
             .then(async res => {
                 if (!res.ok) {
@@ -49,16 +49,22 @@ const Overseer = ({ onBack, getSandboxStatusClass, namespace: userNamespace }) =
             .then(data => {
                 setError(null);
                 setOverseers(data || []);
-                if (data && data.length > 0 && !activeOverseer) {
-                    setActiveOverseer(data[0]);
-                }
+                setActiveOverseer(prev => {
+                    if (data && data.length > 0 && !prev) {
+                        return data[0];
+                    } else if (prev) {
+                        const updated = (data || []).find(o => o.metadata.name === prev.metadata.name);
+                        return updated || prev;
+                    }
+                    return prev;
+                });
             })
             .catch(err => {
                 console.error("Failed to fetch overseers:", err);
                 setError(err.message);
                 setOverseers([]);
             });
-    }, [activeOverseer]);
+    }, []);
 
     useEffect(() => {
         fetchOverseers();
@@ -163,6 +169,37 @@ const Overseer = ({ onBack, getSandboxStatusClass, namespace: userNamespace }) =
         }
     };
 
+
+    const handlePauseChore = (choreName) => {
+        if (!activeOverseer) return;
+        fetch(`/api/overseers/${activeOverseer.metadata.name}/chores/${choreName}/pause`, { method: 'POST' })
+            .then(res => {
+                if (res.ok) {
+                    fetchChores();
+                    fetchOverseers();
+                    setActiveChore(null);
+                } else {
+                    alert("Failed to pause chore");
+                }
+            })
+            .catch(err => console.error("Failed to pause chore:", err));
+    };
+
+    const handleResumeChore = (choreName) => {
+        if (!activeOverseer) return;
+        fetch(`/api/overseers/${activeOverseer.metadata.name}/chores/${choreName}/resume`, { method: 'POST' })
+            .then(res => {
+                if (res.ok) {
+                    fetchChores();
+                    fetchOverseers();
+                    setActiveChore(null);
+                } else {
+                    alert("Failed to resume chore");
+                }
+            })
+            .catch(err => console.error("Failed to resume chore:", err));
+    };
+
     const handleChoreClick = (chore) => {
         setActiveChore(chore);
         
@@ -212,6 +249,22 @@ const Overseer = ({ onBack, getSandboxStatusClass, namespace: userNamespace }) =
                                                 <span className="tree-label">{chore.metadata.labels?.['chore.gemini.google.com/name'] || chore.metadata.name}</span>
                                             </div>
                                         ))}
+                                        
+                                        {(() => {
+                                            const excluded = activeOverseer.spec?.chores?.exclude || [];
+                                            return excluded.map(choreName => (
+                                                <div 
+                                                    key={choreName}
+                                                    className={`sidebar-tree-row ${activeChore?.metadata?.name === choreName ? 'active' : ''}`}
+                                                    onClick={() => handleChoreClick({ metadata: { name: choreName, isExcluded: true } })}
+                                                    style={{ paddingLeft: '35px', opacity: 0.6 }}
+                                                >
+                                                    <span className="tree-icon">⏸️</span>
+                                                    <span className="tree-label">{choreName} (Paused)</span>
+                                                </div>
+                                            ));
+                                        })()}
+
                                         {sandboxes.map(sb => {
                                             const type = sb.metadata.labels?.['sandbox-type'] || 'dev';
                                             const icon = type === 'review' ? '🔄' : type === 'issue' ? '🐞' : '🛠️';
@@ -263,8 +316,19 @@ const Overseer = ({ onBack, getSandboxStatusClass, namespace: userNamespace }) =
                         <div className="pr-card-header">
                             <h3>{activeChore.metadata?.labels?.['chore.gemini.google.com/name'] || activeChore.metadata.name}</h3>
                             <div className="pr-card-actions-header">
+                                
+                                            {activeChore.metadata.isExcluded ? (
+                                                <button className="btn btn-sm" style={{backgroundColor: 'var(--status-green)', color: 'white'}} onClick={(e) => { e.stopPropagation(); handleResumeChore(activeChore.metadata.name); }}>
+                                                    ▶ Resume Chore
+                                                </button>
+                                            ) : (
+                                                <button className="btn btn-sm" style={{backgroundColor: 'var(--status-yellow)', color: 'black'}} onClick={(e) => { e.stopPropagation(); handlePauseChore(activeChore.metadata.name); }}>
+                                                    ⏸ Pause Chore
+                                                </button>
+                                            )}
+
                                 {(() => {
-                                    if (!getSandboxStatusClass) return null;
+                                    if (!getSandboxStatusClass || activeChore.metadata.isExcluded) return null;
                                     const overseerNamespace = `overseer-${activeOverseer?.metadata.name}`;
                                     const mappedChore = {
                                         sandbox: activeChore.metadata.name,
@@ -323,14 +387,16 @@ const Overseer = ({ onBack, getSandboxStatusClass, namespace: userNamespace }) =
                             sandbox: activeChore.metadata.name,
                             sandboxStatus: activeChore.status?.conditions?.[0]?.message || '',
                             agentState: activeChore.metadata?.annotations?.agentState || ''
-                        }) === 'green' && (
+                        }) === 'green' && !activeChore.metadata.isExcluded && (
                             <div style={{ borderBottom: '1px solid var(--border-color)' }}>
                                 <SandboxTerminal namespace={`overseer-${activeOverseer?.metadata.name}`} sandboxName={activeChore.metadata.name} />
                             </div>
                         )}
 
                         <div style={{padding: '10px'}}>
-                            {tasks.length > 0 ? (
+                            {activeChore.metadata.isExcluded ? (
+                                <p style={{color: 'var(--text-muted)'}}>This chore is currently paused.</p>
+                            ) : tasks.length > 0 ? (
                                 tasks.slice().reverse().map((task, index) => (
                                     <TaskCard 
                                         key={task.metadata.name} 


### PR DESCRIPTION
Adds a mechanism to view, pause, and resume chores directly from the Overseer page in the review-ui.

- Added POST /api/overseers/:name/chores/:choreName/pause endpoint.
- Added POST /api/overseers/:name/chores/:choreName/resume endpoint.
- Integrated pause/resume endpoints in the UI.
- Pausing a chore adds it to the overseer's 'exclude' list and deletes its sandbox.
- Resuming a chore removes it from the 'exclude' list allowing overseer to run it again.
- Paused chores are listed in the sidebar with a ⏸️ icon.
- Hide tasks and terminal views for paused chores.