### PR TITLE
Fix address-feedback template rendering by adding ID to PRComment

### DIFF
--- a/factory/pkg/commands/pr.go
+++ b/factory/pkg/commands/pr.go
@@ -133,6 +133,7 @@ func runInvestigate(ctx context.Context, prURL, prompt string) error {
 	var prComments []tasks.PRComment
 	for _, c := range comments {
 		prComments = append(prComments, tasks.PRComment{
+			ID:        c.GetID(),
 			UserLogin: c.GetUser().GetLogin(),
 			CreatedAt: c.GetCreatedAt().Format(time.RFC3339),
 			Body:      c.GetBody(),
@@ -306,6 +307,7 @@ func runAddressComments(ctx context.Context, prURL, prompt string) error {
 	var newComments []tasks.PRComment
 	for _, c := range comments {
 		cmt := tasks.PRComment{
+			ID:        c.GetID(),
 			UserLogin: c.GetUser().GetLogin(),
 			CreatedAt: c.GetCreatedAt().Format(time.RFC3339),
 			Body:      c.GetBody(),

--- a/factory/pkg/tasks/fix_issue.go
+++ b/factory/pkg/tasks/fix_issue.go
@@ -60,6 +60,7 @@ type FailedRun struct {
 }
 
 type PRComment struct {
+	ID        int64
 	UserLogin string
 	CreatedAt string
 	Body      string


### PR DESCRIPTION
fix for

```
E0520 11:31:05.369141 1535420 pr.go:582] Address-comments failed: rendering address-feedback prompt: executing prompt template: template: address_feedback.txt:94:22: executing "address_feedback.txt" at <$comment.ID>: can't evaluate field ID in type tasks.PRComment
```