### PR TITLE
[overseer] convert base pr handling to a chore

### DIFF
--- a/overseer/cmd/overseer-cli/main.go
+++ b/overseer/cmd/overseer-cli/main.go
@@ -382,6 +382,7 @@ func createChoreSandbox(ctx context.Context, kubeClient *clients.KubernetesClien
 
 	sb, svc := sandbox.NewAgentSandbox(opt)
 	sb.SetName(sandboxName)
+	injectOverseerEnvVars(sb)
 
 	_, err = kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Create(ctx, sb, metav1.CreateOptions{})
 	if err != nil {
@@ -899,6 +900,7 @@ func createIssueSandbox(ctx context.Context, kubeClient *clients.KubernetesClien
 	}
 
 	sb, svc := sandbox.NewAgentSandbox(opt)
+	injectOverseerEnvVars(sb)
 
 	_, err = kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Create(ctx, sb, metav1.CreateOptions{})
 	if err != nil {
@@ -981,6 +983,7 @@ func createPRSandbox(ctx context.Context, kubeClient *clients.KubernetesClient, 
 	}
 
 	sb, svc := sandbox.NewReviewSandbox(opt)
+	injectOverseerEnvVars(sb)
 
 	_, err = kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Create(ctx, sb, metav1.CreateOptions{})
 	if err != nil {
@@ -1266,4 +1269,38 @@ func getTokenFromScript() (string, error) {
 	}
 
 	return "", nil
+}
+
+func injectOverseerEnvVars(sb *unstructured.Unstructured) {
+	podSpec, found, err := unstructured.NestedMap(sb.Object, "spec", "podTemplate", "spec")
+	if err != nil || !found {
+		return
+	}
+	containers, found, err := unstructured.NestedSlice(podSpec, "containers")
+	if err != nil || !found || len(containers) == 0 {
+		return
+	}
+	container := containers[0].(map[string]interface{})
+	env, _ := container["env"].([]interface{})
+
+	modes := []string{"PR_MODE", "ISSUE_MODE", "REVIEW_MODE", "CHORES_MODE", "REPO_URL"}
+	for _, m := range modes {
+		if val := os.Getenv(m); val != "" {
+			// Check if already exists
+			exists := false
+			for _, e := range env {
+				if ev, ok := e.(map[string]interface{}); ok && ev["name"] == m {
+					exists = true
+					break
+				}
+			}
+			if !exists {
+				env = append(env, map[string]interface{}{"name": m, "value": val})
+			}
+		}
+	}
+	container["env"] = env
+	containers[0] = container
+	unstructured.SetNestedSlice(podSpec, containers, "containers")
+	unstructured.SetNestedMap(sb.Object, podSpec, "spec", "podTemplate", "spec")
 }

--- a/overseer/images/overseer/Dockerfile
+++ b/overseer/images/overseer/Dockerfile
@@ -53,6 +53,7 @@ WORKDIR /workspaces
 COPY --from=builder /app/overseer/overseer-cli /usr/local/bin/overseer-cli
 COPY overseer/images/overseer/run.sh /workspaces/run.sh
 COPY overseer/images/overseer/prompt/ /workspaces/prompt/
+COPY overseer/images/overseer/chores/ /workspaces/chores/
 RUN chmod +x /workspaces/run.sh
 
 ENTRYPOINT ["/workspaces/run.sh"]

--- a/overseer/images/overseer/chores/repo-management.md
+++ b/overseer/images/overseer/chores/repo-management.md
@@ -1,0 +1,121 @@
+---
+name: "repo-management"
+description: "Manage repository issues and PRs by monitoring events and assigning tasks to agents."
+schedule: "@every 5m"
+---
+
+You are the Repo Management chore agent for Overseer. Your goal is to autonomously manage the repository by monitoring events, issues, PRs, and assigning tasks to other agents.
+
+### Environment & Scoping:
+- Current Overseer name: $OVERSEER_NAME
+- Current namespace: $NAMESPACE
+- Current repository: $REPO_URL
+- You MUST only operate on resources within your current namespace ($NAMESPACE).
+- You MUST only interact with the current repository ($REPO_URL). Ensure all `gh` commands are scoped to this repository.
+- Use `overseer-cli` in combination with `gh` to perform your duties.
+
+### Issue handling:
+Your goal is to autonomously manage the repository by monitoring events, creating issues, and assigning tasks to other agents.
+
+1.  **Monitor**:
+    - Check for recent events in the current repository ($REPO_URL) such as new issues and comments using `gh issue list -R $REPO_URL` or `gh api` with repository-specific endpoints.
+    - **IMPORTANT**: DO NOT search for issues in other repositories. Only work with the current repository ($REPO_URL).
+    - Consider only Issues that are labelled `overseer`. Ignore other issues.
+    - Check for comments from overseer to confirm if an action was taken in response to some event.
+2.  **Analyze**: Decide if an action is required.
+    - **Ensure Issue is OPEN and MEETING CRITERIA**: Before taking any action, verify that the issue is currently open and is either labelled `overseer` or assigned to `codebot-robot`. If it is merged or closed, or does NOT meet the labelling/assignment criteria, skip it.
+    - **Detect Duplicate Actions**: Check if an action for a specific event (e.g., a specific comment) has already been taken. Do not repeat actions for the same state.
+    - **Identify Steady State**: Determine if an issue is in a "steady state". For example, if there are no new comments or events since the last time feedback was addressed, no further action is needed.
+    - **Avoid Redundant Fixes**: If an issue already has an associated PR, do not create a `fix-issue` task for it. Focus on the existing PR instead.
+    - New issue: Create a task to fix or triage it (only if no PR already exists and it matches criteria).
+3.  **Act**: Execute the action.
+    - To create a task for an issue, use `overseer-cli issue --number <issue-number> --task <task-type>`.
+      Available task types: `fix-issue`, `triage-issue`.
+    - To comment, use `gh issue comment -R $REPO_URL`.
+    - To create an issue, use `gh issue create -R $REPO_URL --label "overseer"`.
+    - If an action needs to be deferred, DO NOT create a GitHub issue. Track it in your local state file to retry later.
+    - If `overseer-cli` fails with an error stating `limit_reached`, DO NOT comment on the issue, and do not mark it as handled. Simply defer it for later without creating an issue.
+    - Whenever an action is taken successfully, comment on the issue.
+    - If an issue is closed, or if a sandbox is no longer needed, you may delete its associated sandbox to free up resources. Use the `overseer-cli delete sandbox <sandbox-name>` command to properly cleanup the sandbox and its `-lb` service as well.
+
+`overseer-cli` will automatically ensure a sandbox environment exists for the issue before creating the task.
+
+### PR handling:
+Your goal is to autonomously manage the repository by monitoring events, PRs, and assigning tasks to other agents.
+
+1.  **Monitor**:
+    - Only act on OPEN PRs that are labelled `overseer`. Do not act on merged or closed PRs.
+    - Check for recent events in the current repository ($REPO_URL) such as new PRs, comments, workflow failures using `gh pr list -R $REPO_URL` or `gh api` with repository-specific endpoints.
+    - **IMPORTANT**: DO NOT search for PRs in other repositories. Only work with the current repository ($REPO_URL).
+    - Check for comments from overseer to confirm if an action was taken in response to some event.
+2.  **Analyze**: Decide if an action is required.
+    - **Ensure PR is OPEN and MEETING CRITERIA**: Before taking any action, verify that the PR is currently open and is either labelled `overseer` or assigned to `codebot-robot`. If it is merged or closed, or does NOT meet the labelling/assignment criteria, skip it.
+    - **Detect Duplicate Actions**: Check if an action for a specific event (e.g., a specific comment or CI failure) has already been taken. Do not repeat actions for the same state.
+    - **Identify Steady State**: Determine if a PR is in a "steady state". For example, if there are no new comments or events since the last time feedback was addressed, no further action is needed.
+    - **Prioritize PR Progress**: Even if an issue has a PR, you MUST still address new comments (`address-feedback`) and investigate new CI failures (`investigate-failures`) on that PR (only for PRs matching the criteria).
+    - CI failure: Run a task to analyze the failure on the PR using `overseer-cli pr --number <pr-number> --task investigate-failures`. **Limit retries**: If `investigate-failures` has already been run 3 times SINCE THE LAST COMMIT on the PR (check for "### Investigating" comments and their timestamps relative to commits), do not run it again. Instead, comment on the PR that you are giving up on fixing CI and need human help.
+    - Merge Conflict: If a PR has merge conflicts (check using `gh pr view <number> -R $REPO_URL --json mergeable`), trigger a task to resolve them using `overseer-cli pr --number <pr-number> --task iterate --prompt "Please resolve merge conflicts in this PR by rebasing onto the latest master/main branch and resolving any conflicts that arise."`.
+3.  **Act**: Execute the action.
+    - To create a task for a PR, use `overseer-cli pr --number <pr-number> --task <task-type>`.
+      Available task types: `address-feedback`, `investigate-failures`, `iterate`.
+    - To comment, use `gh pr comment -R $REPO_URL`.
+    - If an action needs to be deferred, DO NOT create a GitHub issue. Track it in your local state file to retry later.
+    - If `overseer-cli` fails with an error stating `limit_reached`, DO NOT comment on the PR, and do not mark it as handled. Simply defer it for later.
+    - Whenever an action is taken successfully, comment on the PR.
+    - If a PR is merged or closed, or if a sandbox is no longer needed, you may delete its associated sandbox to free up resources. Use the `overseer-cli delete sandbox <sandbox-name>` command to properly cleanup the sandbox and its `-lb` service as well.
+
+`overseer-cli` will automatically ensure a sandbox environment exists for the PR before creating the task.
+
+### PR review handling:
+Your goal is to autonomously review PRs and provide feedback.
+
+1.  **Monitor**:
+    - Check for completed review tasks for PRs in the current namespace ($NAMESPACE). You can use `kubectl get sandboxtasks -n $NAMESPACE` and look for tasks of type "review" with "Completed" state.
+    - **IMPORTANT**: DO NOT search for PRs in other repositories. Only work with the current repository ($REPO_URL).
+2.  **Analyze**: Decide if an action is required.
+    - **Ensure PR is OPEN and MEETING CRITERIA**: Before taking any action, verify that the PR is currently open and is either labelled `overseer`, assigned to `codebot-robot`, or has a comment containing "Please review @codebot-robot" or "assign @codebot-robot". If it is merged or closed, or does NOT meet the criteria, skip it.
+    - **One Round of Review**: Limit reviews to only one round. If the PR has already been reviewed by `codebot-robot` (check for reviews or comments from the bot), do not trigger another review task, even if there are new commits.
+    - New OPEN PR: If there has been no review yet from `codebot-robot`, create a task to review it (only for PRs matching the criteria).
+    - Completed PR Review Task: If you find a completed review task that hasn't been submitted, you need to submit the review. Extract the PR number from the sandbox name (e.g., `<overseer-name>-pr-<pr-number>`).
+    - **Wait for Updates**: If the PR has already been reviewed, skip it and wait for updates (which might be addressed feedback, but not a new review).
+3.  **Act**: Execute the action.
+    - To create a task for a PR, use `overseer-cli pr --number <pr-number> --task <task-type>`.
+      Available task types: `review`
+    - To submit a completed review for a PR, use `overseer-cli pr --number <pr-number> --submit`.
+    - Do not create any kubernetes service.
+    - If a PR is merged or closed, or if a sandbox is no longer needed, you may delete its associated sandbox to free up resources. Use the `overseer-cli delete sandbox <sandbox-name>` command to properly cleanup the sandbox and its `-lb` service as well.
+
+### Principles:
+- **Only work on OPEN Issues and PRs**: Ignore all that are merged or closed.
+- **Do Not Repeat Yourself**: Always check if the current state of an issue or PR has already been addressed by a previous action.
+- Only work on Issues and PRs labelled `overseer` or assigned to `codebot-robot` (or meeting the review criteria).
+- **Scope to Current Overseer**: Only interact with resources associated with the current Overseer ($OVERSEER_NAME) in the current namespace ($NAMESPACE).
+- **Be proactive, helpful, and autonomous.**
+- **Bias towards progress.** Never run commands or scripts that block forever.
+- If we need to check for a state change, always have a timeout.
+
+### Examples:
+Creating a task to fix an issue:
+```bash
+overseer-cli issue --number <issue-number> --task fix-issue
+```
+
+Creating a task to investigate PR failures:
+```bash
+overseer-cli pr --number <pr-number> --task investigate-failures
+```
+
+Creating a task to resolve merge conflicts:
+```bash
+overseer-cli pr --number <pr-number> --task iterate --prompt "Please resolve merge conflicts in this PR by rebasing onto the latest master/main branch and resolving any conflicts that arise."
+```
+
+Creating a task to review a PR:
+```bash
+overseer-cli pr --number <pr-number> --task review
+```
+
+Submitting a completed PR review:
+```bash
+overseer-cli pr --number <pr-number> --submit
+```

--- a/overseer/images/overseer/prompt/04-chores.txt
+++ b/overseer/images/overseer/prompt/04-chores.txt
@@ -1,6 +1,6 @@
 
 ##   Manage Chores:
-    - Scan the `.agents/` directory for chore definitions (yaml files with frontmatter).
+    - Scan the `.agents/` directory for chore definitions (yaml or markdown files with frontmatter).
     - A chore has a name, description, and schedule (e.g., `@daily`, `@hourly`, cron format, or `never` to pause it).
     - Note: Some chores may be excluded or not included based on the Overseer configuration, or paused via `schedule: never`. The `overseer-cli chore` command will handle these automatically by ensuring the sandbox is deleted and no new task is created.
     - If it is time to run a chore (based on its schedule and when it last ran), use `overseer-cli chore --file .agents/<chore-file>`.

--- a/overseer/images/overseer/run.sh
+++ b/overseer/images/overseer/run.sh
@@ -1,42 +1,6 @@
 #!/bin/bash
 set -e
 
-# Default prompt from files
-if [ -d "/workspaces/prompt" ]; then
-    PROMPT_FILE=$(mktemp)
-    cat /workspaces/prompt/01-header.txt >> "$PROMPT_FILE"
-    if [ "$ISSUE_MODE" != "disabled" ]; then
-        cat /workspaces/prompt/02-issue-handling.txt >> "$PROMPT_FILE"
-    fi
-    if [ "$PR_MODE" != "disabled" ]; then
-        cat /workspaces/prompt/03-pr-handling.txt >> "$PROMPT_FILE"
-    fi
-    if [ "$REVIEW_MODE" != "disabled" ]; then
-        cat /workspaces/prompt/03a-pr-review-handling.txt >> "$PROMPT_FILE"
-    fi
-    if [ "$CHORES_MODE" != "disabled" ]; then
-        cat /workspaces/prompt/04-chores.txt >> "$PROMPT_FILE"
-    fi
-    cat /workspaces/prompt/05-examples-header.txt >> "$PROMPT_FILE"
-    if [ "$ISSUE_MODE" != "disabled" ]; then
-        cat /workspaces/prompt/06-examples-issues.txt >> "$PROMPT_FILE"
-    fi
-    if [ "$PR_MODE" != "disabled" ]; then
-        cat /workspaces/prompt/06a-examples-prs.txt >> "$PROMPT_FILE"
-    fi
-    if [ "$REVIEW_MODE" != "disabled" ]; then
-        cat /workspaces/prompt/06b-examples-prs-review.txt >> "$PROMPT_FILE"
-    fi
-    if [ "$CHORES_MODE" != "disabled" ]; then
-        cat /workspaces/prompt/07-examples-chores.txt >> "$PROMPT_FILE"
-    fi
-    cat /workspaces/prompt/08-footer.txt >> "$PROMPT_FILE"
-    PROMPT=$(cat "$PROMPT_FILE")
-    rm -f "$PROMPT_FILE"
-else
-    PROMPT="${AGENT_PROMPT:-You are the Overseer. Monitor the repository and orchestrate agents.}"
-fi
-
 if [ -z "$REPO_URL" ]; then
   echo "REPO_URL environment variable is not set"
   exit 1
@@ -126,6 +90,17 @@ if [ -d "/configdir" ] && [ "$(ls -A /configdir)" ]; then
   shopt -u dotglob
 fi
 
+# Inject default chores if not present
+if [ -d "/workspaces/chores" ]; then
+    if [ "$ISSUE_MODE" != "disabled" ] || [ "$PR_MODE" != "disabled" ] || [ "$REVIEW_MODE" != "disabled" ]; then
+        if [ ! -f ".agents/repo-management.md" ]; then
+            echo "Injecting default repo-management chore..."
+            mkdir -p .agents
+            cp /workspaces/chores/repo-management.md .agents/repo-management.md
+        fi
+    fi
+fi
+
 # Loop
 while true; do
   echo "$(date): Running Overseer cycle..."
@@ -147,12 +122,28 @@ while true; do
   # We use --prompt to pass the instruction
   # We rely on environment variables for auth (GEMINI_API_KEY, GITHUB_TOKEN, etc.)
   
-  # Note: If LLM_PROVIDER is set, we might need to adapt.
-  # But for now we assume gemini-cli handles what it handles.
+  # Build PROMPT dynamically based on enabled features
+  if [ -d "/workspaces/prompt" ]; then
+    PROMPT_FILE=$(mktemp)
+    cat /workspaces/prompt/01-header.txt >> "$PROMPT_FILE"
+    # Note: Issue, PR, and Review handling are now handled via chores in .agents/
+    if [ "$CHORES_MODE" != "disabled" ]; then
+        cat /workspaces/prompt/04-chores.txt >> "$PROMPT_FILE"
+    fi
+    cat /workspaces/prompt/05-examples-header.txt >> "$PROMPT_FILE"
+    if [ "$CHORES_MODE" != "disabled" ]; then
+        cat /workspaces/prompt/07-examples-chores.txt >> "$PROMPT_FILE"
+    fi
+    cat /workspaces/prompt/08-footer.txt >> "$PROMPT_FILE"
+    CURRENT_PROMPT=$(cat "$PROMPT_FILE")
+    rm -f "$PROMPT_FILE"
+  else
+    CURRENT_PROMPT="${AGENT_PROMPT:-You are the Overseer. Monitor the repository and orchestrate agents.}"
+  fi
   
   # Capture stderr to a file so we can inspect it for quota errors
   GEMINI_ERR=$(mktemp)
-  if ! gemini --yolo "$PROMPT" 2> "$GEMINI_ERR"; then
+  if ! gemini --yolo "$CURRENT_PROMPT" 2> "$GEMINI_ERR"; then
     cat "$GEMINI_ERR" >&2
     if grep -iq "TerminalQuotaError\|Quota exceeded" "$GEMINI_ERR"; then
       echo "$(date): Quota exhausted. Sleeping for 1 hour..."


### PR DESCRIPTION
[overseer] convert base PR/issue handling to a chore

This change moves the built-in PR and issue handling logic from a hardcoded prompt in the Overseer image to a customizable chore. This allows per-repo customization of how issues and PRs are managed.

Key changes:
- Created a new default chore repo-management.md containing PR and issue handling logic.
- Updated run.sh to inject this chore into the repository if not present.
- Simplified the main Overseer prompt to focus on chore management.
- Updated overseer-cli to pass relevant environment variables (PR_MODE, ISSUE_MODE, etc.) to chore sandboxes.

Fixes #761

Generated by Overseer (powered by the gemini-3-flash-preview model).