### PR TITLE
Claude code cli as new LLM provider

### DIFF
--- a/repo-agent/LLM_ARCHITECTURE_PROPOSAL.md
+++ b/repo-agent/LLM_ARCHITECTURE_PROPOSAL.md
@@ -1,0 +1,94 @@
+# CLI-First LLM Provider Architecture (Claude Code)
+
+## 1. Executive Summary
+The Repo Agent is standardizing on a **CLI-First Architecture** for agentic tasks. While raw API providers remain available for stateless text generation, we delegate complex reasoning and "Action" loops to specialized LLM CLI binaries like `gemini` and Anthropic's `claude` (Claude Code).
+
+For a detailed guide on implementing new providers, see the [LLM Provider Architecture & Integration Guide](docs/design/adding-a-new-llm-provider.md).
+
+### 1.1 Rationale: Why not extend `gemini-cli`?
+A common question is whether `gemini-cli` could be extended to support Claude models via Vertex AI. We have determined that a separate provider is necessary because:
+*   **Incompatible Protocols**: Gemini and Claude use fundamentally different API schemas (e.g., Gemini's `contents` vs. Claude's `messages`). Even on Vertex AI, these models are exposed via different endpoints with distinct request/response structures.
+*   **Specialized Reasoning Loops**: `gemini-cli` and `claude-cli` each contain unique, model-specific logic for tool use, terminal interaction, and "ReAct" loops. These are "black box" implementations tuned by their respective vendors for the specific behaviors of their models.
+*   **Hardcoded Targets**: The `gemini-cli` binary is specifically built to target Google's Generative AI services. It does not have the internal routing logic to address the `publishers/anthropic` endpoints required for Claude on Vertex.
+*   **Ecosystem Alignment**: Standardizing on each model's native CLI ensures we benefit from vendor-led innovation (like Claude's MCP support) without building complex translation layers.
+
+---
+
+## 2. Technical Details: Claude Code CLI (`claude-cli`)
+
+### 2.1 Tooling & Runtime (DevContainer Feature Model)
+*   **Delivery**: Instead of baking the binary into the `RepoSandboxImage`, we use **DevContainer Features**.
+*   **Package**: `@anthropic-ai/claude-code` (via npm).
+*   **Feature**: `ghcr.io/gke-labs/gemini-for-kubernetes-development/claude-code:latest`.
+*   **Benefit**: This allows the sandbox to remain lightweight and allows the same binary to be injected into any base image supported by `envbuilder`.
+
+### 2.2 Integration Mechanics
+A new `ClaudeCLI` struct will implement the `Provider` interface in `pkg/llm/claude-cli.go`. The existing `Claude` struct in `pkg/llm/claude.go` will remain untouched.
+
+*   **Non-Interactive Mode**: Claude Code will be executed using the `execute` command with a "yes" flag to prevent hanging on user prompts.
+    *   *Draft Command*: `claude execute "task description" --yes`.
+*   **Prompt Passing**: Tasks will be passed as the primary argument to the `execute` command.
+*   **Usage Tracking**: We will attempt to parse Claude's output for token consumption to populate the `Stats` object.
+
+### 2.3 Authentication (Secret-to-Env Pattern)
+The `claude-cli` provider will follow the project's established pattern for secure credential injection:
+
+*   **Secret Management**: The `anthropic-api-key` Kubernetes secret (managed by `installer.sh`) contains the API key under the `claude` key.
+*   **Volume Mount**: The Sandbox controller mounts this secret into the agent container at `/tokens/`.
+*   **Translation**: The `Setup()` method in `pkg/llm/claude-cli.go` will:
+    1. Read the raw key from `/tokens/claude`.
+    2. Set the `ANTHROPIC_API_KEY` environment variable.
+    3. Ensure any CLI-specific config files (e.g., in `~/.claude/`) are initialized using this key.
+*   **Non-Interactivity**: `Setup()` will also handle any one-time "consent" or "telemetry" flags required by the CLI to ensure subsequent `Run()` calls are fully automated.
+
+---
+
+## 3. Implementation Plan
+
+### Phase 1: Sandbox Image Update
+*   **Files**: `images/generic-golang/Dockerfile`, `images/dind-golang/Dockerfile`.
+*   **Action**: Install Node.js, npm, and the `@anthropic-ai/claude-code` global package.
+*   **Goal**: Ensure `claude` is available in the sandbox `$PATH`.
+
+### Phase 2: Add `pkg/llm/claude-cli.go`
+*   **New Struct**: `ClaudeCLI` using `CommandExecutor`.
+*   **New Provider Registration**: Update `NewLLMProvider` in `pkg/llm/provider.go` to recognize the `claude-cli` name.
+*   **Methods**:
+    *   `Setup()`: Validates `ANTHROPIC_API_KEY`.
+    *   `Run()`: Executes `claude execute ...`.
+
+### Phase 3: Extension Support (MCP)
+*   Claude Code uses the **Model Context Protocol (MCP)**.
+*   **Action**: Update the provider to generate or link an `mcp_servers.json` configuration based on the `Extensions` provided in the config.
+
+---
+
+## 4. Lessons Learned & Operational Considerations
+
+During the initial rollout and cluster re-initialization, several critical dependencies were identified:
+
+### 4.1 Dependency on Registry-Based Features
+The system has moved away from local `Makefile` builds for CLI binaries. It now relies on `ghcr.io` (or a local registry like `kind.local`) to host DevContainer Features. 
+*   **Lesson**: If the `devcontainer.json` references a feature that isn't accessible, the sandbox will hang in the `envbuilder` phase.
+*   **Fix**: Ensure `configmap-devcontainer.yaml` is updated to include the `claude-code` feature.
+
+### 4.2 Secret Bootstrapping
+The `repowatch-controller` and the sandboxes are highly sensitive to the presence of valid secrets (`anthropic-api-key`, `github-pat`).
+*   **Lesson**: Re-creating the cluster without sourcing environment variables leads to `401 Bad Credentials` errors in the controller.
+*   **Fix**: The `make create-secrets` target must be run with a fully populated environment to ensure the controller can authenticate with GitHub and the LLM providers can authenticate during `Setup()`.
+
+### 4.3 Sandbox Defaulting
+The transition to `envbuilder` means that sandboxes often start from a generic base image (e.g., `base:ubuntu`).
+*   **Lesson**: Binaries like `claude` or `gemini` MUST be injected via the feature mechanism or the `inject-agent` init container.
+*   **Fix**: Standardize on DevContainer features for all external LLM CLIs to ensure consistency across different user-provided base images.
+
+---
+
+## 5. Provider Comparison
+
+| Feature | `gemini-cli` | `claude` (API) | `claude-cli` |
+| :--- | :--- | :--- | :--- |
+| **Logic** | Binary CLI | Raw HTTP API | Binary CLI |
+| **Agentic** | Yes (ReAct) | No (Stateless) | Yes (ReAct) |
+| **Primary Use** | Sandboxed Tasks | Simple Reviews | Sandboxed Tasks |
+| **Runtime** | Go (bundled) | Go (native) | Node.js |

--- a/repo-agent/Makefile
+++ b/repo-agent/Makefile
@@ -30,6 +30,8 @@ check-prereqs:
 	@command -v kind >/dev/null 2>&1 || { echo >&2 "kind not found. Please install it. https://kind.sigs.k8s.io/docs/user/quick-start/#installation"; exit 1; }
 	@command -v kubectl >/dev/null 2>&1 || { echo >&2 "kubectl not found. Please install it. https://kubernetes.io/docs/tasks/tools/install-kubectl/"; exit 1; }
 	@command -v helm >/dev/null 2>&1 || { echo >&2 "helm not found. Please install it. https://helm.sh/docs/intro/install/"; exit 1; }
+	@command -v node >/dev/null 2>&1 || { echo >&2 "node not found. Please install it. https://nodejs.org/"; exit 1; }
+	@command -v npm >/dev/null 2>&1 || { echo >&2 "npm not found. Please install it. https://docs.npmjs.com/downloading-and-installing-node-js-and-npm"; exit 1; }
 	@echo "All prerequisites are installed."
 
 .PHONY: generate

--- a/repo-agent/api/repowatch/v1alpha1/repowatch_types.go
+++ b/repo-agent/api/repowatch/v1alpha1/repowatch_types.go
@@ -25,6 +25,8 @@ const (
 	GeminiProvider = "gemini-cli"
 	// ClaudeProvider represents the Claude LLM provider.
 	ClaudeProvider = "claude"
+	// ClaudeCLIProvider represents the Claude Code CLI provider.
+	ClaudeCLIProvider = "claude-cli"
 	// Dummy provider for testing
 	DummyProvider = "dummy"
 
@@ -38,7 +40,7 @@ type LLMConfig struct {
 	// Provider is the name of the LLM provider to use. This field is used to
 	// determine which LLM client to instantiate and how to interact with the
 	// LLM API.
-	// +kubebuilder:validation:Enum=gemini-cli;claude;dummy
+	// +kubebuilder:validation:Enum=gemini-cli;claude;claude-cli;dummy
 	// +kubebuilder:default=gemini-cli
 	Provider string `json:"provider,omitempty"`
 

--- a/repo-agent/docs/design/adding-a-new-llm-provider.md
+++ b/repo-agent/docs/design/adding-a-new-llm-provider.md
@@ -1,277 +1,141 @@
-# Adding a New LLM Provider
+# LLM Provider Architecture & Integration Guide
 
-This document provides a step-by-step guide for developers to extend the Gemini Code Repo Agent by integrating a new Large Language Model (LLM) provider.
+This document describes how the Gemini Code Repo Agent integrates with Large Language Models (LLMs). It covers the high-level "CLI-First" architecture, the dynamic sandbox environment powered by DevContainers, and a step-by-step guide for adding new providers.
 
-The system uses a standard `Provider` interface, which ensures that new providers can be added smoothly. This guide will walk you through implementing this interface, registering your new provider, and making it available for use in `RepoWatch` resources.
+---
 
-## 1. The `Provider` Interface
+## 1. Architectural Strategy: CLI-First
 
-The core of the provider system is the `Provider` interface, located in `pkg/llm/provider.go`. Any new LLM provider must implement this interface.
+The Repo Agent follows a **CLI-First Architecture** for agentic tasks. While raw HTTP APIs are suitable for stateless text generation, complex software engineering tasks (like multi-step code reviews or bug fixing) require specialized "action loops."
+
+### 1.1 Why CLIs?
+Instead of building complex "ReAct" loops or tool-use frameworks in Go, we delegate these behaviors to model-specific CLI binaries like `gemini` (Gemini CLI) and `claude` (Claude Code).
+*   **Optimized Reasoning**: Vendor-provided CLIs are tuned for the specific strengths of their models (e.g., Claude's reasoning loop for terminal interaction).
+*   **Tool-Use Capabilities**: These CLIs handle local tool execution (file reads, shell commands, git operations) natively.
+*   **Reduced Complexity**: The Repo Agent core remains a lightweight orchestrator, while the model logic stays encapsulated within the binary.
+
+### 1.2 Interactive vs. Non-Interactive
+In the Repo Agent, these CLIs are executed in **non-interactive mode** within an ephemeral sandbox.
+*   **Gemini**: Uses `gemini -y --output-format json`.
+*   **Claude**: Uses `claude --print --output-format json`.
+
+---
+
+## 2. Sandbox Environment & CLI Delivery
+
+A critical challenge in the Repo Agent architecture is delivering model-specific CLI binaries (like `claude` or `gemini`) into the ephemeral sandbox where the task executes. The system supports two primary delivery models: **Dynamic Injection** and **Pre-baked "Fat" Images**.
+
+### 2.1 Dynamic Injection (DevContainer Features)
+This model leverages `envbuilder` to construct a development environment at runtime.
+*   **Mechanism**: The sandbox starts from a generic base image (e.g., `ubuntu`). `envbuilder` reads a `devcontainer.json` and dynamically downloads/installs "Features" (modular scripts and binaries) from a remote registry.
+*   **Pros**: Highly flexible and modular. Allows users to "mix and match" tools without rebuilding images.
+*   **Cons**: High runtime latency. The sandbox must clone the repo and install tools (often taking 2-5 minutes) before the agent can start. It also introduces a runtime dependency on external registries.
+
+### 2.2 Pre-baked "Fat" Images (Preferred Approach)
+The **preferred approach** for production and performance-sensitive environments is to use a pre-baked, self-contained image (e.g., `images/generic-golang/Dockerfile`).
+
+*   **Mechanism**: The LLM CLI and all its dependencies (like Node.js for Claude) are installed during the Docker build phase:
+    ```dockerfile
+    RUN npm install -g @anthropic-ai/claude-code
+    ```
+*   **Performance Benefit**: By eliminating the `envbuilder` installation phase, the sandbox enters the "Ready" state in **seconds rather than minutes**. All tools are immediately available in the `$PATH`.
+*   **Reliability**: The sandbox is entirely self-contained. It does not depend on dynamic network requests to a Feature registry at runtime, making it more robust against network flakes or registry outages.
+*   **Configuration**: To use this model, specify the `image` field directly in the `RepoWatch` manifest and omit the `devcontainerConfigRef`:
+    ```yaml
+    review:
+      image: ghcr.io/your-org/generic-golang:latest
+      llm:
+        provider: claude-cli
+    ```
+
+### 2.3 Injection Logic Summary
+When the `RepoWatch` controller reconciles a task:
+1.  If **`spec.review.image`** is set: It uses the specified image and executes `repo-sandbox dev-daemon`. This daemon handles cloning and task execution using the binaries already present in the image.
+2.  If **`spec.review.devcontainerConfigRef`** is set (and no image is specified): It defaults to the `envbuilder` workflow to dynamically assemble the environment.
+
+---
+
+## 3. The `Provider` Interface
+
+All LLM logic in the Go codebase is abstracted behind the `Provider` interface in `pkg/llm/provider.go`.
 
 ```go
-// pkg/llm/provider.go
-
 type Provider interface {
-	Setup(workspacesDir, tokensDir string) error
-	Cleanup(workspacesDir string) error
-	Run(prompt string) ([]byte, error)
+	Setup() error
+	Cleanup() error
+	ExpandPrompt(prompt string) (string, error)
+	Run(prompt string) ([]byte, *Stats, error)
 	AddPostProcessor(p PostProcessor)
+	QuotaCheck() bool
 }
 ```
 
-### Method Explanations
+### Key Methods
+*   **`Setup()`**: Handles authentication. It reads API keys from a mounted secret volume (usually `/tokens/`) and sets the required environment variables (e.g., `ANTHROPIC_API_KEY`).
+*   **`Run(prompt)`**: Executes the CLI binary. It **MUST** request JSON output to enable programmatic parsing of results and token usage.
+*   **`ExpandPrompt()`**: Allows for provider-specific prompt transformations (e.g., expanding custom command macros).
 
--   `Setup(workspacesDir, tokensDir string) error`: This method is called before running the LLM. It is responsible for any necessary setup, such as reading API keys from the `tokensDir` and setting them as environment variables, or preparing configuration files in the `workspacesDir`.
--   `Cleanup(workspacesDir string) error`: This method is called after the LLM run is complete. It should be used to clean up any temporary files or configurations created during the `Setup` phase.
--   `Run(prompt string) ([]byte, error)`: This is the primary method that executes the LLM. It takes the prompt as input and should return the raw output from the LLM as a byte slice.
--   `AddPostProcessor(p PostProcessor)`: This method adds a function to a slice of post-processors that are run sequentially on the raw LLM output. For example, you can add the included `StripYAMLMarkers` post-processor to automatically clean up code blocks.
+---
 
-## 2. Step-by-Step Implementation Guide
+## 4. Case Study: `claude-cli`
 
-Here is how to create a new provider called `MyProvider`.
+The `claude-cli` provider (implemented in `pkg/llm/claude-cli.go`) illustrates the standard integration pattern.
 
-### Step 2.1: Create the Provider File
+### 4.1 Implementation Mechanics
+1.  **Binary**: `@anthropic-ai/claude-code` (via npm).
+2.  **Execution**: It runs `claude --print --output-format json "prompt"`.
+3.  **Parsing**: It expects a JSON envelope:
+    ```json
+    {
+      "result": "...",
+      "modelUsage": {
+        "claude-3-7-sonnet": {
+          "inputTokens": 123,
+          "outputTokens": 456
+        }
+      }
+    }
+    ```
+4.  **Stats Mapping**: The `modelUsage` is mapped to the internal `llm.Stats` struct for observability and usage tracking.
 
-Create a new file for your provider in the `pkg/llm/` directory. For this example, we will call it `pkg/llm/my_provider.go`.
+---
 
-### Step 2.2: Define the Provider Struct and Implement the Interface
+## 5. Adding a New Provider (Developer Guide)
 
-In your new file, define a struct for your provider and implement the methods from the `Provider` interface. You can use the existing `gemini.go` implementation as a template.
+### Step 1: Implement the Logic
+Create `pkg/llm/my-provider.go`. Implement the `Provider` interface. If it's a CLI provider, use the `CommandExecutor` to run the binary.
 
+### Step 2: Register the Provider
+Update the factory function in `pkg/llm/provider.go`:
 ```go
-// pkg/llm/my_provider.go
-
-package llm
-
-import (
-	"fmt"
-	// Add any other necessary imports for your provider's SDK, etc.
-)
-
-// Ensure MyProvider implements the Provider interface.
-var _ Provider = &MyProvider{}
-
-type MyProvider struct {
-	// Add any fields your provider needs, like an API client.
-	processors []PostProcessor
-}
-
-func (m *MyProvider) AddPostProcessor(p PostProcessor) {
-	m.processors = append(m.processors, p)
-}
-
-func (m *MyProvider) Setup(workspacesDir, tokensDir string) error {
-	// TODO: Implement your setup logic.
-	// For example, read an API key from a file in tokensDir and initialize a client.
-	// apiKey, err := os.ReadFile(filepath.Join(tokensDir, "my-provider-key"))
-	// if err != nil {
-	// 	return fmt.Errorf("failed to read API key: %w", err)
-	// }
-	// m.client = myapi.NewClient(string(apiKey))
-	fmt.Println("MyProvider setup complete.")
-	return nil
-}
-
-func (m *MyProvider) Cleanup(workspacesDir string) error {
-	// TODO: Implement your cleanup logic if needed.
-	fmt.Println("MyProvider cleanup complete.")
-	return nil
-}
-
-func (m *MyProvider) Run(prompt string) ([]byte, error) {
-	// TODO: Implement the logic to call your LLM's API.
-	// rawOutput, err := m.client.Generate(prompt)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// This is a placeholder implementation.
-	rawOutput := []byte(fmt.Sprintf("Response from MyProvider for prompt: %s", prompt))
-
-	// Apply any post-processors.
-	var err error
-	for _, p := range m.processors {
-		rawOutput, err = p(rawOutput)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return rawOutput, nil
-}
+case "my-provider":
+    return &MyProvider{...}, nil
 ```
 
-## 3. Registering the New Provider
-
-To make the system aware of your new provider, you must add it to the `NewLLMProvider` factory function located in `pkg/llm/provider.go`.
-
-Modify the `switch` statement to include a new case for your provider. This allows users to select it in their `RepoWatch` manifests.
-
-**File:** `pkg/llm/provider.go`
-
-```diff
- // ... existing code ...
- func NewLLMProvider(name string, outputStartIndicator string) (Provider, error) {
- 	switch name {
- 	case "gemini-cli":
- 		g := &Gemini{Executor: &RealCommandExecutor{}}
- 		g.AddPostProcessor(StripYAMLMarkers)
- 		if outputStartIndicator != "" {
-			g.AddPostProcessor(StripUnillStartIndicator(outputStartIndicator))
-		}
- 		return g, nil
- 	case "claude":
- 		c := &Claude{}
- 		c.AddPostProcessor(StripYAMLMarkers)
- 		return c, nil
-+	case "my-provider": // Add your provider's name here
-+		 m := &MyProvider{}
-+		 m.AddPostProcessor(StripYAMLMarkers) // Optionally add default post-processors
-+		 return m, nil
- 	default:
- 		return nil, fmt.Errorf("unknown provider: %s", name)
- 	}
- }
- // ... existing code ...
+### Step 3: Update API Types
+Add the new provider to the `LLMConfig` enum in `api/repowatch/v1alpha1/repowatch_types.go`:
+```go
+// +kubebuilder:validation:Enum=gemini-cli;claude;claude-cli;my-provider
+Provider string `json:"provider,omitempty"`
 ```
+Then run `make manifests` to regenerate the CRD YAMLs.
 
-## 4. Updating the API Types
+### Step 4: Infrastructure (DevContainer)
+1.  Ensure a DevContainer Feature image exists for your provider (or that it's pre-installed in the base image).
+2.  Update the default `devcontainer-json` ConfigMap in `k8s/configmap-devcontainer.yaml` to include the feature.
 
-To ensure your new provider is a valid option in the `RepoWatch` Custom Resource Definition (CRD), you need to add its name to the `LLMConfig` type definition.
+### Step 5: Secrets
+Update the `Makefile` and `review-api` (if necessary) to handle the provisioning and copying of the required API key secrets.
 
-**File:** `repowatch/api/v1alpha1/repowatch_types.go`
+---
 
-1.  **Add a new constant for your provider's name.**
+## 6. Common Pitfalls & FAQs
 
-    ```diff
-     const (
-     	// GeminiProvider represents the Gemini LLM provider.
-     	GeminiProvider = "gemini-cli"
-     	// ClaudeProvider represents the Claude LLM provider.
-     	ClaudeProvider = "claude"
-    +	// MyProvider represents our new custom provider.
-    +	MyProviderName = "my-provider"
-     )
-    ```
+**Q: Should I use the raw API or the CLI?**
+**A**: If the task requires "doing" things in the repo (editing files, running tests), use the CLI. If it's just a simple text transformation, the raw API is faster.
 
-2.  **Add the name to the `+kubebuilder:validation:Enum` list.** This enforces that only registered provider names can be used in the manifest.
+**Q: How do I handle non-JSON output?**
+**A**: Many CLIs output progress bars or warnings to stdout. Your parser should find the first `{` character to locate the start of the JSON response.
 
-    ```diff
-     // Provider is the name of the LLM provider to use. This field is used to
-     // determine which LLM client to instantiate and how to interact with the
-     // LLM API.
-    -// +kubebuilder:validation:Enum=gemini-cli;claude
-    +// +kubebuilder:validation:Enum=gemini-cli;claude;my-provider
-     // +kubebuilder:default=gemini-cli
-     Provider string `json:"provider,omitempty"`
-    ```
-
-
-## 5. Creating the API Key Secret (Local Development)
-
-For local development and testing, API key secrets are typically created in the `repo-agent-system` namespace using the `create-secrets` target in the `Makefile`. This provides a convenient way to provision secrets from environment variables.
-
-### Step 5.1: Update the `Makefile` `create-secrets` Target
-
-Add a `kubectl create secret` command to the `create-secrets` target in your `Makefile`. This command will create a Kubernetes Secret containing your provider's API key, sourced from an environment variable.
-
-**File:** `Makefile`
-
-```diff
- .PHONY: create-secrets
- create-secrets:
-	kubectl create namespace repo-agent-system || true
-	@kubectl create secret -n repo-agent-system generic gemini-vscode-tokens --from-literal=gemini=${GEMINI_API_KEY} --dry-run=client -o yaml | kubectl apply -f -
-	@kubectl create secret -n repo-agent-system generic github-pat --from-literal=pat="${GITHUB_PAT}" --from-literal=name="`git config --global user.name`" --from-literal=email=`git config --global user.email` --dry-run=client -o yaml | kubectl apply -f -
-	@kubectl create secret -n repo-agent-system generic anthropic-api-key --from-literal=claude=${ANTHROPIC_API_KEY} --dry-run=client -o yaml | kubectl apply -f -
-+	@ifndef MY_PROVIDER_API_KEY
-+	$(warning MY_PROVIDER_API_KEY is not set. MyProvider will not work.)
-+	@else
-+	@kubectl create secret -n repo-agent-system generic my-provider-secret --from-literal=mykey=${MY_PROVIDER_API_KEY} --dry-run=client -o yaml | kubectl apply -f -
-+	@endif
-	# Create github-token secret for the API, optionally including OAuth credentials
-```
-
-### Step 5.2 (Optional): Add `ifndef` Environment Variable Check
-
-It's good practice to add an `ifndef` check at the top of your `Makefile` to provide a warning or error if the environment variable for your new provider's API key is not set. This helps ensure users are aware of missing prerequisites.
-
-**File:** `Makefile` (top section)
-
-```diff
- # Check pre-reqs
-+ifndef MY_PROVIDER_API_KEY
-+$(warning MY_PROVIDER_API_KEY is not set. MyProvider will not work.)
-+endif
-
- ifndef GEMINI_API_KEY
- $(error GEMINI_API_KEY is not set. Please set it before running make.)
- ```
-
-## 6. Making the API Key Available to the Agent
-
-For the new provider's API key to be accessible by the agent sandboxes, its Kubernetes Secret must be copied from the `repo-agent-system` namespace into the user's personal namespace when they first log in. This bootstrapping process is handled by the `review-api` service.
-
-### Step 6.1: Register the Secret in the API Service
-
-**File:** `review-ui/review-api/main.go`
-
-First, define a new constant for your provider's secret name. This secret must be created in the `repo-agent-system` namespace.
-
-```diff
- const (
-	// ... existing constants
-	githubSecretName = "github-pat"
-	geminiSecretName = "gemini-vscode-tokens"
-+	myProviderSecretName = "my-provider-secret" // The name of the secret holding your provider's key
- )
-```
-
-### Step 6.2: Add Secret-Copying Logic
-
-Next, add logic to the `bootstrapNamespace` function to copy this secret into new user namespaces.
-
-**File:** `review-ui/review-api/main.go`
-
-```diff
- func bootstrapNamespace(ctx context.Context, targetNS string) error {
-	// ... existing namespace creation and other secret copies ...
-	if err := copySecret(ctx, systemNamespace, geminiSecretName, targetNS, geminiSecretName); err != nil {
-		log.Printf("Warning: failed to copy default gemini secret: %v", err)
-	}
-+	if err := copySecret(ctx, systemNamespace, myProviderSecretName, targetNS, myProviderSecretName); err != nil {
-+		log.Printf("Warning: failed to copy my-provider secret: %v", err)
-+	}
-
-	if err := setupServiceAccounts(ctx, targetNS); err != nil {
-		log.Printf("Warning: failed to setup service accounts: %v", err)
-	}
-
-	return nil
- }
-```
-
-### Step 6.3: How the Secret is Mounted and Used
-
-This new logic ensures that the secret is available in the user's namespace. The end-to-end flow for the key is as follows:
-
-1.  A user references the secret name in their `RepoWatch` manifest (e.g., `apiKeySecretRef: my-provider-secret`).
-2.  The `repowatch-controller` reads this reference and configures the agent sandbox Pod to mount the specified Secret as a volume.
-3.  The volume is mounted to a known directory inside the agent pod, such as `/etc/llm-tokens/`.
-4.  The `Provider.Setup()` method, which you implemented in Step 2, receives this path in its `tokensDir` argument.
-5.  Your `Setup` logic can now read the key from the file system (e.g., `os.ReadFile(filepath.Join(tokensDir, "your-key-name-in-secret"))`) and use it to configure your LLM client.
-
-## 7. Usage
-
-Once the steps above are complete, users can select your new provider in any `RepoWatch` manifest by setting the `provider` field in the `llm` configuration.
-
-```yaml
-# ... inside a RepoWatch manifest ...
-spec:
-  review:
-    llm:
-      provider: my-provider # Use the new provider
-      apiKeySecretRef: my-provider-api-key-secret
-      prompt: "Please review this pull request."
-# ... rest of the manifest ...
-```
+**Q: What about authentication?**
+**A**: Always use the "Secret-to-Env" pattern. Mount the secret to `/tokens/`, read it in `Setup()`, and set it as an environment variable. Never hardcode keys.

--- a/repo-agent/docs/development.md
+++ b/repo-agent/docs/development.md
@@ -1,5 +1,15 @@
 ## Developer Installation from source
 
+### Prerequisites
+
+Ensure you have the following installed:
+- **Go 1.25+**
+- **Docker**
+- **KinD**
+- **kubectl**
+- **Helm**
+- **Node.js 18+ & npm** (Required for LLM CLIs like `gemini` and `claude`)
+
 1.  **Set Environment Variables:**
 
     Follow [these instructions](env-variables.md) to set the required `env` variables.

--- a/repo-agent/examples/claude-cli-fat-image.yaml
+++ b/repo-agent/examples/claude-cli-fat-image.yaml
@@ -1,0 +1,17 @@
+apiVersion: review.gemini.google.com/v1alpha1
+kind: RepoWatch
+metadata:
+  name: claude-cli-fat-image
+  namespace: repo-agent-system
+spec:
+  repoURL: https://github.com/your-org/your-repo
+  githubSecretName: github-pat
+  review:
+    # Use the pre-baked image containing Node.js and Claude CLI
+    image: ghcr.io/gke-labs/gemini-for-kubernetes-development/generic-golang:latest
+    # Specify the claude-cli provider
+    llm:
+      provider: claude-cli
+      apiKeySecretRef: anthropic-api-key
+    maxActiveSandboxes: 5
+    # Note: No devcontainerConfigRef is needed here as the image is self-contained.

--- a/repo-agent/examples/claude-cli-repowatch.yaml
+++ b/repo-agent/examples/claude-cli-repowatch.yaml
@@ -1,0 +1,16 @@
+apiVersion: review.gemini.google.com/v1alpha1
+kind: RepoWatch
+metadata:
+  name: claude-cli
+  namespace: repo-agent-system
+spec:
+  repoURL: https://github.com/your-org/your-repo
+  githubSecretName: github-pat
+  pollIntervalSeconds: 60
+  review:
+    maxActiveSandboxes: 5
+    devcontainerConfigRef: devcontainer-json
+    llm:
+      provider: claude-cli
+      apiKeySecretRef: anthropic-api-key
+      prompt: "Please review this PR for security issues and code quality."

--- a/repo-agent/images/dind-golang/Dockerfile
+++ b/repo-agent/images/dind-golang/Dockerfile
@@ -73,7 +73,7 @@ ENV PATH=$PATH:/usr/local/go/bin
 ENV GOTOOLCHAIN=auto
 
 # -------- Install global Node.js packages --------
-RUN npm install -g @google/gemini-cli
+RUN npm install -g @google/gemini-cli @anthropic-ai/claude-code
 
 # -------- Download binary releases --------
 # Install Kind

--- a/repo-agent/images/generic-golang/Dockerfile
+++ b/repo-agent/images/generic-golang/Dockerfile
@@ -54,7 +54,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     apt-get update && apt-get install -y google-cloud-cli
 
-RUN npm install -g @google/gemini-cli
+RUN npm install -g @google/gemini-cli @anthropic-ai/claude-code
 
 # Install code-server
 RUN curl -fsSL https://code-server.dev/install.sh | sh

--- a/repo-agent/k8s/configmap-devcontainer.yaml
+++ b/repo-agent/k8s/configmap-devcontainer.yaml
@@ -13,6 +13,7 @@ data:
         "ghcr.io/devcontainers/features/go:1": { "version": "latest" },
         "ghcr.io/devcontainers/features/node:1": { "version": "lts" },
         "ghcr.io/gke-labs/gemini-for-kubernetes-development/gemini-cli:latest": {},
+        "ghcr.io/gke-labs/gemini-for-kubernetes-development/claude-code:latest": {},
         "ghcr.io/coder/devcontainer-features/code-server:1": {
           "port": 13337,
           "host": "0.0.0.0",

--- a/repo-agent/k8s/crds/review.gemini.google.com_repowatches.yaml
+++ b/repo-agent/k8s/crds/review.gemini.google.com_repowatches.yaml
@@ -92,6 +92,7 @@ spec:
                         enum:
                         - gemini-cli
                         - claude
+                        - claude-cli
                         - dummy
                         type: string
                     required:
@@ -183,6 +184,7 @@ spec:
                         enum:
                         - gemini-cli
                         - claude
+                        - claude-cli
                         - dummy
                         type: string
                     required:
@@ -264,6 +266,7 @@ spec:
                         enum:
                         - gemini-cli
                         - claude
+                        - claude-cli
                         - dummy
                         type: string
                     required:

--- a/repo-agent/pkg/llm/claude-cli.go
+++ b/repo-agent/pkg/llm/claude-cli.go
@@ -1,0 +1,128 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llm
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"k8s.io/klog/v2"
+)
+
+// ClaudeCLI is an Provider that uses the claude CLI (@anthropic-ai/claude-code).
+var _ Provider = &ClaudeCLI{}
+
+type ClaudeCLI struct {
+	Executor   CommandExecutor
+	processors []PostProcessor
+	ProviderConfig
+}
+
+type ClaudeJSONOutput struct {
+	Result     string                      `json:"result"`
+	ModelUsage map[string]ClaudeModelUsage `json:"modelUsage"`
+}
+
+type ClaudeModelUsage struct {
+	InputTokens              int64 `json:"inputTokens"`
+	OutputTokens             int64 `json:"outputTokens"`
+	CacheReadInputTokens     int64 `json:"cacheReadInputTokens"`
+	CacheCreationInputTokens int64 `json:"cacheCreationInputTokens"`
+}
+
+func (c *ClaudeCLI) AddPostProcessor(p PostProcessor) {
+	c.processors = append(c.processors, p)
+}
+
+func (c *ClaudeCLI) QuotaCheck() bool {
+	return true
+}
+
+func (c *ClaudeCLI) Setup() error {
+	// 1. Setup API Key from /tokens/claude
+	apiKeyPath := filepath.Join(c.TokensDir, "claude")
+	apiKeyBytes, err := os.ReadFile(apiKeyPath)
+	if err != nil {
+		klog.Infof("Warning: failed to read API key from %s: %v. Falling back to env.", apiKeyPath, err)
+	} else {
+		os.Setenv("ANTHROPIC_API_KEY", string(apiKeyBytes))
+	}
+
+	// 2. TODO: Handle MCP servers configuration in Phase 3
+	// 3. Ensure any one-time consent/config for claude-code is handled if needed.
+
+	return nil
+}
+
+func (c *ClaudeCLI) Cleanup() error {
+	return nil
+}
+
+func (c *ClaudeCLI) ExpandPrompt(prompt string) (string, error) {
+	// For now, we don't have a specific command expansion for claude-cli,
+	// but we could use the same logic as gemini if needed.
+	return prompt, nil
+}
+
+func (c *ClaudeCLI) Run(agentPrompt string) ([]byte, *Stats, error) {
+	klog.Info("running claude-cli")
+
+	// Execute claude --print --output-format json "prompt"
+	stdout, stderr, err := c.Executor.Run("claude", "--print", "--output-format", "json", agentPrompt)
+
+	if err != nil {
+		klog.Infof("claude command failed: %v. Stderr: %s", err, string(stderr))
+		return nil, nil, fmt.Errorf("claude command failed: %w. Stderr: %s", err, string(stderr))
+	}
+
+	// Parse the JSON envelope
+	var envelope ClaudeJSONOutput
+	// Find first '{' to skip any non-JSON prefix warnings
+	idx := bytes.IndexByte(stdout, '{')
+	if idx == -1 {
+		return nil, nil, fmt.Errorf("claude --output-format json returned no JSON object")
+	}
+	if err := json.Unmarshal(stdout[idx:], &envelope); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse claude JSON output: %w", err)
+	}
+
+	output := []byte(envelope.Result)
+	for _, p := range c.processors {
+		output, err = p(output)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	// Convert stats
+	usage := &Stats{
+		Models: make(map[string]ModelUsage),
+	}
+	for model, data := range envelope.ModelUsage {
+		usage.Models[model] = ModelUsage{
+			Tokens: TokenUsage{
+				Input:  data.InputTokens,
+				Output: data.OutputTokens,
+				Cached: data.CacheReadInputTokens,
+				Total:  data.InputTokens + data.OutputTokens,
+			},
+		}
+	}
+
+	return output, usage, nil
+}

--- a/repo-agent/pkg/llm/claude-cli_test.go
+++ b/repo-agent/pkg/llm/claude-cli_test.go
@@ -1,0 +1,93 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llm
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestClaudeCLI_Setup(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tokensDir := filepath.Join(tmpDir, "tokens")
+		if err := os.MkdirAll(tokensDir, 0755); err != nil {
+			t.Fatalf("Failed to create tokens dir: %v", err)
+		}
+
+		apiKeyFile := filepath.Join(tokensDir, "claude")
+		if err := os.WriteFile(apiKeyFile, []byte("test-claude-key"), 0644); err != nil {
+			t.Fatalf("Failed to write claude token file: %v", err)
+		}
+
+		c := &ClaudeCLI{ProviderConfig: ProviderConfig{TokensDir: tokensDir}}
+		if err := c.Setup(); err != nil {
+			t.Fatalf("ClaudeCLI.Setup() failed: %v", err)
+		}
+
+		apiKey := os.Getenv("ANTHROPIC_API_KEY")
+		if apiKey != "test-claude-key" {
+			t.Errorf("Expected ANTHROPIC_API_KEY to be 'test-claude-key', but got '%s'", apiKey)
+		}
+	})
+}
+
+func TestClaudeCLI_Run(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mockOutput := `{"result": "Claude response", "modelUsage": {"claude-sonnet-4-6": {"inputTokens": 10, "outputTokens": 20, "cacheReadInputTokens": 5}}}`
+		mockExecutor := &MockCommandExecutor{
+			Output: []byte(mockOutput),
+			Err:    nil,
+		}
+
+		c := &ClaudeCLI{Executor: mockExecutor}
+
+		output, usage, err := c.Run("fix this bug")
+		if err != nil {
+			t.Fatalf("ClaudeCLI.Run() failed: %v", err)
+		}
+
+		if string(output) != "Claude response" {
+			t.Errorf("Expected output 'Claude response', got %q", string(output))
+		}
+
+		if usage == nil {
+			t.Fatal("Expected non-nil usage")
+		}
+		if usage.Models["claude-sonnet-4-6"].Tokens.Input != 10 {
+			t.Errorf("Expected 10 input tokens, got %d", usage.Models["claude-sonnet-4-6"].Tokens.Input)
+		}
+
+		if mockExecutor.Command != "claude" {
+			t.Errorf("Expected command 'claude', got %q", mockExecutor.Command)
+		}
+		if len(mockExecutor.Args) != 4 {
+			t.Fatalf("Expected 4 args, got %d", len(mockExecutor.Args))
+		}
+		if mockExecutor.Args[0] != "--print" {
+			t.Errorf("Expected arg[0] '--print', got %q", mockExecutor.Args[0])
+		}
+		if mockExecutor.Args[1] != "--output-format" {
+			t.Errorf("Expected arg[1] '--output-format', got %q", mockExecutor.Args[1])
+		}
+		if mockExecutor.Args[2] != "json" {
+			t.Errorf("Expected arg[2] 'json', got %q", mockExecutor.Args[2])
+		}
+		if mockExecutor.Args[3] != "fix this bug" {
+			t.Errorf("Expected arg[3] 'fix this bug', got %q", mockExecutor.Args[3])
+		}
+	})
+}

--- a/repo-agent/pkg/llm/provider.go
+++ b/repo-agent/pkg/llm/provider.go
@@ -110,6 +110,13 @@ func NewLLMProvider(cfg ProviderConfig) (Provider, error) {
 		}
 		c.AddPostProcessor(StripYAMLMarkers)
 		return c, nil
+	case "claude-cli":
+		c := &ClaudeCLI{
+			Executor:       &RealCommandExecutor{},
+			ProviderConfig: cfg,
+		}
+		c.AddPostProcessor(StripYAMLMarkers)
+		return c, nil
 	case "dummy":
 		d := &Dummy{
 			ProviderConfig: cfg,


### PR DESCRIPTION
This PR adds support for Claude Code CLI as an LLM provider, following the project's "CLI-First" architecture for sandboxed tasks.

#### Technical Implementation
   * New Provider: Added ClaudeCLI (`pkg/llm/claude-cli.go`) to execute the claude binary with JSON output for result and token tracking.
   * Secure Auth: Implemented `Setup()` to automatically map the `anthropic-api-key` secret to the `ANTHROPIC_API_KEY` environment variable.
   * Sandbox Delivery: Pre-installed @anthropic-ai/claude-code in the generic-golang and dind-golang Docker images to eliminate runtime installation lag.

#### Schema & Integration
   * CRD Updates: Registered `claude-cli` as a valid provider in the `RepoWatch` API and factory logic.
   * DevContainer Support: Added the Claude Code feature to `k8s/configmap-devcontainer.yaml` for dynamic environment injection.
   * Dependency Management: Updated the `Makefile` and developer docs to include node and npm as requirements.

#### Documentation & Examples
   * Architecture: Added `LLM_ARCHITECTURE_PROPOSAL.md` explaining the shift toward vendor-specific CLI binaries.
   * Guides: Updated the integration guide to cover the new "Fat Image" vs. "Dynamic Injection" delivery models.
   * Examples: Added manifests showing Claude CLI configuration for both standard and pre-baked image workflows.