### PR TITLE
fix(infra): ensure /repo-agent directory exists in sandbox images

### DIFF
--- a/repo-agent/images/generic-golang/Dockerfile
+++ b/repo-agent/images/generic-golang/Dockerfile
@@ -60,6 +60,7 @@ RUN npm install -g @google/gemini-cli @anthropic-ai/claude-code
 RUN curl -fsSL https://code-server.dev/install.sh | sh
 RUN code-server --install-extension golang.go --install-extension vscodevim.vim
 
+RUN mkdir -p /repo-agent
 COPY --from=build-repo-sandbox /repo-sandbox /repo-agent/repo-sandbox
 COPY --from=build-gh /bin/gh /bin/gh
 

--- a/repo-agent/images/repo-sandbox/Dockerfile
+++ b/repo-agent/images/repo-sandbox/Dockerfile
@@ -31,6 +31,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -v -o /gemini-stream-proc
 
 # Envbuilder root
 FROM ghcr.io/coder/envbuilder
+RUN mkdir -p /repo-agent
 COPY --from=builder /repo-sandbox /repo-agent/repo-sandbox
 COPY --from=builder /gemini-stream-processor /usr/local/bin/gemini-stream-processor
 ENV KANIKO_DIR=/.envbuilder


### PR DESCRIPTION
Fixes #922. Fixes #959. All sandboxes are currently failing because /repo-agent is being created as a file instead of a directory in the Docker images.