### PR TITLE
Autopoll for pull-request comments also

### DIFF
--- a/repo-agent/pkg/commands/github-autopoll.go
+++ b/repo-agent/pkg/commands/github-autopoll.go
@@ -146,23 +146,52 @@ func (p *AutoPoller) pollOnce(ctx context.Context) error {
 		log.V(2).Info("Found issues assigned to bot", "repo", repoStr, "count", len(issues))
 
 		for _, issue := range issues {
-			// Skip pull requests (GitHub API returns PRs as issues)
-			if issue.PullRequestLinks != nil {
-				continue
-			}
-
-			issueKey := fmt.Sprintf("%s/%s#%d", repo.Owner, repo.Name, issue.GetNumber())
+			issueNumber := issue.GetNumber()
+			isPR := issue.PullRequestLinks != nil
+			issueKey := fmt.Sprintf("%s/%s#%d", repo.Owner, repo.Name, issueNumber)
 
 			// Skip if already processed in this run
 			if info := p.processedIssues[issueKey]; info != nil {
-				log.V(2).Info("Skipping issue, already processed", "issue", issueKey, "reason", info.Reason)
+				log.V(2).Info("Skipping, already processed", "issue", issueKey, "reason", info.Reason)
 				continue
 			}
 
 			// Check if issue author is in allowlist
 			author := issue.GetUser().GetLogin()
 			if !p.allowlistMap[author] {
-				log.Info("Skipping issue, author not in allowlist", "issue", issueKey, "author", author)
+				log.Info("Skipping, author not in allowlist", "issue", issueKey, "author", author)
+				continue
+			}
+
+			if isPR {
+				log.Info("Processing pull request feedback", "pr", issueKey)
+
+				// Mark as processed
+				p.processedIssues[issueKey] = &Info{Reason: "processed"}
+
+				// Remove assignment
+				_, _, err := p.githubAPI.Issues.RemoveAssignees(ctx, repo.Owner, repo.Name, issueNumber, []string{p.opt.AssignedTo})
+				if err != nil {
+					log.Error(err, "failed to remove assignment", "pr", issueKey)
+				}
+
+				prURL := issue.GetHTMLURL()
+				go func(prURL string, prNumber int) {
+					feedback := GithubFeedbackCommand{
+						URL:             prURL,
+						PullRequestID:   prNumber,
+						InPod:           false,
+						GithubUserLogin: "codebot-robot",
+						GithubUserEmail: "codebot-robot@google.com",
+						GithubUserName:  "codebot-robot",
+						GithubUserToken: os.Getenv("CODEBOT_ROBOT_GITHUB_TOKEN"),
+					}
+					feedback.InitDefaults()
+
+					if err := feedback.Run(ctx); err != nil {
+						log.Error(err, "failed to process PR feedback", "pr", issueKey)
+					}
+				}(prURL, issueNumber)
 				continue
 			}
 
@@ -175,7 +204,7 @@ func (p *AutoPoller) pollOnce(ctx context.Context) error {
 				continue
 			}
 			if !shouldProcess {
-				log.Info("Skipping issue", "issue", issueKey, "reason", reason)
+				log.V(2).Info("Skipping issue", "issue", issueKey, "reason", reason)
 				p.processedIssues[issueKey] = &Info{Reason: reason}
 				continue
 			}
@@ -186,7 +215,7 @@ func (p *AutoPoller) pollOnce(ctx context.Context) error {
 			p.processedIssues[issueKey] = &Info{Reason: "processed"}
 
 			// Create the issue URL and invoke github-fix-issue logic
-			issueURL := fmt.Sprintf("https://github.com/%s/%s/issues/%d", repo.Owner, repo.Name, issue.GetNumber())
+			issueURL := fmt.Sprintf("https://github.com/%s/%s/issues/%d", repo.Owner, repo.Name, issueNumber)
 
 			go func(issueURL string) {
 				// TODO (barney-s): set additional fields
@@ -198,7 +227,7 @@ func (p *AutoPoller) pollOnce(ctx context.Context) error {
 					GithubUserName:  "codebot-robot",
 					GithubUserToken: os.Getenv("CODEBOT_ROBOT_GITHUB_TOKEN"),
 				}
-				// fixIssue.InitDefaults()
+				fixIssue.InitDefaults()
 
 				if err := fixIssue.Run(ctx); err != nil {
 					log.Error(err, "failed to process issue", "issue", issueKey)

--- a/repo-agent/pkg/commands/github-autopoll.go
+++ b/repo-agent/pkg/commands/github-autopoll.go
@@ -181,15 +181,21 @@ func (p *AutoPoller) pollOnce(ctx context.Context) error {
 						URL:             prURL,
 						PullRequestID:   prNumber,
 						InPod:           false,
-						GithubUserLogin: "codebot-robot",
-						GithubUserEmail: "codebot-robot@google.com",
-						GithubUserName:  "codebot-robot",
-						GithubUserToken: os.Getenv("CODEBOT_ROBOT_GITHUB_TOKEN"),
+						GithubUserLogin: p.opt.AssignedTo,
+						GithubUserEmail: fmt.Sprintf("%s@google.com", p.opt.AssignedTo),
+						GithubUserName:  p.opt.AssignedTo,
 					}
 					feedback.InitDefaults()
 
 					if err := feedback.Run(ctx); err != nil {
 						log.Error(err, "failed to process PR feedback", "pr", issueKey)
+						errorMsg := fmt.Sprintf("I failed to process the feedback: %v\n\nPlease re-assign me if you'd like me to try again.", err)
+						_, _, commentErr := p.githubAPI.Issues.CreateComment(ctx, repo.Owner, repo.Name, prNumber, &gogithub.IssueComment{
+							Body: &errorMsg,
+						})
+						if commentErr != nil {
+							log.Error(commentErr, "failed to post error comment", "pr", issueKey)
+						}
 					}
 				}(prURL, issueNumber)
 				continue

--- a/repo-agent/pkg/commands/github-feedback.go
+++ b/repo-agent/pkg/commands/github-feedback.go
@@ -119,17 +119,18 @@ func (c *GithubFeedbackCommand) taskPath(name string, args ...interface{}) strin
 }
 
 func (c *GithubFeedbackCommand) loadGithubObjects(ctx context.Context) error {
-	token, err := github.GetGithubToken(ctx)
+	if c.GithubUserToken == "" {
+		token, err := github.GetGithubToken(ctx)
+		if err != nil {
+			return err
+		}
+		c.GithubUserToken = token
+	}
+
+	githubAPI, err := github.NewClientWithToken(context.Background(), c.GithubUserToken)
 	if err != nil {
 		return err
 	}
-	c.GithubUserToken = token
-
-	githubAPI, err := github.NewClient(context.Background())
-	if err != nil {
-		return err
-	}
-
 	c.repo, err = githubAPI.GetRepositoryFromIssueURL(ctx, c.URL)
 	if err != nil {
 		return err
@@ -202,6 +203,8 @@ func (c *GithubFeedbackCommand) loadSandbox(ctx context.Context) error {
 	}
 
 	if c.Sandbox == "" {
+		log := klog.FromContext(ctx)
+		log.Info("Automatically creating sandbox for PR feedback")
 		sb, err := sandbox.NewIssueSandbox(ctx, c.InPod, c.repo, c.issue, "")
 		if err != nil {
 			return err
@@ -210,7 +213,6 @@ func (c *GithubFeedbackCommand) loadSandbox(ctx context.Context) error {
 		c.sandboxID = sb.GetSandboxID()
 		return nil
 	}
-
 	// Reusing existing sandbox
 	podID, err := sandbox.FindSandboxPod(ctx, c.Sandbox)
 	if err != nil {

--- a/repo-agent/pkg/commands/github-feedback.go
+++ b/repo-agent/pkg/commands/github-feedback.go
@@ -201,6 +201,16 @@ func (c *GithubFeedbackCommand) loadSandbox(ctx context.Context) error {
 		return nil
 	}
 
+	if c.Sandbox == "" {
+		sb, err := sandbox.NewIssueSandbox(ctx, c.InPod, c.repo, c.issue, "")
+		if err != nil {
+			return err
+		}
+		c.sandbox = sb
+		c.sandboxID = sb.GetSandboxID()
+		return nil
+	}
+
 	// Reusing existing sandbox
 	podID, err := sandbox.FindSandboxPod(ctx, c.Sandbox)
 	if err != nil {

--- a/repo-agent/pkg/github/client.go
+++ b/repo-agent/pkg/github/client.go
@@ -49,6 +49,11 @@ func NewClient(ctx context.Context) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	return NewClientWithToken(ctx, token)
+}
+
+// NewClientWithToken creates a new GitHub client using the provided token.
+func NewClientWithToken(ctx context.Context, token string) (*Client, error) {
 	return &Client{
 		Client: clients.NewGitHubClient(ctx, token),
 	}, nil


### PR DESCRIPTION
We currently poll for issues assigned to codebot-robot, and if we see an issue we will launch a sandbox to create a PR addressing the issue.

Humans can also review the PR, and tests can fail; in both cases we probably want to update the PR by pushing changes. We (currently) don't want to automatically do this for each piece of feedback - it can be more efficient to wait a few minutes to get a "full picture" of the test failures / PR feedback.

So this PR adds polling of the pull requests, looking for any PRs that are assigned to codebot-robot (just like we look for issues assigned to codebot robot). For a pull request, it removes the assignment, and then runs RunGithubFeedback to address the feedback.

Fixes #360

Generated by Overseer (powered by the gemini-3-flash-preview model)