### PR TITLE
Install ripgrep in factory and repo-agent golang docker images

### DIFF
--- a/factory/images/factory-golang/Dockerfile
+++ b/factory/images/factory-golang/Dockerfile
@@ -35,7 +35,7 @@ ENV GOTOOLCHAIN=auto
 # We want a functional python, because gemini-cli likes to use python
 RUN apt-get update && apt-get install -y python3 python3-pip python3-yaml python-is-python3 python3-venv
 
-RUN apt-get update && apt-get install -y git tmux nodejs npm sudo curl apt-transport-https ca-certificates gnupg jq
+RUN apt-get update && apt-get install -y git tmux nodejs npm sudo curl apt-transport-https ca-certificates gnupg jq ripgrep
 
 # Install Google Cloud CLI
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \

--- a/repo-agent/images/dind-golang/Dockerfile
+++ b/repo-agent/images/dind-golang/Dockerfile
@@ -57,7 +57,8 @@ RUN apt-get update && \
     sudo \
     helm \
     build-essential \
-    google-cloud-cli
+    google-cloud-cli \
+    ripgrep
 
 # ------- Install go -------
 ENV GO_VERSION=1.26.1

--- a/repo-agent/images/generic-golang/Dockerfile
+++ b/repo-agent/images/generic-golang/Dockerfile
@@ -49,7 +49,7 @@ ENV GOTOOLCHAIN=auto
 # We want a functional python, because gemini-cli likes to use python
 RUN apt-get update && apt-get install -y python3 python3-pip python3-yaml python-is-python3 python3-venv
 
-RUN apt-get update && apt-get install -y git tmux nodejs npm sudo curl apt-transport-https ca-certificates gnupg jq
+RUN apt-get update && apt-get install -y git tmux nodejs npm sudo curl apt-transport-https ca-certificates gnupg jq ripgrep
 
 # Install Google Cloud CLI
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \


### PR DESCRIPTION
This PR installs the `ripgrep` package in the Dockerfiles for:
- `factory/images/factory-golang/Dockerfile`
- `repo-agent/images/generic-golang/Dockerfile`
- `repo-agent/images/dind-golang/Dockerfile`

This resolves the issue where `gemini-cli` or other agents running inside these golang development sandbox images would log:
`YOLO mode is enabled. All tool calls will be automatically approved. Ripgrep is not available. Falling back to GrepTool.`

Having `ripgrep` pre-installed provides faster, more efficient grep searches for the AI agents, avoiding the fallback warning.

---
This PR was generated by **Overseer** (powered by the gemini-3.5-flash model).
