### PR TITLE
fix: label PRs created by repo-agent repo-agent

### DIFF
--- a/overseer/cmd/overseer-cli/main.go
+++ b/overseer/cmd/overseer-cli/main.go
@@ -498,6 +498,7 @@ func runIssue(ctx context.Context, number int, prNumber int, taskType string, cu
 		"ISSUE_URL":       issue.GetHTMLURL(),
 		"PULL_REQUEST_ID": fmt.Sprintf("%d", prNumber),
 		"AGENT_PROMPT":    agentPrompt,
+		"PR_LABEL":        "overseer",
 	}
 	params["model"] = strings.Join(IssueModelsOrder, ",")
 

--- a/repo-agent/pkg/api/handlers_issue.go
+++ b/repo-agent/pkg/api/handlers_issue.go
@@ -522,6 +522,8 @@ func (s *Server) createIssueTask(c *gin.Context) {
 		}
 	}
 
+	params["PR_LABEL"] = "repo-agent"
+
 	err = s.K8sManager.CreateSandboxTask(c.Request.Context(), namespace, sandboxName, "Sandbox", taskType, params)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create task", "details": err.Error()})

--- a/repo-agent/pkg/commands/github-fix-issue.go
+++ b/repo-agent/pkg/commands/github-fix-issue.go
@@ -165,6 +165,7 @@ func (c *GithubFixIssueCommand) Run(ctx context.Context) error {
 		PromptFile:    promptPath,
 		Models:        strings.Split(c.Model, ","),
 		Branch:        os.Getenv("ISSUE_BRANCH"),
+		PRLabel:       os.Getenv("PR_LABEL"),
 	}
 
 	if c.ExtensionsJSON != "" {

--- a/repo-agent/pkg/controllers/repowatch/repowatch_controller.go
+++ b/repo-agent/pkg/controllers/repowatch/repowatch_controller.go
@@ -1137,6 +1137,7 @@ func (r *Reconciler) ensureIssueTask(ctx context.Context, repoWatch *reviewv1alp
 		"ISSUEID":      fmt.Sprintf("%d", *issue.Number),
 		"AGENT_PROMPT": prompt,
 		"HANDLER_NAME": handler.Name,
+		"PR_LABEL":     "repo-agent",
 	}
 	//params["GIT_PUSH_ENABLED"] = "true"
 	if repoWatch.Spec.Issue.LLM.Provider != "" {

--- a/repo-agent/pkg/tasks/fix_issue.go
+++ b/repo-agent/pkg/tasks/fix_issue.go
@@ -19,6 +19,7 @@ type FixIssueModel struct {
 	Models        []string
 	Extensions    []reviewv1alpha1.Extension
 	Branch        string
+	PRLabel       string
 }
 
 func (m *FixIssueModel) Name() string {

--- a/repo-agent/pkg/tasks/fix_issue.txt
+++ b/repo-agent/pkg/tasks/fix_issue.txt
@@ -17,7 +17,7 @@ Tips:
 * Also use the github MCP tools to read related issues and PRs, and follow patterns established there.
 * If you get stuck, push a PR but start the PR title with "[WIP]".  Other people on github may have suggestions on how to proceed.  Some tasks are blocked on problems in other libraries, and we probably want to fix those in separate PRs anyway.
 * Do not forget to open your pull request using `gh` cli tool when you are done.  Just pushing the branch is not enough.
-* You MUST label the PR `overseer` `gh pr edit <PR_NUMBER> --add-label "overseer"` or  `gh pr create --label "overseer"`
+{{ if .PRLabel }}* You MUST label the PR `{{ .PRLabel }}` `gh pr edit <PR_NUMBER> --add-label "{{ .PRLabel }}"` or  `gh pr create --label "{{ .PRLabel }}"`{{ end }}
 * The year is 2026.  Copyright headers on new files should use 2026.
 
 Final Steps:

--- a/repo-agent/pkg/tasks/prompt_test.go
+++ b/repo-agent/pkg/tasks/prompt_test.go
@@ -45,6 +45,7 @@ type MockModel struct {
 	PromptFile    string
 	Extensions    []MockExtension
 	Branch        string
+	PRLabel       string
 }
 
 func TestFixIssuePromptTemplate(t *testing.T) {


### PR DESCRIPTION
Label PRs created by overseer overseer and repo-agent repo-agent. Currently both are labelled overseer which is causing overseer to step in on repo-agent;s toes.

Side effect: 
overseer could forcepush a bunch of changes from its sandbox undermining repo-agent sandbox.

example: https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/7322/changes