### PR TITLE
fix(infra): ensure /repo-agent directory exists in sandbox images

### DIFF
--- a/repo-agent/images/generic-golang/Dockerfile
+++ b/repo-agent/images/generic-golang/Dockerfile
@@ -60,7 +60,7 @@ RUN npm install -g @google/gemini-cli @anthropic-ai/claude-code
 RUN curl -fsSL https://code-server.dev/install.sh | sh
 RUN code-server --install-extension golang.go --install-extension vscodevim.vim
 
-COPY --from=build-repo-sandbox /repo-sandbox /repo-agent/repo-sandbox
+RUN mkdir -p /repo-agent && COPY --from=build-repo-sandbox /repo-sandbox /repo-agent/repo-sandbox
 COPY --from=build-gh /bin/gh /bin/gh
 
 RUN ln -sf /usr/local/go/bin/go /usr/local/bin/go

--- a/repo-agent/images/repo-sandbox/Dockerfile
+++ b/repo-agent/images/repo-sandbox/Dockerfile
@@ -31,6 +31,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -v -o /gemini-stream-proc
 
 # Envbuilder root
 FROM ghcr.io/coder/envbuilder
-COPY --from=builder /repo-sandbox /repo-agent/repo-sandbox
+RUN mkdir -p /repo-agent && COPY --from=builder /repo-sandbox /repo-agent/repo-sandbox
 COPY --from=builder /gemini-stream-processor /usr/local/bin/gemini-stream-processor
 ENV KANIKO_DIR=/.envbuilder


### PR DESCRIPTION
Fixes #922. This PR ensures that the /repo-agent directory is created before copying the repo-sandbox binary in the Dockerfiles.