### PR TITLE
fix: resolve repo-sandbox binary path mismatch in sandboxes

### DIFF
--- a/repo-agent/images/generic-golang/Dockerfile
+++ b/repo-agent/images/generic-golang/Dockerfile
@@ -60,10 +60,10 @@ RUN npm install -g @google/gemini-cli @anthropic-ai/claude-code
 RUN curl -fsSL https://code-server.dev/install.sh | sh
 RUN code-server --install-extension golang.go --install-extension vscodevim.vim
 
-COPY --from=build-repo-sandbox /repo-sandbox /repo-agent/repo-sandbox
+COPY --from=build-repo-sandbox /repo-sandbox /usr/local/bin/repo-sandbox
 COPY --from=build-gh /bin/gh /bin/gh
 
 RUN ln -sf /usr/local/go/bin/go /usr/local/bin/go
 
 WORKDIR /workspaces
-ENTRYPOINT ["/repo-agent/repo-sandbox", "agent"]
+ENTRYPOINT ["/usr/local/bin/repo-sandbox", "agent"]

--- a/repo-agent/images/repo-sandbox/Dockerfile
+++ b/repo-agent/images/repo-sandbox/Dockerfile
@@ -31,6 +31,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -v -o /gemini-stream-proc
 
 # Envbuilder root
 FROM ghcr.io/coder/envbuilder
-COPY --from=builder /repo-sandbox /repo-agent/repo-sandbox
+COPY --from=builder /repo-sandbox /usr/local/bin/repo-sandbox
 COPY --from=builder /gemini-stream-processor /usr/local/bin/gemini-stream-processor
 ENV KANIKO_DIR=/.envbuilder

--- a/repo-agent/pkg/sandbox/agent_sandbox.go
+++ b/repo-agent/pkg/sandbox/agent_sandbox.go
@@ -308,14 +308,13 @@ func NewAgentSandbox(opt AgentSandboxOptions) (*unstructured.Unstructured, *core
 								})
 							}
 							containers = append(containers, map[string]interface{}{
-								"name":    "inject-agent",
-								"image":   opt.RepoSandboxImage,
-								"command": []interface{}{"/repo-agent/repo-sandbox", "inject", "--path", "/opt/repo-agent"},
-								"volumeMounts": []interface{}{
-									map[string]interface{}{"name": "agent-bin", "mountPath": "/opt/repo-agent"},
-								},
-							})
-							return containers
+							        "name":    "inject-agent",
+							        "image":   opt.RepoSandboxImage,
+							        "command": []interface{}{"repo-sandbox", "inject", "--path", "/opt/repo-agent"},
+							        "volumeMounts": []interface{}{
+							                map[string]interface{}{"name": "agent-bin", "mountPath": "/opt/repo-agent"},
+							        },
+							})							return containers
 						}(),
 						"containers": []interface{}{
 							map[string]interface{}{

--- a/repo-agent/pkg/sandbox/agent_sandbox.go
+++ b/repo-agent/pkg/sandbox/agent_sandbox.go
@@ -314,7 +314,8 @@ func NewAgentSandbox(opt AgentSandboxOptions) (*unstructured.Unstructured, *core
 							        "volumeMounts": []interface{}{
 							                map[string]interface{}{"name": "agent-bin", "mountPath": "/opt/repo-agent"},
 							        },
-							})							return containers
+							})
+							return containers
 						}(),
 						"containers": []interface{}{
 							map[string]interface{}{

--- a/repo-agent/pkg/sandbox/review_sandbox.go
+++ b/repo-agent/pkg/sandbox/review_sandbox.go
@@ -263,7 +263,8 @@ func NewReviewSandbox(opt ReviewSandboxOptions) (*unstructured.Unstructured, *co
 							                       "mountPath": "/opt/repo-agent",
 							                },
 							        },
-							})							return containers
+							})
+							return containers
 						}(),
 						"containers": []interface{}{
 							map[string]interface{}{

--- a/repo-agent/pkg/sandbox/review_sandbox.go
+++ b/repo-agent/pkg/sandbox/review_sandbox.go
@@ -254,17 +254,16 @@ func NewReviewSandbox(opt ReviewSandboxOptions) (*unstructured.Unstructured, *co
 								})
 							}
 							containers = append(containers, map[string]interface{}{
-								"name":    "inject-agent",
-								"image":   opt.RepoSandboxImage,
-								"command": []interface{}{"/repo-agent/repo-sandbox", "inject", "--path", "/opt/repo-agent"},
-								"volumeMounts": []interface{}{
-									map[string]interface{}{
-										"name":      "agent-bin",
-										"mountPath": "/opt/repo-agent",
-									},
-								},
-							})
-							return containers
+							        "name":    "inject-agent",
+							        "image":   opt.RepoSandboxImage,
+							        "command": []interface{}{"repo-sandbox", "inject", "--path", "/opt/repo-agent"},
+							        "volumeMounts": []interface{}{
+							                map[string]interface{}{
+							                       "name":      "agent-bin",
+							                       "mountPath": "/opt/repo-agent",
+							                },
+							        },
+							})							return containers
 						}(),
 						"containers": []interface{}{
 							map[string]interface{}{


### PR DESCRIPTION
The repo-sandbox binary was being hardcoded to /repo-agent/repo-sandbox in the
pod spec, but some build environments (like ko) put it in /ko-app/repo-sandbox.

This change:
1. Updates the Dockerfiles to put the binary in /usr/local/bin/repo-sandbox.
2. Updates the sandbox configuration to use 'repo-sandbox' without an absolute
   path, relying on it being in the PATH in both Docker and ko images.

Fixes #922
