### PR TITLE
Upgrade to gemini-3.5-flash

### DIFF
--- a/factory/pkg/commands/fix.go
+++ b/factory/pkg/commands/fix.go
@@ -181,7 +181,7 @@ func runFix(ctx context.Context, targetURL, prompt, name string) error {
 		IssueComments: issueComments,
 		Instruction:   prompt,
 		Branch:        branchName,
-		Models:        []string{"gemini-3-flash-preview", "gemini-3.1-pro-preview", "gemini-2.5-pro"},
+		Models:        []string{"gemini-3.5-flash", "gemini-3-flash-preview", "gemini-3.1-pro-preview", "gemini-2.5-pro"},
 		DraftPR:       false,
 		PRLabel:       "factory",
 	}
@@ -228,7 +228,7 @@ func runFix(ctx context.Context, targetURL, prompt, name string) error {
 		"GITHUB_USER_EMAIL":          githubEmail,
 		"GITHUB_USER_NAME":           githubLogin,
 		"BRANCH_NAME":                branchName,
-		"MODELS":                     "gemini-3-flash-preview gemini-3.1-pro-preview gemini-2.5-pro",
+		"MODELS":                     "gemini-3.5-flash gemini-3-flash-preview gemini-3.1-pro-preview gemini-2.5-pro",
 	}
 
 	fmt.Println("Running fix-issue task via envd...")

--- a/factory/pkg/commands/pr.go
+++ b/factory/pkg/commands/pr.go
@@ -168,7 +168,7 @@ func runInvestigate(ctx context.Context, prURL, prompt string) error {
 		},
 		FailedRuns:    failedRuns,
 		IssueComments: prComments,
-		Models:        []string{"gemini-3-flash-preview", "gemini-3.1-pro-preview", "gemini-2.5-pro"},
+		Models:        []string{"gemini-3.5-flash", "gemini-3-flash-preview", "gemini-3.1-pro-preview", "gemini-2.5-pro"},
 	}
 
 	scriptBytes, err := tasks.GetInvestigateScript()
@@ -213,7 +213,7 @@ func runInvestigate(ctx context.Context, prURL, prompt string) error {
 		"PR_NUMBER":                  strconv.Itoa(prNum),
 		"FAILED_RUNS":                strings.Join(failedRunIDs, " "),
 		"FAILED_PROW_RUNS":           strings.Join(failedProwRuns, " "),
-		"MODELS":                     "gemini-3-flash-preview gemini-3.1-pro-preview gemini-2.5-pro",
+		"MODELS":                     "gemini-3.5-flash gemini-3-flash-preview gemini-3.1-pro-preview gemini-2.5-pro",
 	}
 
 	fmt.Println("Running investigate task via envd...")
@@ -386,7 +386,7 @@ func runAddressComments(ctx context.Context, prURL, prompt string) error {
 		IssueComments:         newComments,
 		OldPullRequestReviews: oldReviews,
 		PullRequestReviews:    newReviews,
-		Models:                []string{"gemini-3-flash-preview", "gemini-3.1-pro-preview", "gemini-2.5-pro"},
+		Models:                []string{"gemini-3.5-flash", "gemini-3-flash-preview", "gemini-3.1-pro-preview", "gemini-2.5-pro"},
 	}
 
 	scriptBytes, err := tasks.GetAddressFeedbackScript()
@@ -429,7 +429,7 @@ func runAddressComments(ctx context.Context, prURL, prompt string) error {
 		"GITHUB_USER_EMAIL":          githubEmail,
 		"GITHUB_USER_NAME":           githubLogin,
 		"PR_NUMBER":                  strconv.Itoa(prNum),
-		"MODELS":                     "gemini-3-flash-preview gemini-3.1-pro-preview gemini-2.5-pro",
+		"MODELS":                     "gemini-3.5-flash gemini-3-flash-preview gemini-3.1-pro-preview gemini-2.5-pro",
 	}
 
 	fmt.Println("Running address-comments task via envd...")

--- a/factory/pkg/tasks/address_feedback.sh
+++ b/factory/pkg/tasks/address_feedback.sh
@@ -136,7 +136,7 @@ function runGemini {
         export GIT_COMMITTER_EMAIL="$GITHUB_BOT_EMAIL"
     fi
 
-    MODELS_LIST="${MODELS:-gemini-3-flash-preview gemini-3.1-pro-preview gemini-2.5-pro}"
+    MODELS_LIST="${MODELS:-gemini-3.5-flash gemini-3-flash-preview gemini-3.1-pro-preview gemini-2.5-pro}"
     SUCCESS=false
     for MODEL in $MODELS_LIST; do
         echo "Trying model: $MODEL"

--- a/factory/pkg/tasks/fix_issue.go
+++ b/factory/pkg/tasks/fix_issue.go
@@ -86,7 +86,7 @@ func GetInvestigateScript() ([]byte, error) {
 
 func RenderInvestigatePrompt(params InvestigateParams) ([]byte, error) {
 	if len(params.Models) == 0 {
-		params.Models = []string{"gemini-3-flash-preview", "gemini-3.1-pro-preview", "gemini-2.5-pro"}
+		params.Models = []string{"gemini-3.5-flash", "gemini-3-flash-preview", "gemini-3.1-pro-preview", "gemini-2.5-pro"}
 	}
 
 	promptTmpl, err := getPromptTemplate("investigate_failures.txt")
@@ -135,7 +135,7 @@ func GetAddressFeedbackScript() ([]byte, error) {
 
 func RenderAddressFeedbackPrompt(params AddressFeedbackParams) ([]byte, error) {
 	if len(params.Models) == 0 {
-		params.Models = []string{"gemini-3-flash-preview", "gemini-3.1-pro-preview", "gemini-2.5-pro"}
+		params.Models = []string{"gemini-3.5-flash", "gemini-3-flash-preview", "gemini-3.1-pro-preview", "gemini-2.5-pro"}
 	}
 
 	promptTmpl, err := getPromptTemplate("address_feedback.txt")

--- a/factory/pkg/tasks/investigate_failures.sh
+++ b/factory/pkg/tasks/investigate_failures.sh
@@ -160,7 +160,7 @@ function runGemini {
         export GIT_COMMITTER_EMAIL="$GITHUB_BOT_EMAIL"
     fi
 
-    MODELS_LIST="${MODELS:-gemini-3-flash-preview gemini-3.1-pro-preview gemini-2.5-pro}"
+    MODELS_LIST="${MODELS:-gemini-3.5-flash gemini-3-flash-preview gemini-3.1-pro-preview gemini-2.5-pro}"
     SUCCESS=false
     for MODEL in $MODELS_LIST; do
         echo "Trying model: $MODEL"

--- a/overseer/cmd/overseer-cli/main.go
+++ b/overseer/cmd/overseer-cli/main.go
@@ -48,6 +48,7 @@ var (
 	workspaceDiskSize string
 	iamEmail          string
 	IssueModelsOrder  = []string{
+		"gemini-3.5-flash",
 		"gemini-3-flash-preview",
 		"gemini-3.1-pro-preview",
 		"gemini-2.5-pro",
@@ -2455,6 +2456,7 @@ func runRepoInit(ctx context.Context, nameFlag string, githubSecret string) erro
 						"provider":        "gemini-cli",
 					},
 					"models": []interface{}{
+						"gemini-3.5-flash",
 						"gemini-3-flash-preview",
 						"gemini-3.1-pro-preview",
 						"gemini-2.5-pro",

--- a/repo-agent/pkg/templates/data/agent-sandbox.yaml
+++ b/repo-agent/pkg/templates/data/agent-sandbox.yaml
@@ -38,6 +38,7 @@ spec:
     llm:
         apiKeySecretRef: gemini-vscode-tokens
     models:
+    - gemini-3.5-flash
     - gemini-3-flash-preview
     - gemini-3.1-pro-preview
     - gemini-2.5-pro

--- a/repo-agent/pkg/templates/data/ai-factory.yaml
+++ b/repo-agent/pkg/templates/data/ai-factory.yaml
@@ -41,6 +41,7 @@ spec:
     llm:
         apiKeySecretRef: gemini-vscode-tokens
     models:
+    - gemini-3.5-flash
     - gemini-3-flash-preview
     - gemini-3.1-pro-preview
     - gemini-2.5-pro

--- a/repo-agent/pkg/templates/data/default.yaml
+++ b/repo-agent/pkg/templates/data/default.yaml
@@ -36,6 +36,7 @@ spec:
     llm:
       apiKeySecretRef: gemini-vscode-tokens
     models:
+    - gemini-3.5-flash
     - gemini-3-flash-preview
     - gemini-3.1-pro-preview
     - gemini-2.5-pro

--- a/repo-agent/pkg/templates/data/gateway-api-reference-implementation.yaml
+++ b/repo-agent/pkg/templates/data/gateway-api-reference-implementation.yaml
@@ -39,6 +39,7 @@ spec:
     llm:
         apiKeySecretRef: gemini-vscode-tokens
     models:
+    - gemini-3.5-flash
     - gemini-3-flash-preview
     - gemini-3.1-pro-preview
     - gemini-2.5-pro

--- a/repo-agent/pkg/templates/data/kcc.yaml
+++ b/repo-agent/pkg/templates/data/kcc.yaml
@@ -293,6 +293,7 @@ spec:
     llm:
         apiKeySecretRef: gemini-vscode-tokens
     models:
+    - gemini-3.5-flash
     - gemini-3-flash-preview
     - gemini-3.1-pro-preview
     - gemini-2.5-pro

--- a/repo-agent/pkg/templates/data/kubernetes-dv.yaml
+++ b/repo-agent/pkg/templates/data/kubernetes-dv.yaml
@@ -234,6 +234,7 @@ spec:
     llm:
       apiKeySecretRef: gemini-vscode-tokens
     models:
+    - gemini-3.5-flash
     - gemini-3-flash-preview
     - gemini-3.1-pro-preview
     - gemini-2.5-pro

--- a/repo-agent/pkg/templates/data/kubernetes.yaml
+++ b/repo-agent/pkg/templates/data/kubernetes.yaml
@@ -755,6 +755,7 @@ spec:
     llm:
       apiKeySecretRef: gemini-vscode-tokens
     models:
+    - gemini-3.5-flash
     - gemini-3-flash-preview
     - gemini-3.1-pro-preview
     - gemini-2.5-pro

--- a/repo-agent/pkg/templates/data/repo-agent.yaml
+++ b/repo-agent/pkg/templates/data/repo-agent.yaml
@@ -39,6 +39,7 @@ spec:
     llm:
         apiKeySecretRef: gemini-vscode-tokens
     models:
+    - gemini-3.5-flash
     - gemini-3-flash-preview
     - gemini-3.1-pro-preview
     - gemini-2.5-pro

--- a/repo-agent/review-ui/ui/src/PrReviewCard.js
+++ b/repo-agent/review-ui/ui/src/PrReviewCard.js
@@ -751,6 +751,7 @@ function PrReviewCard({
   const lastDragTargetRef = useRef(null);
 
   const reviewModels = (availableModels && availableModels.length > 0) ? availableModels : [
+    'gemini-3.5-flash',
     'gemini-3.1-pro-preview',
     'gemini-3-flash-preview',
     'gemini-2.0-pro-exp-02-05',

--- a/repo-agent/scripts/ops/mutate_repowatches.py
+++ b/repo-agent/scripts/ops/mutate_repowatches.py
@@ -144,6 +144,7 @@ def inject_issue_model_list(repowatch):
     spec = repowatch.get("spec", {})
     if "issue" in spec and isinstance(spec["issue"], dict):
         target_models = [
+            "gemini-3.5-flash",
             "gemini-3-flash-preview",
             "gemini-3.1-pro-preview",
             "gemini-2.5-pro",


### PR DESCRIPTION
Everywhere we support falling back on quota, adding gemini-3.5-flash. It will now be the first mode we try.
We will then fall back to the existing model set we had on quota exhaustion.
There are a few places we just use 2.5.
I left those alone as I do not believe they support fallback. Also we clearly did not find it useful to use an upgraded model for these use cases.