### PR TITLE
feat(factory): introduce sandbox daemon

### DIFF
--- a/factory/images/factory-golang/Dockerfile
+++ b/factory/images/factory-golang/Dockerfile
@@ -16,6 +16,16 @@ RUN git clone --depth 1 --branch 2026.20 https://github.com/e2b-dev/infra.git /i
     # sed -i 's/var formattedVars \[\]string/formattedVars := os.Environ()/' internal/services/process/handler/handler.go && \
     CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -v -o /envd .
 
+# --------------------------------
+
+# Build factory binary
+FROM golang:1.26.2 AS build-factory
+WORKDIR /app/factory
+COPY factory/go.mod factory/go.sum ./
+RUN go mod download
+COPY factory/ ./
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -v -o /factory .
+
 
 
 # Main image
@@ -40,8 +50,9 @@ RUN code-server --install-extension golang.go --install-extension vscodevim.vim
 
 COPY --from=build-gh /bin/gh /bin/gh
 COPY --from=build-envd /envd /usr/local/bin/envd
+COPY --from=build-factory /factory /usr/local/bin/factory
 
 RUN ln -sf /usr/local/go/bin/go /usr/local/bin/go
 
 WORKDIR /workspaces
-ENTRYPOINT ["/usr/local/bin/envd"]
+ENTRYPOINT ["/usr/local/bin/factory", "daemon"]

--- a/factory/pkg/commands/cleanup.go
+++ b/factory/pkg/commands/cleanup.go
@@ -1,0 +1,172 @@
+package commands
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+func getEnvDuration(key string, defaultValue time.Duration) time.Duration {
+	if val := os.Getenv(key); val != "" {
+		if d, err := time.ParseDuration(val); err == nil {
+			return d
+		}
+	}
+	return defaultValue
+}
+
+func startPeriodicCleanup(ctx context.Context) {
+	log := klog.FromContext(ctx)
+	log.Info("Starting periodic cleanup task")
+
+	tmpInterval := getEnvDuration("CLEANUP_TMP_INTERVAL", 1*time.Hour)
+	goInterval := getEnvDuration("CLEANUP_GO_INTERVAL", 6*time.Hour)
+
+	// Ticker for tmp directory cleanup
+	tmpTicker := time.NewTicker(tmpInterval)
+	defer tmpTicker.Stop()
+
+	// Ticker for go cache cleanup
+	var goTickerChan <-chan time.Time
+	if goInterval > 0 {
+		goTicker := time.NewTicker(goInterval)
+		defer goTicker.Stop()
+		goTickerChan = goTicker.C
+	}
+
+	// Initial cleanup - only for TMP, not Go (to avoid wiping cache on every restart)
+	performTmpCleanup(ctx)
+
+	for {
+		select {
+		case <-tmpTicker.C:
+			performTmpCleanup(ctx)
+		case <-goTickerChan:
+			performGoCleanup(ctx)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func performTmpCleanup(ctx context.Context) {
+	log := klog.FromContext(ctx)
+	log.Info("Running periodic TMPDIR cleanup")
+
+	maxAge := getEnvDuration("CLEANUP_TMP_MAX_AGE", 24*time.Hour)
+
+	// 1. Clean up TMPDIR
+	tmpDir := os.Getenv("TMPDIR")
+	if tmpDir != "" {
+		cleanOldFiles(ctx, tmpDir, maxAge)
+	}
+
+	// 2. Clean up GOTMPDIR
+	goTmpDir := os.Getenv("GOTMPDIR")
+	if goTmpDir != "" {
+		// Normalize paths before comparison
+		cleanTmp := filepath.Clean(tmpDir)
+		cleanGoTmp := filepath.Clean(goTmpDir)
+		if cleanGoTmp != cleanTmp {
+			cleanOldFiles(ctx, goTmpDir, maxAge)
+		}
+	}
+}
+
+func performGoCleanup(ctx context.Context) {
+	// The reviewer noted that Go 1.15+ automatically manages its build cache.
+	// Unconditional 'go clean -cache' can break active builds.
+	// We only run this if explicitly enabled via environment variable.
+	if os.Getenv("CLEANUP_GO_CACHE_ENABLED") != "true" {
+		return
+	}
+
+	log := klog.FromContext(ctx)
+
+	// Check if 'go' command exists
+	if _, err := exec.LookPath("go"); err != nil {
+		return
+	}
+
+	log.Info("Running periodic Go cache cleanup")
+
+	// Clean up Go build cache (this includes test cache)
+	cmd := exec.CommandContext(ctx, "go", "clean", "-cache")
+	if err := cmd.Run(); err != nil {
+		log.Error(err, "failed to run go clean -cache")
+	}
+}
+
+func cleanOldFiles(ctx context.Context, dir string, maxAge time.Duration) {
+	log := klog.FromContext(ctx)
+
+	dir = filepath.Clean(dir)
+	// Safety check: don't clean root or very short paths
+	if dir == "/" || dir == "" || len(dir) < 2 {
+		log.Error(nil, "Refusing to clean directory (too dangerous or invalid)", "path", dir)
+		return
+	}
+
+	now := time.Now()
+
+	// We'll collect directories to try and remove them after their contents.
+	var dirs []string
+
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+
+		// Don't delete the root directory being cleaned
+		if path == dir {
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+
+		age := now.Sub(info.ModTime())
+
+		if d.IsDir() {
+			dirs = append(dirs, path)
+			return nil
+		}
+
+		// Don't delete very recent files
+		if age > maxAge {
+			log.Info("Removing old file", "path", path, "age", age)
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				log.Error(err, "failed to remove old file", "path", path)
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		log.Error(err, "error walking directory for cleanup", "path", dir)
+	}
+
+	// Remove empty directories in reverse order (bottom-up)
+	for i := len(dirs) - 1; i >= 0; i-- {
+		d := dirs[i]
+		info, err := os.Stat(d)
+		if err != nil {
+			continue
+		}
+		if now.Sub(info.ModTime()) > maxAge {
+			// os.Remove only succeeds if the directory is empty
+			if err := os.Remove(d); err == nil {
+				log.Info("Removed old empty directory", "path", d)
+			}
+		}
+	}
+}

--- a/factory/pkg/commands/daemon.go
+++ b/factory/pkg/commands/daemon.go
@@ -1,0 +1,69 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/sandbox"
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+)
+
+func NewDaemonCommand(ctx context.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "daemon",
+		Short: "Run the factory sandbox daemon to initialize workspace storage and start envd",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return fmt.Errorf("daemon command does not take any arguments")
+			}
+			return runDaemon(cmd.Context())
+		},
+	}
+	return cmd
+}
+
+func runDaemon(ctx context.Context) error {
+	log := klog.FromContext(ctx)
+
+	// Ensure cache and temporary directories exist on /workspaces
+	// This is important for Go builds to avoid ephemeral storage exhaustion.
+	dirs := []string{
+		sandbox.GoCachePath,
+		sandbox.GoModCachePath,
+		sandbox.TmpDirPath,
+		os.Getenv("GOCACHE"),
+		os.Getenv("GOMODCACHE"),
+		os.Getenv("TMPDIR"),
+		os.Getenv("GOTMPDIR"),
+	}
+	for _, dir := range dirs {
+		if dir == "" {
+			continue
+		}
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			log.Error(err, "failed to create directory", "path", dir)
+		} else {
+			log.Info("Initialized directory", "path", dir)
+		}
+	}
+
+	// Start periodic cleanup in background
+	go startPeriodicCleanup(ctx)
+
+	log.Info("Starting envd daemon...")
+
+	cmd := exec.CommandContext(ctx, "envd")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		log.Error(err, "envd daemon exited with error")
+		return fmt.Errorf("envd daemon exited: %w", err)
+	}
+
+	log.Info("envd daemon exited successfully")
+	return nil
+}

--- a/factory/pkg/commands/root.go
+++ b/factory/pkg/commands/root.go
@@ -96,5 +96,9 @@ coding tasks without local side effects or host dependencies.`,
 	sandboxCmd.GroupID = "management"
 	cmd.AddCommand(sandboxCmd)
 
+	daemonCmd := NewDaemonCommand(ctx)
+	daemonCmd.GroupID = "management"
+	cmd.AddCommand(daemonCmd)
+
 	return cmd
 }

--- a/factory/pkg/sandbox/manifests.go
+++ b/factory/pkg/sandbox/manifests.go
@@ -10,6 +10,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+const (
+	GoCachePath    = "/workspaces/.cache/go-build"
+	GoModCachePath = "/workspaces/.cache/mod"
+	TmpDirPath     = "/workspaces/.tmp"
+)
+
 // DevSandboxOptions holds common options for creating Sandboxes.
 type DevSandboxOptions struct {
 	Name              string
@@ -92,7 +98,12 @@ func NewAgentSandbox(opt AgentSandboxOptions) (*unstructured.Unstructured, *core
 		diskSize = "10Gi"
 	}
 
-	env := []interface{}{}
+	env := []interface{}{
+		map[string]interface{}{"name": "GOCACHE", "value": GoCachePath},
+		map[string]interface{}{"name": "GOMODCACHE", "value": GoModCachePath},
+		map[string]interface{}{"name": "TMPDIR", "value": TmpDirPath},
+		map[string]interface{}{"name": "GOTMPDIR", "value": TmpDirPath},
+	}
 
 	sandbox := &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -115,7 +126,7 @@ func NewAgentSandbox(opt AgentSandboxOptions) (*unstructured.Unstructured, *core
 							map[string]interface{}{
 								"name":    "sandbox",
 								"image":   opt.Image,
-								"command": []interface{}{"envd"},
+								"command": []interface{}{"factory", "daemon"},
 								"resources": map[string]interface{}{
 									"requests": map[string]interface{}{
 										"cpu":               resources.Requests.Cpu().String(),
@@ -217,7 +228,12 @@ func NewReviewSandbox(opt ReviewSandboxOptions) (*unstructured.Unstructured, *co
 		diskSize = "10Gi"
 	}
 
-	env := []interface{}{}
+	env := []interface{}{
+		map[string]interface{}{"name": "GOCACHE", "value": GoCachePath},
+		map[string]interface{}{"name": "GOMODCACHE", "value": GoModCachePath},
+		map[string]interface{}{"name": "TMPDIR", "value": TmpDirPath},
+		map[string]interface{}{"name": "GOTMPDIR", "value": TmpDirPath},
+	}
 
 	sandbox := &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -242,7 +258,7 @@ func NewReviewSandbox(opt ReviewSandboxOptions) (*unstructured.Unstructured, *co
 							map[string]interface{}{
 								"name":    "sandbox",
 								"image":   opt.Image,
-								"command": []interface{}{"envd"},
+								"command": []interface{}{"factory", "daemon"},
 								"resources": map[string]interface{}{
 									"limits": map[string]interface{}{
 										"ephemeral-storage": "6Gi",


### PR DESCRIPTION
for storage initialization and periodic cleanup

This introduces 'factory daemon' as the primary entrypoint for factory sandboxes, replacing direct 'envd' execution.

Key updates:
- Storage Initialization: Automatically creates GOCACHE, GOMODCACHE, and TMPDIR on the persistent volume claim mounted at /workspaces to prevent ephemeral root disk exhaustion.
- Periodic Cleanup: Runs background tasks to periodically prune old temporary files from TMPDIR/GOTMPDIR and manage Go build cache.
- Manifest & Dockerfile Integration: Updates factory-golang Dockerfile to compile the standalone factory binary and configures AgentSandbox/ReviewSandbox manifests to execute 'factory daemon'.