### PR TITLE
feat(factory/watch): improve factory watch

### DIFF
--- a/factory/README.md
+++ b/factory/README.md
@@ -242,16 +242,23 @@ factory agent create \
 ```
 
 ### Watching Repositories (`factory watch`)
-Continuously monitor a GitHub repository in the foreground for test failures or assigned issues, automatically dispatching `fix` or `investigate` tasks. The watch loop logs explicit sleep intervals between repository polls:
-```bash
-# Watch for assigned issues with specific labels
-factory watch --repo owner/repo --assignee "factory-bot" --labels "p0,urgent"
+Continuously monitor a GitHub repository in the foreground for test failures, assigned issues, or open pull requests, automatically dispatching `fix`, `investigate`, or `address-comments` tasks.
 
-# Watch for unassigned issues with specific labels
+**Key Features**:
+- **Assignee & Label Filtering**: By default, it monitors issues and PRs assigned to the onboarded user (resolved from the `factory-user` secret) OR labelled `overseer`. You can override the assignee with `--assignee` (e.g. `--assignee ""` to watch for unassigned issues/PRs).
+- **PR Check Failure & Comment Watching**: For watched PRs, it automatically dispatches `investigate` on CI test failures and `address-comments` on new review comments since the last commit.
+- **Smart Issue Link Detection**: To prevent redundant work, it will automatically skip triggering a fix task for an issue if it finds an open PR referencing that issue (checked via branch names, PR titles, PR bodies, or the GitHub Timeline API).
+- **Dry-run Execution**: Fully respects the `--dryrun` flag, printing actions without creating sandboxes or starting tasks.
+
+```bash
+# Watch for issues/PRs assigned to the onboarded user (from secret) or labelled "overseer"
+factory watch --repo owner/repo
+
+# Watch for unassigned issues/PRs with specific labels
 factory watch --repo owner/repo --assignee "" --labels "bug,help wanted"
 
-# Simulate actions without creating sandboxes or executing tasks
-factory watch --repo owner/repo --assignee "factory-bot" --dryrun
+# Simulate watch loop actions without executing any tasks or creating sandboxes
+factory watch --repo owner/repo --dryrun
 ```
 
 ---

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -106,130 +106,108 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 	processedPRs := make(map[int]prWatchState)
 
 	checkRepo := func() {
-		// 1. Fetch Pull Requests first to check for referenced issues, and to filter watched PRs
+		// 1. Fetch first 100 open Pull Requests to check for referenced issues
 		prOpts := &githubv39.PullRequestListOptions{
 			State:       "open",
 			ListOptions: githubv39.ListOptions{PerPage: 100},
 		}
 		prs, _, err := ghClient.PullRequests.List(ctx, owner, repo, prOpts)
-		if err != nil {
-			klog.Errorf("Failed to list PRs: %v", err)
-			return
+		referencedIssues := make(map[int]bool)
+		if err == nil {
+			for _, pr := range prs {
+				for num := range getReferencedIssues(pr) {
+					referencedIssues[num] = true
+				}
+			}
+		} else {
+			klog.Errorf("Failed to list open PRs for referenced issue detection: %v", err)
 		}
 
-		// Extract all referenced issues from open PRs
-		referencedIssues := make(map[int]bool)
-		for _, pr := range prs {
-			for num := range getReferencedIssues(pr) {
-				referencedIssues[num] = true
+		// 2. Fetch Issues/PRs matching assignee or labelled "overseer" (using Issues API to fetch both)
+		var allItems []*githubv39.Issue
+		if targetAssignee != "" {
+			opts1 := &githubv39.IssueListByRepoOptions{
+				Assignee:    targetAssignee,
+				State:       "open",
+				ListOptions: githubv39.ListOptions{PerPage: 100},
+			}
+			issues1, _, err := ghClient.Issues.ListByRepo(ctx, owner, repo, opts1)
+			if err != nil {
+				klog.Errorf("Failed to list issues for assignee %s: %v", targetAssignee, err)
+			} else {
+				allItems = append(allItems, issues1...)
 			}
 		}
 
-		// 2. Fetch and process Issues
-		issueOpts := &githubv39.IssueListByRepoOptions{
+		opts2 := &githubv39.IssueListByRepoOptions{
+			Labels:      []string{"overseer"},
 			State:       "open",
 			ListOptions: githubv39.ListOptions{PerPage: 100},
 		}
-		issues, _, err := ghClient.Issues.ListByRepo(ctx, owner, repo, issueOpts)
+		issues2, _, err := ghClient.Issues.ListByRepo(ctx, owner, repo, opts2)
 		if err != nil {
-			klog.Errorf("Failed to list issues: %v", err)
+			klog.Errorf("Failed to list issues for label overseer: %v", err)
 		} else {
-			for _, issue := range issues {
-				if issue.PullRequestLinks != nil {
+			allItems = append(allItems, issues2...)
+		}
+
+		// Deduplicate and group into issues and PRs
+		uniqueIssues := make(map[int]*githubv39.Issue)
+		for _, item := range allItems {
+			uniqueIssues[item.GetNumber()] = item
+		}
+
+		var issues []*githubv39.Issue
+		var prIssues []*githubv39.Issue
+		for _, item := range uniqueIssues {
+			if item.PullRequestLinks != nil {
+				prIssues = append(prIssues, item)
+			} else {
+				issues = append(issues, item)
+			}
+		}
+
+		// 3. Process Issues
+		for _, issue := range issues {
+			num := issue.GetNumber()
+			if referencedIssues[num] {
+				klog.Infof("Skipping issue #%d because there is already a PR referencing it.", num)
+				continue
+			}
+			if lastProcessed, ok := processedIssues[num]; !ok || time.Since(lastProcessed) > 24*time.Hour {
+				linked, err := hasLinkedPR(ctx, ghClient, owner, repo, num)
+				if err != nil {
+					klog.Errorf("Failed to check linked PR for issue #%d: %v", num, err)
+				} else if linked {
+					klog.Infof("Skipping issue #%d because it has a linked PR according to the Timeline API.", num)
 					continue
 				}
 
-				// Filter issue: must be assigned to targetAssignee OR labelled "overseer"
-				isAssigned := false
-				if targetAssignee != "" {
-					if issue.GetAssignee().GetLogin() == targetAssignee {
-						isAssigned = true
-					}
-					for _, assignee := range issue.Assignees {
-						if assignee.GetLogin() == targetAssignee {
-							isAssigned = true
-							break
-						}
-					}
+				issueURL := fmt.Sprintf("https://github.com/%s/%s/issues/%d", owner, repo, num)
+				if dryRun {
+					fmt.Printf("[DRYRUN] Would trigger fix for issue #%d (%s): %s\n", num, issue.GetTitle(), issueURL)
 				} else {
-					if len(issue.Assignees) == 0 && issue.GetAssignee().GetLogin() == "" {
-						isAssigned = true
-					}
-				}
-
-				hasOverseerLabel := false
-				for _, lbl := range issue.Labels {
-					if strings.ToLower(lbl.GetName()) == "overseer" {
-						hasOverseerLabel = true
-						break
-					}
-				}
-
-				if !isAssigned && !hasOverseerLabel {
-					continue
-				}
-				num := issue.GetNumber()
-				if referencedIssues[num] {
-					klog.Infof("Skipping issue #%d because there is already a PR referencing it.", num)
-					continue
-				}
-				if lastProcessed, ok := processedIssues[num]; !ok || time.Since(lastProcessed) > 24*time.Hour {
-					linked, err := hasLinkedPR(ctx, ghClient, owner, repo, num)
-					if err != nil {
-						klog.Errorf("Failed to check linked PR for issue #%d: %v", num, err)
-					} else if linked {
-						klog.Infof("Skipping issue #%d because it has a linked PR according to the Timeline API.", num)
-						continue
-					}
-
-					issueURL := fmt.Sprintf("https://github.com/%s/%s/issues/%d", owner, repo, num)
-					if dryRun {
-						fmt.Printf("[DRYRUN] Would trigger fix for issue #%d (%s): %s\n", num, issue.GetTitle(), issueURL)
-					} else {
-						fmt.Printf("\nFound assigned issue #%d (%s). Triggering fix...\n", num, issue.GetTitle())
-						processedIssues[num] = time.Now()
-						if err := runFix(ctx, issueURL, "Fix this issue", "", false, false, 0, watchTimeout, ephemeralStorage, secrets); err != nil {
-							klog.Errorf("Fix for issue #%d failed: %v", num, err)
-						}
+					fmt.Printf("\nFound assigned issue #%d (%s). Triggering fix...\n", num, issue.GetTitle())
+					processedIssues[num] = time.Now()
+					if err := runFix(ctx, issueURL, "Fix this issue", "", false, false, 0, watchTimeout, ephemeralStorage, secrets); err != nil {
+						klog.Errorf("Fix for issue #%d failed: %v", num, err)
 					}
 				}
 			}
 		}
 
-		// 3. Process Pull Requests
-		for _, pr := range prs {
-			num := pr.GetNumber()
-			headSHA := pr.GetHead().GetSHA()
+		// 4. Process Pull Requests
+		for _, prIssue := range prIssues {
+			num := prIssue.GetNumber()
 
-			// Filter PR: must be assigned to targetAssignee OR labelled "overseer"
-			isAssigned := false
-			if targetAssignee != "" {
-				if pr.GetAssignee().GetLogin() == targetAssignee {
-					isAssigned = true
-				}
-				for _, assignee := range pr.Assignees {
-					if assignee.GetLogin() == targetAssignee {
-						isAssigned = true
-						break
-					}
-				}
-			} else {
-				if len(pr.Assignees) == 0 && pr.GetAssignee().GetLogin() == "" {
-					isAssigned = true
-				}
-			}
-
-			hasOverseerLabel := false
-			for _, lbl := range pr.Labels {
-				if strings.ToLower(lbl.GetName()) == "overseer" {
-					hasOverseerLabel = true
-					break
-				}
-			}
-
-			if !isAssigned && !hasOverseerLabel {
+			// Fetch full Pull Request to get HEAD SHA and other details
+			pr, _, err := ghClient.PullRequests.Get(ctx, owner, repo, num)
+			if err != nil {
+				klog.Errorf("Failed to fetch full PR #%d: %v", num, err)
 				continue
 			}
+
+			headSHA := pr.GetHead().GetSHA()
 
 			// Check 3.1: Check CI check runs and commit statuses for failures
 			hasFailure := false

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -3,13 +3,17 @@ package commands
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/clients"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/github"
 	factorysandbox "github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/sandbox"
 	githubv39 "github.com/google/go-github/v39/github"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 )
 
@@ -46,7 +50,7 @@ func NewWatchCommand(ctx context.Context) *cobra.Command {
 			if len(parts) != 2 {
 				return fmt.Errorf("invalid repo format, expected owner/repo, got %s", flags.Repo)
 			}
-			return runWatch(ctx, parts[0], parts[1], flags.PollInterval, flags.Assignee, flags.Labels, flags.DryRun, flags.WatchTimeout, rootFlags.EphemeralStorage, rootFlags.ResolvedSecrets)
+			return runWatch(ctx, parts[0], parts[1], flags.PollInterval, flags.Assignee, cmd.Flags().Changed("assignee"), flags.Labels, flags.DryRun, flags.WatchTimeout, rootFlags.EphemeralStorage, rootFlags.ResolvedSecrets)
 		},
 	}
 
@@ -60,13 +64,29 @@ func NewWatchCommand(ctx context.Context) *cobra.Command {
 	return cmd
 }
 
-func runWatch(ctx context.Context, owner, repo string, interval time.Duration, assignee string, labels []string, dryRun bool, watchTimeout time.Duration, ephemeralStorage string, secrets []factorysandbox.SecretMount) error {
-	fmt.Printf("Starting watch for repository %s/%s (poll interval: %s, assignee: '%s', labels: %v, dryRun: %v, watchTimeout: %s)...\n", owner, repo, interval, assignee, labels, dryRun, watchTimeout)
-
+func runWatch(ctx context.Context, owner, repo string, interval time.Duration, assignee string, assigneeChanged bool, labels []string, dryRun bool, watchTimeout time.Duration, ephemeralStorage string, secrets []factorysandbox.SecretMount) error {
 	ghClient, err := github.NewClient(ctx)
 	if err != nil {
 		return fmt.Errorf("creating github client: %w", err)
 	}
+
+	kubeClient, err := clients.NewKubernetesClient()
+	if err != nil {
+		return fmt.Errorf("creating k8s client: %w", err)
+	}
+
+	secret, err := kubeClient.Clientset.CoreV1().Secrets(rootFlags.Namespace).Get(ctx, rootFlags.SecretName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("fetching %s secret in namespace %s: %w (make sure to run 'factory user onboard' first)", rootFlags.SecretName, rootFlags.Namespace, err)
+	}
+	githubLogin := string(secret.Data[KeyGithubLogin])
+
+	targetAssignee := assignee
+	if !assigneeChanged {
+		targetAssignee = githubLogin
+	}
+
+	fmt.Printf("Starting watch for repository %s/%s (poll interval: %s, assignee: '%s', labels: %v, dryRun: %v, watchTimeout: %s)...\n", owner, repo, interval, targetAssignee, labels, dryRun, watchTimeout)
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -77,25 +97,40 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 	}
 
 	type prWatchState struct {
-		lastSHA          string
-		lastInvestigated time.Time
+		lastSHA                  string
+		lastInvestigatedTime     time.Time
+		lastCommentAddressedTime time.Time
 	}
 
 	processedIssues := make(map[int]time.Time)
 	processedPRs := make(map[int]prWatchState)
 
 	checkRepo := func() {
-		assigneeFilter := assignee
-		if assigneeFilter == "" {
-			assigneeFilter = "none"
-		}
-		opts := &githubv39.IssueListByRepoOptions{
-			Assignee:    assigneeFilter,
+		// 1. Fetch Pull Requests first to check for referenced issues, and to filter watched PRs
+		prOpts := &githubv39.PullRequestListOptions{
 			State:       "open",
-			Labels:      labels,
-			ListOptions: githubv39.ListOptions{PerPage: 50},
+			ListOptions: githubv39.ListOptions{PerPage: 100},
 		}
-		issues, _, err := ghClient.Issues.ListByRepo(ctx, owner, repo, opts)
+		prs, _, err := ghClient.PullRequests.List(ctx, owner, repo, prOpts)
+		if err != nil {
+			klog.Errorf("Failed to list PRs: %v", err)
+			return
+		}
+
+		// Extract all referenced issues from open PRs
+		referencedIssues := make(map[int]bool)
+		for _, pr := range prs {
+			for num := range getReferencedIssues(pr) {
+				referencedIssues[num] = true
+			}
+		}
+
+		// 2. Fetch and process Issues
+		issueOpts := &githubv39.IssueListByRepoOptions{
+			State:       "open",
+			ListOptions: githubv39.ListOptions{PerPage: 100},
+		}
+		issues, _, err := ghClient.Issues.ListByRepo(ctx, owner, repo, issueOpts)
 		if err != nil {
 			klog.Errorf("Failed to list issues: %v", err)
 		} else {
@@ -103,14 +138,56 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 				if issue.PullRequestLinks != nil {
 					continue
 				}
+
+				// Filter issue: must be assigned to targetAssignee OR labelled "overseer"
+				isAssigned := false
+				if targetAssignee != "" {
+					if issue.GetAssignee().GetLogin() == targetAssignee {
+						isAssigned = true
+					}
+					for _, assignee := range issue.Assignees {
+						if assignee.GetLogin() == targetAssignee {
+							isAssigned = true
+							break
+						}
+					}
+				} else {
+					if len(issue.Assignees) == 0 && issue.GetAssignee().GetLogin() == "" {
+						isAssigned = true
+					}
+				}
+
+				hasOverseerLabel := false
+				for _, lbl := range issue.Labels {
+					if strings.ToLower(lbl.GetName()) == "overseer" {
+						hasOverseerLabel = true
+						break
+					}
+				}
+
+				if !isAssigned && !hasOverseerLabel {
+					continue
+				}
 				num := issue.GetNumber()
+				if referencedIssues[num] {
+					klog.Infof("Skipping issue #%d because there is already a PR referencing it.", num)
+					continue
+				}
 				if lastProcessed, ok := processedIssues[num]; !ok || time.Since(lastProcessed) > 24*time.Hour {
-					fmt.Printf("\nFound assigned issue #%d (%s). Triggering fix...\n", num, issue.GetTitle())
-					processedIssues[num] = time.Now()
+					linked, err := hasLinkedPR(ctx, ghClient, owner, repo, num)
+					if err != nil {
+						klog.Errorf("Failed to check linked PR for issue #%d: %v", num, err)
+					} else if linked {
+						klog.Infof("Skipping issue #%d because it has a linked PR according to the Timeline API.", num)
+						continue
+					}
+
 					issueURL := fmt.Sprintf("https://github.com/%s/%s/issues/%d", owner, repo, num)
 					if dryRun {
-						fmt.Printf("[DRYRUN] Would trigger fix for issue #%d: %s\n", num, issueURL)
+						fmt.Printf("[DRYRUN] Would trigger fix for issue #%d (%s): %s\n", num, issue.GetTitle(), issueURL)
 					} else {
+						fmt.Printf("\nFound assigned issue #%d (%s). Triggering fix...\n", num, issue.GetTitle())
+						processedIssues[num] = time.Now()
 						if err := runFix(ctx, issueURL, "Fix this issue", "", false, false, 0, watchTimeout, ephemeralStorage, secrets); err != nil {
 							klog.Errorf("Fix for issue #%d failed: %v", num, err)
 						}
@@ -119,53 +196,116 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 			}
 		}
 
-		prOpts := &githubv39.PullRequestListOptions{
-			State:       "open",
-			ListOptions: githubv39.ListOptions{PerPage: 50},
-		}
-		prs, _, err := ghClient.PullRequests.List(ctx, owner, repo, prOpts)
-		if err != nil {
-			klog.Errorf("Failed to list PRs: %v", err)
-		} else {
-			for _, pr := range prs {
-				num := pr.GetNumber()
-				headSHA := pr.GetHead().GetSHA()
+		// 3. Process Pull Requests
+		for _, pr := range prs {
+			num := pr.GetNumber()
+			headSHA := pr.GetHead().GetSHA()
 
-				hasFailure := false
-				checkRuns, err := listAllCheckRuns(ctx, ghClient, owner, repo, headSHA)
-				if err == nil {
-					for _, run := range checkRuns {
-						if run.GetConclusion() == "failure" {
-							hasFailure = true
-							break
+			// Filter PR: must be assigned to targetAssignee OR labelled "overseer"
+			isAssigned := false
+			if targetAssignee != "" {
+				if pr.GetAssignee().GetLogin() == targetAssignee {
+					isAssigned = true
+				}
+				for _, assignee := range pr.Assignees {
+					if assignee.GetLogin() == targetAssignee {
+						isAssigned = true
+						break
+					}
+				}
+			} else {
+				if len(pr.Assignees) == 0 && pr.GetAssignee().GetLogin() == "" {
+					isAssigned = true
+				}
+			}
+
+			hasOverseerLabel := false
+			for _, lbl := range pr.Labels {
+				if strings.ToLower(lbl.GetName()) == "overseer" {
+					hasOverseerLabel = true
+					break
+				}
+			}
+
+			if !isAssigned && !hasOverseerLabel {
+				continue
+			}
+
+			// Check 3.1: Check CI check runs and commit statuses for failures
+			hasFailure := false
+			checkRuns, err := listAllCheckRuns(ctx, ghClient, owner, repo, headSHA)
+			if err == nil {
+				for _, run := range checkRuns {
+					if run.GetConclusion() == "failure" {
+						hasFailure = true
+						break
+					}
+				}
+			}
+
+			statuses, _, err := ghClient.Repositories.ListStatuses(ctx, owner, repo, headSHA, nil)
+			if err == nil {
+				for _, status := range statuses {
+					if status.GetState() == "failure" || status.GetState() == "error" {
+						hasFailure = true
+						break
+					}
+				}
+			}
+
+			state := processedPRs[num]
+
+			if hasFailure {
+				if state.lastSHA != headSHA || time.Since(state.lastInvestigatedTime) > 6*time.Hour {
+					prURL := fmt.Sprintf("https://github.com/%s/%s/pull/%d", owner, repo, num)
+					if dryRun {
+						fmt.Printf("[DRYRUN] Would trigger investigate for PR #%d (%s) (SHA: %s): %s\n", num, pr.GetTitle(), headSHA[:7], prURL)
+					} else {
+						fmt.Printf("\nFound failing PR #%d (%s) (SHA: %s). Triggering investigate...\n", num, pr.GetTitle(), headSHA[:7])
+						state.lastSHA = headSHA
+						state.lastInvestigatedTime = time.Now()
+						processedPRs[num] = state
+						if err := runInvestigate(ctx, prURL, "Investigate check failures for this PR", false, ephemeralStorage, secrets); err != nil {
+							klog.Errorf("Investigate for PR #%d failed: %v", num, err)
 						}
 					}
 				}
+			}
 
-				statuses, _, err := ghClient.Repositories.ListStatuses(ctx, owner, repo, headSHA, nil)
-				if err == nil {
-					for _, status := range statuses {
-						if status.GetState() == "failure" || status.GetState() == "error" {
-							hasFailure = true
-							break
-						}
+			// Check 3.2: Check new review comments/feedback after latest commit
+			prCommits, _, err := ghClient.PullRequests.ListCommits(ctx, owner, repo, num, nil)
+			if err == nil {
+				var lastCommitTime time.Time
+				for _, c := range prCommits {
+					if c.GetCommit().GetAuthor().GetDate().After(lastCommitTime) {
+						lastCommitTime = c.GetCommit().GetAuthor().GetDate()
 					}
 				}
 
-				if hasFailure {
-					state, ok := processedPRs[num]
-					if !ok || headSHA != state.lastSHA || time.Since(state.lastInvestigated) > 6*time.Hour {
-						fmt.Printf("\nFound failing PR #%d (%s) (SHA: %s). Triggering investigate & review...\n", num, pr.GetTitle(), headSHA[:7])
-						processedPRs[num] = prWatchState{
-							lastSHA:          headSHA,
-							lastInvestigated: time.Now(),
+				comments, _, err := ghClient.Issues.ListComments(ctx, owner, repo, num, nil)
+				if err == nil {
+					hasNewComments := false
+					for _, c := range comments {
+						// Ignore comments from bot
+						if strings.Contains(strings.ToLower(c.GetUser().GetLogin()), "bot") {
+							continue
 						}
+						if c.GetCreatedAt().After(lastCommitTime) && c.GetCreatedAt().After(state.lastCommentAddressedTime) {
+							hasNewComments = true
+							break
+						}
+					}
+
+					if hasNewComments {
 						prURL := fmt.Sprintf("https://github.com/%s/%s/pull/%d", owner, repo, num)
 						if dryRun {
-							fmt.Printf("[DRYRUN] Would trigger investigate for PR #%d: %s\n", num, prURL)
+							fmt.Printf("[DRYRUN] Would trigger address-comments for PR #%d (%s): %s\n", num, pr.GetTitle(), prURL)
 						} else {
-							if err := runInvestigate(ctx, prURL, "Investigate check failures for this PR", false, ephemeralStorage, secrets); err != nil {
-								klog.Errorf("Investigate for PR #%d failed: %v", num, err)
+							fmt.Printf("\nFound new review comments for PR #%d (%s). Triggering address-comments...\n", num, pr.GetTitle())
+							state.lastCommentAddressedTime = time.Now()
+							processedPRs[num] = state
+							if err := runAddressComments(ctx, prURL, "Address review feedback for this PR", false, ephemeralStorage, secrets); err != nil {
+								klog.Errorf("Address-comments for PR #%d failed: %v", num, err)
 							}
 						}
 					}
@@ -189,4 +329,52 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 			checkRepo()
 		}
 	}
+}
+
+func getReferencedIssues(pr *githubv39.PullRequest) map[int]bool {
+	referenced := make(map[int]bool)
+
+	// Check branch name
+	if pr.GetHead().GetRef() != "" {
+		re := regexp.MustCompile(`\b\d+\b`)
+		for _, match := range re.FindAllString(pr.GetHead().GetRef(), -1) {
+			if num, err := strconv.Atoi(match); err == nil {
+				referenced[num] = true
+			}
+		}
+	}
+
+	// Check title and body
+	re := regexp.MustCompile(`#(\d+)\b`)
+	for _, text := range []string{pr.GetTitle(), pr.GetBody()} {
+		for _, match := range re.FindAllStringSubmatch(text, -1) {
+			if len(match) > 1 {
+				if num, err := strconv.Atoi(match[1]); err == nil {
+					referenced[num] = true
+				}
+			}
+		}
+	}
+
+	return referenced
+}
+
+func hasLinkedPR(ctx context.Context, client *githubv39.Client, owner, repo string, issueNum int) (bool, error) {
+	timeline, _, err := client.Issues.ListIssueTimeline(ctx, owner, repo, issueNum, nil)
+	if err != nil {
+		return false, err
+	}
+	for _, event := range timeline {
+		if event.GetEvent() == "cross-referenced" && event.Source != nil {
+			if event.Source.Issue != nil {
+				if event.GetSource().GetType() == "issue" {
+					continue
+				}
+				if event.Source.Issue.PullRequestLinks != nil {
+					return true, nil
+				}
+			}
+		}
+	}
+	return false, nil
 }


### PR DESCRIPTION
### Summary of Changes:

1. **Smart Issue Link Detection**:
   - The watch command now fetches open Pull Requests *before* issues.
   - It performs a **local regex scan** on open PR titles, bodies, and branch names to find references to issue numbers.
   - If that doesn't match, it uses the **GitHub Timeline API** (`ListIssueTimeline`) as a fallback to detect if a PR has cross-referenced/linked the issue.
   - If a link exists, it skips triggering redundant `fix` tasks.

2. **Assignee & Label filtering**:
   - Updated filtering logic to use your onboarded GitHub login (resolved from the `factory-user` secret) as the default assignee.
   - The `--assignee` command-line flag is still fully supported (e.g. `--assignee ""` for unassigned issues/PRs, or a specific bot username).
   - Issues and PRs are now filtered locally to check if they match the assignee **OR** contain the label `overseer`.

3. **Check for both PR Feedback and Failures**:
   - Matches watched PRs against:
     - **CI failures**: Runs `runInvestigate` if failures are found.
     - **Review comments**: Runs `runAddressComments` if new review comments or feedback are found since the last commit (and since the last time comments were addressed).
   - Both are fully supported under the `--dryrun` flag.

4. **Updated `factory/README.md`**:
   - Documented the new features, local filtering, timeline fallback, and smart issue linking under the `Watching Repositories (factory watch)` section.

logs:
```
barni@barni.c ~/workspace/src/github.com/barney-s/gemini-for-kubernetes-development/factory% ./bin/factory watch  -n overseer-kcc --repo GoogleCloudPlatform/k8s-config-connector --dryrun  


Starting watch for repository GoogleCloudPlatform/k8s-config-connector (poll interval: 2m0s, assignee: 'codebot-robot', labels: [], dryRun: true, watchTimeout: 0s)...
[DRYRUN] Would trigger fix for issue #9191 (ai:chore: Implement direct types for: VertexAINotebookExecutionJob): https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/9191
[DRYRUN] Would trigger fix for issue #9188 (Implement round-trip KRM fuzzer for DNSManagedZone): https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/9188
[DRYRUN] Would trigger fix for issue #9187 (Implement identity and reference types for ServiceDirectoryNamespace): https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/9187
[DRYRUN] Would trigger fix for issue #9186 (Implement round-trip KRM fuzzer for DataflowJob): https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/9186
I0604 18:03:31.990632 2200151 watch.go:173] Skipping issue #9185 because there is already a PR referencing it.
I0604 18:03:31.990727 2200151 watch.go:173] Skipping issue #9184 because there is already a PR referencing it.
I0604 18:03:31.990736 2200151 watch.go:173] Skipping issue #9181 because there is already a PR referencing it.
I0604 18:03:31.990745 2200151 watch.go:173] Skipping issue #9179 because there is already a PR referencing it.
I0604 18:03:31.990752 2200151 watch.go:173] Skipping issue #9171 because there is already a PR referencing it.
I0604 18:03:31.990760 2200151 watch.go:173] Skipping issue #9170 because there is already a PR referencing it.
I0604 18:03:31.990769 2200151 watch.go:173] Skipping issue #9157 because there is already a PR referencing it.
I0604 18:03:31.990782 2200151 watch.go:173] Skipping issue #9154 because there is already a PR referencing it.
[DRYRUN] Would trigger fix for issue #9153 (Implement identity and reference types for DNSManagedZone): https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/9153
I0604 18:03:32.379673 2200151 watch.go:173] Skipping issue #9133 because there is already a PR referencing it.
I0604 18:03:32.379707 2200151 watch.go:173] Skipping issue #9131 because there is already a PR referencing it.
I0604 18:03:32.379724 2200151 watch.go:173] Skipping issue #9126 because there is already a PR referencing it.
I0604 18:03:32.379737 2200151 watch.go:173] Skipping issue #9115 because there is already a PR referencing it.
I0604 18:03:32.379750 2200151 watch.go:173] Skipping issue #9112 because there is already a PR referencing it.
I0604 18:03:32.379759 2200151 watch.go:173] Skipping issue #9092 because there is already a PR referencing it.
I0604 18:03:32.379768 2200151 watch.go:173] Skipping issue #9080 because there is already a PR referencing it.
I0604 18:03:32.379780 2200151 watch.go:173] Skipping issue #9036 because there is already a PR referencing it.
I0604 18:03:32.379792 2200151 watch.go:173] Skipping issue #9035 because there is already a PR referencing it.
I0604 18:03:32.379806 2200151 watch.go:173] Skipping issue #9033 because there is already a PR referencing it.
I0604 18:03:32.379815 2200151 watch.go:173] Skipping issue #9023 because there is already a PR referencing it.
I0604 18:03:32.379821 2200151 watch.go:173] Skipping issue #9022 because there is already a PR referencing it.
I0604 18:03:32.379832 2200151 watch.go:173] Skipping issue #9021 because there is already a PR referencing it.
I0604 18:03:32.379846 2200151 watch.go:173] Skipping issue #9020 because there is already a PR referencing it.
I0604 18:03:32.379856 2200151 watch.go:173] Skipping issue #9019 because there is already a PR referencing it.
I0604 18:03:32.379865 2200151 watch.go:173] Skipping issue #9018 because there is already a PR referencing it.
I0604 18:03:32.379876 2200151 watch.go:173] Skipping issue #9017 because there is already a PR referencing it.
I0604 18:03:32.379885 2200151 watch.go:173] Skipping issue #9016 because there is already a PR referencing it.
I0604 18:03:32.379894 2200151 watch.go:173] Skipping issue #9015 because there is already a PR referencing it.
[DRYRUN] Would trigger investigate for PR #9168 (feat: Implement direct controller E2E test fixtures and identity tests for AutoMLDataset) (SHA: 7e728b4): https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/9168
[DRYRUN] Would trigger investigate for PR #9150 (Implement direct controller for APIHubAPI) (SHA: b7cf35d): https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/9150
[DRYRUN] Would trigger investigate for PR #9054 (ai:chore: Implement direct types for: NetworkSecuritySACRealm) (SHA: 7739331): https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/9054
[DRYRUN] Would trigger investigate for PR #9050 (ai:chore: Implement direct types for NetworkSecurityUrlList) (SHA: b46777c): https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/9050

```