### PR TITLE
Fix multiple deployment friction points (Issue #917)

### DIFF
--- a/overseer/k8s/overseer-controller.yaml
+++ b/overseer/k8s/overseer-controller.yaml
@@ -55,7 +55,7 @@ rules:
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: [""]
   resources: ["pods", "events"]
-  verbs: ["get", "list"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/overseer/k8s/overseer-rbac.yaml
+++ b/overseer/k8s/overseer-rbac.yaml
@@ -31,7 +31,7 @@ rules:
   verbs: ["get", "list", "create", "update", "patch", "delete"]
 - apiGroups: [""]
   resources: ["secrets", "pods", "events"]
-  verbs: ["get", "list"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["configdir.gke.io"]
   resources: ["configdirs", "configfiles"]
   verbs: ["get", "list", "watch"]

--- a/repo-agent/cmd/repowatch-controller/main.go
+++ b/repo-agent/cmd/repowatch-controller/main.go
@@ -101,8 +101,18 @@ func main() {
 		NewGithubClient: func(ctx context.Context, k8sClient client.Client, repoWatch *reviewv1alpha1.RepoWatch) (*github.Client, map[string]string, error) {
 			return repowatch.NewGithubClient(ctx, k8sClient, repoWatch)
 		},
-		RepoSandboxImage: os.Getenv("REPO_SANDBOX_IMAGE"),
-		ConfigDirImage:   os.Getenv("CONFIGDIR_CLI_IMAGE"),
+		RepoSandboxImage: func() string {
+			if img := os.Getenv("REPO_SANDBOX_IMAGE"); img != "" {
+				return img
+			}
+			return "gcr.io/gke-labs/repo-sandbox:latest"
+		}(),
+		ConfigDirImage: func() string {
+			if img := os.Getenv("CONFIGDIR_CLI_IMAGE"); img != "" {
+				return img
+			}
+			return "gcr.io/gke-labs/configdir-cli:latest"
+		}(),
 		ForceSandboxMode: forceSandboxMode,
 	}).SetupWithManager(mgr, concurrentReconciles); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "RepoWatch")

--- a/repo-agent/cmd/review-api/main.go
+++ b/repo-agent/cmd/review-api/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"net/http"
 	"os"
 	"strings"
 
@@ -66,6 +67,12 @@ func main() {
 		sessionSecret = base64.StdEncoding.EncodeToString(b)
 	}
 	store := cookie.NewStore([]byte(sessionSecret))
+	store.Options(sessions.Options{
+		Secure:   false, // Allow login over HTTP for local/non-HTTPS setups
+		SameSite: http.SameSiteLaxMode,
+		Path:     "/",
+		MaxAge:   86400 * 7, // 7 days
+	})
 	router.Use(sessions.Sessions(sessionName, store))
 
 	// Register Routes

--- a/repo-agent/k8s/api-rbac.yaml
+++ b/repo-agent/k8s/api-rbac.yaml
@@ -34,7 +34,7 @@ rules:
 # Can list pods to find sandboxes and exec into them for terminal
 - apiGroups: [""]
   resources: ["pods", "pods/exec", "pods/log"]
-  verbs: ["get", "list", "create"]
+  verbs: ["get", "list", "watch", "create"]
 # Can proxy to nodes for exec
 - apiGroups: [""]
   resources: ["nodes", "nodes/proxy"]
@@ -108,4 +108,6 @@ roleRef:
   kind: ClusterRole
   name: configdir-controller
   apiGroup: rbac.authorization.k8s.io
+
+.k8s.io
 

--- a/repo-agent/pkg/api/handlers_repo.go
+++ b/repo-agent/pkg/api/handlers_repo.go
@@ -376,12 +376,9 @@ func (s *Server) updateRepoWatch(c *gin.Context) {
 		var pullRequests []int64
 		if found {
 			for _, v := range pullRequestsSlice {
-				if i, ok := v.(int64); ok {
+				if i, ok := toInt64(v); ok {
 					pullRequests = append(pullRequests, i)
-				} else if i, ok := v.(int); ok {
-					pullRequests = append(pullRequests, int64(i))
-				}
-			}
+				}			}
 		}
 
 		// Check for duplicates
@@ -666,9 +663,14 @@ func (s *Server) getRepos(c *gin.Context) {
 		if pendingPRsSlice, found, err := unstructured.NestedSlice(repoWatch.Object, "status", "pendingPRs"); err == nil && found {
 			var prNumbers []int64
 			for _, v := range pendingPRsSlice {
-				if i, ok := v.(int64); ok {
+				switch i := v.(type) {
+				case int64:
 					prNumbers = append(prNumbers, i)
-				} else if i, ok := v.(int); ok {
+				case int:
+					prNumbers = append(prNumbers, int64(i))
+				case int32:
+					prNumbers = append(prNumbers, int64(i))
+				case float64:
 					prNumbers = append(prNumbers, int64(i))
 				}
 			}
@@ -760,10 +762,8 @@ func (s *Server) getRepos(c *gin.Context) {
 			for _, v := range pendingIssuesMap {
 				if issuesSlice, ok := v.([]interface{}); ok {
 					for _, issue := range issuesSlice {
-						if i, ok := issue.(int64); ok {
+						if i, ok := toInt64(issue); ok {
 							issueNumbers = append(issueNumbers, i)
-						} else if i, ok := issue.(int); ok {
-							issueNumbers = append(issueNumbers, int64(i))
 						}
 					}
 				}
@@ -866,9 +866,14 @@ func (s *Server) getRepo(c *gin.Context) {
 	if pendingPRsSlice, found, err := unstructured.NestedSlice(repoWatch.Object, "status", "pendingPRs"); err == nil && found {
 		var prNumbers []int64
 		for _, v := range pendingPRsSlice {
-			if i, ok := v.(int64); ok {
+			switch i := v.(type) {
+			case int64:
 				prNumbers = append(prNumbers, i)
-			} else if i, ok := v.(int); ok {
+			case int:
+				prNumbers = append(prNumbers, int64(i))
+			case int32:
+				prNumbers = append(prNumbers, int64(i))
+			case float64:
 				prNumbers = append(prNumbers, int64(i))
 			}
 		}
@@ -960,10 +965,8 @@ func (s *Server) getRepo(c *gin.Context) {
 		for _, v := range pendingIssuesMap {
 			if issuesSlice, ok := v.([]interface{}); ok {
 				for _, issue := range issuesSlice {
-					if i, ok := issue.(int64); ok {
+					if i, ok := toInt64(issue); ok {
 						issueNumbers = append(issueNumbers, i)
-					} else if i, ok := issue.(int); ok {
-						issueNumbers = append(issueNumbers, int64(i))
 					}
 				}
 			}

--- a/repo-agent/pkg/api/server.go
+++ b/repo-agent/pkg/api/server.go
@@ -53,13 +53,19 @@ func (s *Server) RegisterRoutes(router *gin.Engine) {
 		api.GET("/repos", s.getRepos)
 		api.POST("/repos", s.createRepoWatch)
 		api.GET("/repos/:repo", s.getRepo)
+		api.GET("/repo/:repo", s.getRepo) // Alias
 		api.GET("/getRepoWatch", s.getDefaultRepoWatch)
 		api.GET("/templates", s.getTemplates)
 		api.GET("/repos/:repo/yaml", s.getRepoWatchYAML)
+		api.GET("/repo/:repo/yaml", s.getRepoWatchYAML) // Alias
 		api.PUT("/repos/:repo", s.updateRepoWatch)
+		api.PUT("/repo/:repo", s.updateRepoWatch) // Alias
 		api.DELETE("/repos/:repo", s.deleteRepoWatch)
+		api.DELETE("/repo/:repo", s.deleteRepoWatch) // Alias
 		api.GET("/repos/:repo/instructions", s.getInstructions)
+		api.GET("/repo/:repo/instructions", s.getInstructions) // Alias
 		api.POST("/repos/:repo/instructions", s.updateInstructions)
+		api.POST("/repo/:repo/instructions", s.updateInstructions) // Alias
 
 		api.GET("/settings", s.getSettings)
 		api.POST("/settings", s.updateSettings)

--- a/repo-agent/pkg/api/utils.go
+++ b/repo-agent/pkg/api/utils.go
@@ -40,6 +40,21 @@ func convInt64SliceToInterfaceSlice(in []int64) []interface{} {
 	return out
 }
 
+func toInt64(v interface{}) (int64, bool) {
+	switch i := v.(type) {
+	case int64:
+		return i, true
+	case int:
+		return int64(i), true
+	case int32:
+		return int64(i), true
+	case float64:
+		return int64(i), true
+	default:
+		return 0, false
+	}
+}
+
 func parseRepoURL(repoURL string) (string, string, error) {
 	u, err := url.Parse(repoURL)
 	if err != nil {

--- a/repo-agent/pkg/sandbox/interactive.go
+++ b/repo-agent/pkg/sandbox/interactive.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/agentsandboxes/pkg/threads"
@@ -156,9 +157,14 @@ func LaunchSandbox(ctx context.Context, kube *clients.KubernetesClient, repo *gi
 
 	log.Info("Creating sandbox", "name", sandboxName, "repos", cloneRepos, "issue", issueURL)
 
+	image := os.Getenv("REPO_SANDBOX_IMAGE")
+	if image == "" {
+		image = "gcr.io/gke-labs/repo-sandbox:latest"
+	}
+
 	container := v1.Container{}
 	container.Name = "agent"
-	container.Image = "gcr.io/justinsb-knotai-dev/generic-golang:latest"
+	container.Image = image
 
 	container.Env = append(container.Env, v1.EnvVar{
 		Name:  "CLONE_REPOS",


### PR DESCRIPTION
This PR addresses several issues identified in the #917 Epic to improve fresh installs and resolve source-image drift.

Key changes:
- **#908**: Set session cookie `Secure` flag to `false` to allow login over HTTP, which was preventing login in non-HTTPS environments.
- **#910**: Improved numeric type handling for `PendingPRs` and `PendingIssues` in API handlers using a new `toInt64` helper. This prevents potential crashes when Kubernetes unstructured data contains `float64` or different integer types.
- **#911, #912**: Added missing `watch` verb to RBAC ClusterRoles for pods and sandboxes in `api-rbac.yaml`, `overseer-controller.yaml`, and `overseer-rbac.yaml`.
- **#913**: Replaced a hardcoded private GCR image in `interactive.go` with the `REPO_SANDBOX_IMAGE` environment variable and a sensible public default.
- **#914**: Provided default public images for `REPO_SANDBOX_IMAGE` and `CONFIGDIR_CLI_IMAGE` in the `repowatch-controller` if the environment variables are not set.
- **#916**: Added singular URL aliases (`/api/repo/:repo`) for all repository-level API routes to resolve inconsistencies and potential mismatches with the frontend.

This PR was generated by **Overseer** (powered by the gemini-2.0-flash model).
Fixes #917