### PR TITLE
fix(factory): align background log filenames

### DIFF
--- a/factory/pkg/commands/agent.go
+++ b/factory/pkg/commands/agent.go
@@ -74,11 +74,16 @@ func NewAgentCreateCommand(ctx context.Context) *cobra.Command {
 			sessionName := "factory-agent"
 			u, err := url.Parse(flags.URL)
 			if err == nil {
-				parts := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
-				if len(parts) >= 4 && parts[2] == "pull" {
-					sessionName = fmt.Sprintf("factory-agent-pr-%s", parts[3])
-				} else {
-					sessionName = fmt.Sprintf("factory-agent-%s", slugify(flags.Agent))
+				path := strings.TrimSuffix(strings.TrimPrefix(u.Path, "/"), ".git")
+				parts := strings.Split(path, "/")
+				if len(parts) >= 2 {
+					repo := parts[1]
+					agentName := slugify(flags.Agent)
+					taskID := agentName
+					if len(parts) >= 4 && parts[2] == "pull" {
+						taskID = fmt.Sprintf("pr-%s-%s", parts[3], agentName)
+					}
+					sessionName = fmt.Sprintf("agent-%s-%s-agent", repo, taskID)
 				}
 			}
 

--- a/factory/pkg/commands/fix.go
+++ b/factory/pkg/commands/fix.go
@@ -77,10 +77,15 @@ func NewFixCommand(ctx context.Context) *cobra.Command {
 			u, err := url.Parse(flags.URL)
 			if err == nil {
 				parts := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
-				if len(parts) >= 4 && parts[2] == "issues" {
-					sessionName = fmt.Sprintf("factory-fix-%s", parts[3])
-				} else if flags.Name != "" {
-					sessionName = fmt.Sprintf("factory-fix-%s", flags.Name)
+				if len(parts) >= 2 {
+					repo := parts[1]
+					taskID := "task"
+					if len(parts) >= 4 && parts[2] == "issues" {
+						taskID = parts[3]
+					} else if flags.Name != "" {
+						taskID = flags.Name
+					}
+					sessionName = fmt.Sprintf("fix-%s-%s-fix", repo, taskID)
 				}
 			}
 

--- a/factory/pkg/commands/pr.go
+++ b/factory/pkg/commands/pr.go
@@ -57,12 +57,12 @@ func NewInvestigateCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("--pr-url is required")
 			}
 
-			sessionName := "factory-investigate"
+			sessionName := "factory-pr-unknown-investigate"
 			u, err := url.Parse(flags.PRURL)
 			if err == nil {
 				parts := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
 				if len(parts) >= 4 && parts[2] == "pull" {
-					sessionName = fmt.Sprintf("factory-investigate-%s", parts[3])
+					sessionName = fmt.Sprintf("factory-pr-%s-investigate", parts[3])
 				}
 			}
 
@@ -284,12 +284,12 @@ func NewAddressCommentsCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("--pr-url is required")
 			}
 
-			sessionName := "factory-address-comments"
+			sessionName := "factory-pr-unknown-address-comments"
 			u, err := url.Parse(flags.PRURL)
 			if err == nil {
 				parts := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
 				if len(parts) >= 4 && parts[2] == "pull" {
-					sessionName = fmt.Sprintf("factory-address-%s", parts[3])
+					sessionName = fmt.Sprintf("factory-pr-%s-address-comments", parts[3])
 				}
 			}
 
@@ -771,12 +771,12 @@ func NewIterateCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("--pr-url is required")
 			}
 
-			sessionName := "factory-iterate"
+			sessionName := "factory-pr-unknown-iterate"
 			u, err := url.Parse(flags.PRURL)
 			if err == nil {
 				parts := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
 				if len(parts) >= 4 && parts[2] == "pull" {
-					sessionName = fmt.Sprintf("factory-iterate-%s", parts[3])
+					sessionName = fmt.Sprintf("factory-pr-%s-iterate", parts[3])
 				}
 			}
 

--- a/factory/pkg/commands/review.go
+++ b/factory/pkg/commands/review.go
@@ -57,12 +57,12 @@ func NewReviewCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("invalid value for --publish: %s. Must be one of [no, yes, ask, draft]", flags.Publish)
 			}
 
-			sessionName := "factory-review"
+			sessionName := "factory-pr-unknown-review"
 			u, err := url.Parse(flags.PRURL)
 			if err == nil {
 				parts := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
 				if len(parts) >= 4 && parts[2] == "pull" {
-					sessionName = fmt.Sprintf("factory-review-%s", parts[3])
+					sessionName = fmt.Sprintf("factory-pr-%s-review", parts[3])
 				}
 			}
 

--- a/factory/pkg/commands/root.go
+++ b/factory/pkg/commands/root.go
@@ -201,7 +201,8 @@ func checkAndRunInBackground(sessionName string) (bool, error) {
 		return false, fmt.Errorf("failed to create logs directory: %w", err)
 	}
 
-	logFile := filepath.Join(logDir, fmt.Sprintf("%s.log", sessionName))
+	timestamp := time.Now().Format("20060102-150405")
+	logFile := filepath.Join(logDir, fmt.Sprintf("%s-%s.log", sessionName, timestamp))
 	f, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
 		return false, fmt.Errorf("failed to open log file: %w", err)


### PR DESCRIPTION
 with sandbox names and append timestamps

This prevents log overwrite on concurrent tasks on the same sandbox.