### PR TITLE
feat(factory): implement label-based sandbox discovery and session continuity

### DIFF
--- a/factory/README.md
+++ b/factory/README.md
@@ -33,6 +33,7 @@ It spins up isolated development environments (`agents.x-k8s.io`), establishes d
 - **Zero Host Side-Effects**: No temporary file creation on your local machine. All scripts, prompts, and task logs are written directly to timestamped subdirectories inside the sandbox PVC (`/workspaces/tasks/fix-<timestamp>/`).
 - **Full Environment Injection**: The CLI dynamically resolves your GitHub credentials and Gemini API keys from Kubernetes Secrets and injects them directly into the `envd` execution environment via Connect-RPC `StartRequest`.
 - **Live Streaming & Logging**: Standard output and error are streamed live to your terminal while simultaneously being recorded into `execution.log` inside the sandbox.
+- **Label-Based Discovery & Session Continuity**: Sandboxes are dynamically aliased to Pull Requests via Kubernetes labels (`factory.gemini.google.com/pr`), allowing `pr watch`, `investigate`, and `address-comments` to reuse existing sandboxes (`fix-...`) and maintain full Gemini chat session history across PR workflows.
 
 ### Command Tree
 ```
@@ -140,7 +141,7 @@ Automatically spin up a sandbox, clone the repository, checkout a dedicated issu
 factory fix --url https://github.com/owner/repo/issues/1
 ```
 
-**Advanced Customization**: Override the default instruction, provide an instruction file, execute repository-level tasks without an issue, or push a branch without creating a PR:
+**Advanced Customization**: Override the default instruction, provide an instruction file, execute repository-level tasks without an issue, push a branch without creating a PR, or automatically transition to watching the created PR:
 ```bash
 factory fix \
   --url https://github.com/owner/repo/issues/1 \
@@ -164,8 +165,14 @@ factory fix \
 factory fix \
   --url https://github.com/owner/repo/issues/1 \
   --name refactor-auth \
-  --instruction "Refactor the auth package"
+  --instruction "Refactor the auth package" \
   --no-pr
+
+# Automatically alias the sandbox to the created PR and start watching it for CI failures or review feedback
+factory fix \
+  --url https://github.com/owner/repo/issues/1 \
+  --watch \
+  --poll-interval 1m
 ```
 
 ### Reviewing Pull Requests (`factory pr review`)
@@ -175,25 +182,25 @@ factory pr review --pr-url https://github.com/owner/repo/pull/1
 ```
 
 ### Investigating Check Failures (`factory pr investigate`)
-Spin up a review sandbox to analyze failed CI check logs, review previous investigation comments, and attempt to fix the failure or report root causes:
+Spin up a review sandbox to analyze failed CI check logs, review previous investigation comments, and attempt to fix the failure or report root causes. Use `--continue-session` to preserve LLM conversation history across multiple PR operations in the same sandbox:
 ```bash
-factory pr investigate --pr-url https://github.com/owner/repo/pull/1
+factory pr investigate --pr-url https://github.com/owner/repo/pull/1 --continue-session
 ```
 
 ### Addressing Review Comments (`factory pr address-comments`)
-Spin up a review sandbox to parse new review feedback and PR comments, execute code fixes, and push updated commits:
+Spin up a review sandbox to parse new review feedback and PR comments, execute code fixes, and push updated commits. Use `--continue-session` to maintain full Gemini chat context from previous fixes or investigations:
 ```bash
-factory pr address-comments --pr-url https://github.com/owner/repo/pull/1
+factory pr address-comments --pr-url https://github.com/owner/repo/pull/1 --continue-session
 ```
 
 ### Watching Pull Requests (`factory pr watch`)
-Continuously monitor a specific PR in the foreground, automatically triggering `investigate` on CI failures or `address-comments` on new review feedback:
+Continuously monitor a specific PR in the foreground, automatically triggering `investigate` on CI failures or `address-comments` on new review feedback. Use `--continue-session` to ensure all dispatched tasks inherit the ongoing chat session. The watch loop logs explicit sleep intervals and cleanly terminates when the PR is merged or closed:
 ```bash
-factory pr watch --pr-url https://github.com/owner/repo/pull/1 --poll-interval 1m
+factory pr watch --pr-url https://github.com/owner/repo/pull/1 --poll-interval 1m --continue-session
 ```
 
 ### Watching Repositories (`factory watch`)
-Continuously monitor a GitHub repository in the foreground for test failures or assigned issues, automatically dispatching `fix` or `investigate` tasks:
+Continuously monitor a GitHub repository in the foreground for test failures or assigned issues, automatically dispatching `fix` or `investigate` tasks. The watch loop logs explicit sleep intervals between repository polls:
 ```bash
 # Watch for assigned issues with specific labels
 factory watch --repo owner/repo --assignee "factory-bot" --labels "p0,urgent"

--- a/factory/pkg/commands/fix.go
+++ b/factory/pkg/commands/fix.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/url"
@@ -16,6 +17,7 @@ import (
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/tasks"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 )
 
 type FixFlags struct {
@@ -24,6 +26,8 @@ type FixFlags struct {
 	InstructionFile string
 	Name            string
 	NoPR            bool
+	Watch           bool
+	PollInterval    time.Duration
 }
 
 func NewFixCommand(ctx context.Context) *cobra.Command {
@@ -64,7 +68,7 @@ func NewFixCommand(ctx context.Context) *cobra.Command {
 
 			ctx, cancel := context.WithTimeout(ctx, rootFlags.Timeout)
 			defer cancel()
-			return runFix(ctx, flags.URL, prompt, flags.Name, flags.NoPR)
+			return runFix(ctx, flags.URL, prompt, flags.Name, flags.NoPR, flags.Watch, flags.PollInterval)
 		},
 	}
 
@@ -73,11 +77,13 @@ func NewFixCommand(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringVar(&flags.InstructionFile, "instruction-file", "", "Path to a file containing custom instruction for the fix task")
 	cmd.Flags().StringVar(&flags.Name, "name", "", "Short name for the sandbox (required when URL is a repository URL without an issue number)")
 	cmd.Flags().BoolVar(&flags.NoPR, "no-pr", false, "Commit changes and push branch remotely, but do not create a pull request")
+	cmd.Flags().BoolVar(&flags.Watch, "watch", false, "Watch the created pull request for check failures and new review comments")
+	cmd.Flags().DurationVar(&flags.PollInterval, "poll-interval", 2*time.Minute, "Polling interval for watching the PR")
 
 	return cmd
 }
 
-func runFix(ctx context.Context, targetURL, prompt, name string, noPR bool) error {
+func runFix(ctx context.Context, targetURL, prompt, name string, noPR, watch bool, pollInterval time.Duration) error {
 	if targetURL == "" {
 		return fmt.Errorf("--url is required to determine the repository")
 	}
@@ -242,5 +248,41 @@ func runFix(ctx context.Context, targetURL, prompt, name string, noPR bool) erro
 	}
 
 	fmt.Println("\nTask execution completed.")
+
+	var buf bytes.Buffer
+	if err := client.Exec(ctx, fmt.Sprintf("cat %s/agent-output.txt", taskDir), "/workspaces", nil, nil, &buf, os.Stderr); err != nil {
+		klog.Warningf("Could not read agent-output.txt: %v", err)
+	}
+
+	var prURL string
+	var prNum int
+	for _, line := range strings.Split(buf.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.Contains(line, "/pull/") {
+			prURL = line
+			parts := strings.Split(line, "/")
+			if len(parts) > 0 {
+				if n, err := strconv.Atoi(parts[len(parts)-1]); err == nil {
+					prNum = n
+					break
+				}
+			}
+		}
+	}
+
+	if prNum > 0 {
+		fmt.Printf("Aliasing sandbox %s to PR #%d...\n", sandboxName, prNum)
+		if err := factorysandbox.AliasSandboxToPR(ctx, kubeClient, rootFlags.Namespace, sandboxName, prNum); err != nil {
+			klog.Warningf("Failed to alias sandbox to PR #%d: %v", prNum, err)
+		}
+
+		if watch {
+			fmt.Printf("\nStarting PR watch for %s...\n", prURL)
+			return runPRWatch(ctx, prURL, pollInterval, false, true)
+		}
+	} else if watch {
+		fmt.Println("\nWarning: --watch was specified but could not determine PR URL from task output.")
+	}
+
 	return nil
 }

--- a/factory/pkg/commands/pr.go
+++ b/factory/pkg/commands/pr.go
@@ -31,8 +31,9 @@ func NewPRCommand(ctx context.Context) *cobra.Command {
 }
 
 type InvestigateFlags struct {
-	PRURL  string
-	Prompt string
+	PRURL           string
+	Prompt          string
+	ContinueSession bool
 }
 
 func NewInvestigateCommand(ctx context.Context) *cobra.Command {
@@ -49,17 +50,18 @@ func NewInvestigateCommand(ctx context.Context) *cobra.Command {
 			}
 			ctx, cancel := context.WithTimeout(ctx, rootFlags.Timeout)
 			defer cancel()
-			return runInvestigate(ctx, flags.PRURL, flags.Prompt)
+			return runInvestigate(ctx, flags.PRURL, flags.Prompt, flags.ContinueSession)
 		},
 	}
 
 	cmd.Flags().StringVar(&flags.PRURL, "pr-url", "", "GitHub PR URL (e.g. https://github.com/owner/repo/pull/123)")
 	cmd.Flags().StringVar(&flags.Prompt, "prompt", "Investigate check failures for this PR", "Custom prompt for the investigate task")
+	cmd.Flags().BoolVar(&flags.ContinueSession, "continue-session", false, "Continue the Gemini session from previous runs in the sandbox")
 
 	return cmd
 }
 
-func runInvestigate(ctx context.Context, prURL, prompt string) error {
+func runInvestigate(ctx context.Context, prURL, prompt string, continueSession bool) error {
 	fmt.Printf("Resolving PR URL: %s...\n", prURL)
 
 	u, err := url.Parse(prURL)
@@ -214,6 +216,7 @@ func runInvestigate(ctx context.Context, prURL, prompt string) error {
 		"FAILED_RUNS":                strings.Join(failedRunIDs, " "),
 		"FAILED_PROW_RUNS":           strings.Join(failedProwRuns, " "),
 		"MODELS":                     "gemini-3.5-flash gemini-3-flash-preview gemini-3.1-pro-preview gemini-2.5-pro",
+		"GEMINI_CONTINUE_SESSION":    strconv.FormatBool(continueSession),
 	}
 
 	fmt.Println("Running investigate task via envd...")
@@ -227,8 +230,9 @@ func runInvestigate(ctx context.Context, prURL, prompt string) error {
 }
 
 type AddressCommentsFlags struct {
-	PRURL  string
-	Prompt string
+	PRURL           string
+	Prompt          string
+	ContinueSession bool
 }
 
 func NewAddressCommentsCommand(ctx context.Context) *cobra.Command {
@@ -245,17 +249,18 @@ func NewAddressCommentsCommand(ctx context.Context) *cobra.Command {
 			}
 			ctx, cancel := context.WithTimeout(ctx, rootFlags.Timeout)
 			defer cancel()
-			return runAddressComments(ctx, flags.PRURL, flags.Prompt)
+			return runAddressComments(ctx, flags.PRURL, flags.Prompt, flags.ContinueSession)
 		},
 	}
 
 	cmd.Flags().StringVar(&flags.PRURL, "pr-url", "", "GitHub PR URL (e.g. https://github.com/owner/repo/pull/123)")
 	cmd.Flags().StringVar(&flags.Prompt, "prompt", "Address review feedback for this PR", "Custom prompt for the address-comments task")
+	cmd.Flags().BoolVar(&flags.ContinueSession, "continue-session", false, "Continue the Gemini session from previous runs in the sandbox")
 
 	return cmd
 }
 
-func runAddressComments(ctx context.Context, prURL, prompt string) error {
+func runAddressComments(ctx context.Context, prURL, prompt string, continueSession bool) error {
 	fmt.Printf("Resolving PR URL: %s...\n", prURL)
 
 	u, err := url.Parse(prURL)
@@ -430,6 +435,7 @@ func runAddressComments(ctx context.Context, prURL, prompt string) error {
 		"GITHUB_USER_NAME":           githubLogin,
 		"PR_NUMBER":                  strconv.Itoa(prNum),
 		"MODELS":                     "gemini-3.5-flash gemini-3-flash-preview gemini-3.1-pro-preview gemini-2.5-pro",
+		"GEMINI_CONTINUE_SESSION":    strconv.FormatBool(continueSession),
 	}
 
 	fmt.Println("Running address-comments task via envd...")
@@ -443,9 +449,10 @@ func runAddressComments(ctx context.Context, prURL, prompt string) error {
 }
 
 type PRWatchFlags struct {
-	PRURL        string
-	PollInterval time.Duration
-	DryRun       bool
+	PRURL           string
+	PollInterval    time.Duration
+	DryRun          bool
+	ContinueSession bool
 }
 
 func NewPRWatchCommand(ctx context.Context) *cobra.Command {
@@ -460,19 +467,20 @@ func NewPRWatchCommand(ctx context.Context) *cobra.Command {
 			if flags.PRURL == "" {
 				return fmt.Errorf("--pr-url is required")
 			}
-			return runPRWatch(ctx, flags.PRURL, flags.PollInterval, flags.DryRun)
+			return runPRWatch(ctx, flags.PRURL, flags.PollInterval, flags.DryRun, flags.ContinueSession)
 		},
 	}
 
 	cmd.Flags().StringVar(&flags.PRURL, "pr-url", "", "GitHub PR URL (e.g. https://github.com/owner/repo/pull/123)")
 	cmd.Flags().DurationVar(&flags.PollInterval, "poll-interval", 2*time.Minute, "Polling interval")
 	cmd.Flags().BoolVar(&flags.DryRun, "dryrun", false, "Print actions without creating sandboxes or executing tasks")
+	cmd.Flags().BoolVar(&flags.ContinueSession, "continue-session", false, "Continue the Gemini session from previous runs in the sandbox")
 
 	return cmd
 }
 
-func runPRWatch(ctx context.Context, prURL string, interval time.Duration, dryRun bool) error {
-	fmt.Printf("Starting PR watch for %s (poll interval: %s, dryRun: %v)...\n", prURL, interval, dryRun)
+func runPRWatch(ctx context.Context, prURL string, interval time.Duration, dryRun, continueSession bool) error {
+	fmt.Printf("Starting PR watch for %s (poll interval: %s, dryRun: %v, continueSession: %v)...\n", prURL, interval, dryRun, continueSession)
 
 	u, err := url.Parse(prURL)
 	if err != nil {
@@ -500,14 +508,21 @@ func runPRWatch(ctx context.Context, prURL string, interval time.Duration, dryRu
 	var lastInvestigatedTime time.Time
 	var lastCommentAddressedTime time.Time
 
-	checkPR := func() {
+	checkPR := func() bool {
 		pr, _, err := ghClient.PullRequests.Get(ctx, owner, repo, prNum)
 		if err != nil {
 			klog.Errorf("Failed to fetch PR #%d: %v", prNum, err)
-			return
+			return false
 		}
 
-		acted := false
+		if pr.GetMerged() {
+			fmt.Printf("\nPR #%d is merged. Stopping watch.\n", prNum)
+			return true
+		}
+		if pr.GetState() == "closed" {
+			fmt.Printf("\nPR #%d is closed. Stopping watch.\n", prNum)
+			return true
+		}
 
 		// Check 1: Check CI check runs and commit statuses
 		headSHA := pr.GetHead().GetSHA()
@@ -538,11 +553,10 @@ func runPRWatch(ctx context.Context, prURL string, interval time.Duration, dryRu
 				fmt.Printf("\nFound failing checks for PR #%d (SHA: %s). Triggering investigate...\n", prNum, headSHA[:7])
 				lastInvestigatedSHA = headSHA
 				lastInvestigatedTime = time.Now()
-				acted = true
 				if dryRun {
 					fmt.Printf("[DRYRUN] Would trigger investigate for PR #%d\n", prNum)
 				} else {
-					if err := runInvestigate(ctx, prURL, "Investigate check failures for this PR"); err != nil {
+					if err := runInvestigate(ctx, prURL, "Investigate check failures for this PR", continueSession); err != nil {
 						klog.Errorf("Investigate failed: %v", err)
 					}
 				}
@@ -576,11 +590,10 @@ func runPRWatch(ctx context.Context, prURL string, interval time.Duration, dryRu
 				if hasNewComments {
 					fmt.Printf("\nFound new review comments for PR #%d. Triggering address-comments...\n", prNum)
 					lastCommentAddressedTime = time.Now()
-					acted = true
 					if dryRun {
 						fmt.Printf("[DRYRUN] Would trigger address-comments for PR #%d\n", prNum)
 					} else {
-						if err := runAddressComments(ctx, prURL, "Address review feedback for this PR"); err != nil {
+						if err := runAddressComments(ctx, prURL, "Address review feedback for this PR", continueSession); err != nil {
 							klog.Errorf("Address-comments failed: %v", err)
 						}
 					}
@@ -588,20 +601,23 @@ func runPRWatch(ctx context.Context, prURL string, interval time.Duration, dryRu
 			}
 		}
 
-		if !acted {
-			fmt.Print(".")
-		}
+		return false
 	}
 
 	// Run first check immediately
-	checkPR()
+	if checkPR() {
+		return nil
+	}
 
 	for {
+		fmt.Printf("Sleeping for %s...\n", interval)
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			checkPR()
+			if checkPR() {
+				return nil
+			}
 		}
 	}
 }

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -72,8 +72,6 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 	processedPRs := make(map[int]prWatchState)
 
 	checkRepo := func() {
-		acted := false
-
 		assigneeFilter := assignee
 		if assigneeFilter == "" {
 			assigneeFilter = "none"
@@ -96,12 +94,11 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 				if lastProcessed, ok := processedIssues[num]; !ok || time.Since(lastProcessed) > 24*time.Hour {
 					fmt.Printf("\nFound assigned issue #%d (%s). Triggering fix...\n", num, issue.GetTitle())
 					processedIssues[num] = time.Now()
-					acted = true
 					issueURL := fmt.Sprintf("https://github.com/%s/%s/issues/%d", owner, repo, num)
 					if dryRun {
 						fmt.Printf("[DRYRUN] Would trigger fix for issue #%d: %s\n", num, issueURL)
 					} else {
-						if err := runFix(ctx, issueURL, "Fix this issue", "", false); err != nil {
+						if err := runFix(ctx, issueURL, "Fix this issue", "", false, false, 0); err != nil {
 							klog.Errorf("Fix for issue #%d failed: %v", num, err)
 						}
 					}
@@ -150,12 +147,11 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 							lastSHA:          headSHA,
 							lastInvestigated: time.Now(),
 						}
-						acted = true
 						prURL := fmt.Sprintf("https://github.com/%s/%s/pull/%d", owner, repo, num)
 						if dryRun {
 							fmt.Printf("[DRYRUN] Would trigger investigate for PR #%d: %s\n", num, prURL)
 						} else {
-							if err := runInvestigate(ctx, prURL, "Investigate check failures for this PR"); err != nil {
+							if err := runInvestigate(ctx, prURL, "Investigate check failures for this PR", false); err != nil {
 								klog.Errorf("Investigate for PR #%d failed: %v", num, err)
 							}
 						}
@@ -163,16 +159,13 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 				}
 			}
 		}
-
-		if !acted {
-			fmt.Print(".")
-		}
 	}
 
 	// Run first check immediately
 	checkRepo()
 
 	for {
+		fmt.Printf("Sleeping for %s...\n", interval)
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/factory/pkg/sandbox/manifests.go
+++ b/factory/pkg/sandbox/manifests.go
@@ -211,6 +211,7 @@ func NewReviewSandbox(opt ReviewSandboxOptions) (*unstructured.Unstructured, *co
 	}
 	labels["sandbox"] = sandboxName
 	labels["sandbox-type"] = "review"
+	labels["factory.gemini.google.com/pr"] = fmt.Sprintf("%d", opt.PRNumber)
 
 	annotations := make(map[string]interface{})
 	for k, v := range opt.Annotations {

--- a/factory/pkg/sandbox/sandbox.go
+++ b/factory/pkg/sandbox/sandbox.go
@@ -58,10 +58,45 @@ func EnsureFixSandbox(ctx context.Context, kubeClient *clients.KubernetesClient,
 	return name, nil
 }
 
+func AliasSandboxToPR(ctx context.Context, kubeClient *clients.KubernetesClient, namespace, sandboxName string, prNum int) error {
+	unstructObj, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Get(ctx, sandboxName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("getting sandbox %s: %w", sandboxName, err)
+	}
+
+	labels := unstructObj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels["factory.gemini.google.com/pr"] = fmt.Sprintf("%d", prNum)
+	unstructObj.SetLabels(labels)
+
+	annotations := unstructObj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations["pr"] = fmt.Sprintf("%d", prNum)
+	unstructObj.SetAnnotations(annotations)
+
+	_, err = kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Update(ctx, unstructObj, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("updating sandbox %s with PR alias: %w", sandboxName, err)
+	}
+	return nil
+}
+
 func EnsureReviewSandbox(ctx context.Context, kubeClient *clients.KubernetesClient, namespace string, prNum int, prTitle, prHTMLURL, prDiffURL, prCloneURL, image, diskSize string) (string, error) {
+	listOpts := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("factory.gemini.google.com/pr=%d", prNum),
+	}
+	sbs, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).List(ctx, listOpts)
+	if err == nil && len(sbs.Items) > 0 {
+		return sbs.Items[0].GetName(), nil
+	}
+
 	name := fmt.Sprintf("factory-pr-%d", prNum)
 
-	_, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	_, err = kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err == nil {
 		return name, nil
 	}

--- a/factory/pkg/tasks/address_feedback.sh
+++ b/factory/pkg/tasks/address_feedback.sh
@@ -140,7 +140,11 @@ function runGemini {
     SUCCESS=false
     for MODEL in $MODELS_LIST; do
         echo "Trying model: $MODEL"
-        if (cd "/workspaces/${REPO_NAME}" && export GEMINI_API_KEY="${GEMINI_API_KEY}" && gemini --yolo --model "$MODEL" --output-format json < ${PROMPT_FILE} > "$(dirname "${PROMPT_FILE}")/gemini-output.json"); then
+        GEMINI_ARGS=("--yolo" "--model" "$MODEL" "--output-format" "json")
+        if [ "$GEMINI_CONTINUE_SESSION" = "true" ]; then
+            GEMINI_ARGS+=("--resume" "latest")
+        fi
+        if (cd "/workspaces/${REPO_NAME}" && export GEMINI_API_KEY="${GEMINI_API_KEY}" && gemini "${GEMINI_ARGS[@]}" < ${PROMPT_FILE} > "$(dirname "${PROMPT_FILE}")/gemini-output.json"); then
              echo "Gemini execution successful with model: $MODEL"
              SUCCESS=true
              break

--- a/factory/pkg/tasks/investigate_failures.sh
+++ b/factory/pkg/tasks/investigate_failures.sh
@@ -164,7 +164,11 @@ function runGemini {
     SUCCESS=false
     for MODEL in $MODELS_LIST; do
         echo "Trying model: $MODEL"
-        if (cd "/workspaces/${REPO_NAME}" && export GEMINI_API_KEY="${GEMINI_API_KEY}" && gemini --yolo --model "$MODEL" --output-format json < ${PROMPT_FILE} > "$(dirname "${PROMPT_FILE}")/gemini-output.json"); then
+        GEMINI_ARGS=("--yolo" "--model" "$MODEL" "--output-format" "json")
+        if [ "$GEMINI_CONTINUE_SESSION" = "true" ]; then
+            GEMINI_ARGS+=("--resume" "latest")
+        fi
+        if (cd "/workspaces/${REPO_NAME}" && export GEMINI_API_KEY="${GEMINI_API_KEY}" && gemini "${GEMINI_ARGS[@]}" < ${PROMPT_FILE} > "$(dirname "${PROMPT_FILE}")/gemini-output.json"); then
              echo "Gemini execution successful with model: $MODEL"
              SUCCESS=true
              break


### PR DESCRIPTION
This introduces a generic architecture for transitioning sandboxes and preserving LLM session context across PR workflows:

- Decouple sandbox discovery from hardcoded names by implementing AliasSandboxToPR and updating EnsureReviewSandbox to discover existing sandboxes via factory.gemini.google.com/pr K8s labels.
- Add --watch and --poll-interval flags to factory fix to automatically alias the sandbox and watch the created PR.
- Add --continue-session flag to pr watch, pr investigate, and pr address-comments to propagate GEMINI_CONTINUE_SESSION=true to the sandbox.
- Update agent execution scripts (investigate_failures.sh and address_feedback.sh) to check GEMINI_CONTINUE_SESSION and append --resume latest to the Gemini CLI invocation.
- Improve watch loops in pr watch and watch to cleanly terminate when PRs are merged/closed and log sleep intervals.