### PR TITLE
factory - connection resilience and token exhaustion tracking

### DIFF
--- a/factory/pkg/commands/root.go
+++ b/factory/pkg/commands/root.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -11,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/config"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/geminitokens"
 	factorysandbox "github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/sandbox"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -132,44 +132,7 @@ coding tasks without local side effects or host dependencies.`,
 }
 
 func getGeminiAPIKey(secret *corev1.Secret) string {
-	if token, err := getTokenFromScript(); err == nil && token != "" {
-		return token
-	}
-	if secret != nil {
-		return string(secret.Data[KeyGeminiAPIKey])
-	}
-	return ""
-}
-
-func getTokenFromScript() (string, error) {
-	dir := os.Getenv("TOKENSCRIPT_DIR")
-	if dir == "" {
-		return "", nil
-	}
-
-	files, err := os.ReadDir(dir)
-	if err != nil {
-		return "", fmt.Errorf("failed to read tokenscript dir: %w", err)
-	}
-
-	for _, f := range files {
-		if f.IsDir() || strings.HasPrefix(f.Name(), "..") {
-			continue
-		}
-
-		path := filepath.Join(dir, f.Name())
-		cmd := exec.Command(path)
-		var out bytes.Buffer
-		cmd.Stdout = &out
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			return "", fmt.Errorf("failed to run tokenscript %s: %w", path, err)
-		}
-
-		return strings.TrimSpace(out.String()), nil
-	}
-
-	return "", nil
+	return geminitokens.GetGeminiAPIKey(secret)
 }
 
 func checkAndRunInBackground(sessionName string) (bool, error) {

--- a/factory/pkg/commands/sandbox.go
+++ b/factory/pkg/commands/sandbox.go
@@ -119,7 +119,7 @@ func NewSandboxLogsCommand(ctx context.Context) *cobra.Command {
 			defer client.Close()
 
 			fmt.Println("Streaming latest execution log...")
-			return client.RunTask(ctx, "tail -f $(ls -td /workspaces/tasks/fix-* 2>/dev/null | head -1)/execution.log", nil)
+			return client.RunTask(ctx, "tail -f $(ls -td /workspaces/tasks/* 2>/dev/null | head -1)/execution.log", nil)
 		},
 	}
 	cmd.Flags().BoolVar(&flags.Daemon, "daemon", false, "Stream envd daemon logs instead of task execution logs")

--- a/factory/pkg/commands/status.go
+++ b/factory/pkg/commands/status.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/clients"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/geminitokens"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -55,8 +57,15 @@ func NewStatusCommand(ctx context.Context) *cobra.Command {
 				if geminiKey == "" {
 					fmt.Fprintf(w, "Gemini Key\t[FAIL]\tGEMINI_API_KEY missing in secret '%s' and TOKENSCRIPT_DIR was not set or returned empty\n", rootFlags.SecretName)
 				} else {
-					if token, _ := getTokenFromScript(); token != "" {
+					if token := geminitokens.GetGeminiAPIKey(nil); token != "" {
 						fmt.Fprintf(w, "Gemini Key\t[OK]\tConfigured via dynamic tokenscript\n")
+						status, err := geminitokens.GetTokensStatus()
+						if err == nil && status != nil {
+							fmt.Fprintf(w, "Tokens Status\t[OK]\tTotal: %d (Active: %d, Quota Exceeded: %d)\n", status.Total, status.Active, status.QuotaExceeded)
+							if len(status.QuotaExceededList) > 0 {
+								fmt.Fprintf(w, "Quota Exceeded\t[WARN]\t%s (resets at midnight)\n", strings.Join(status.QuotaExceededList, ", "))
+							}
+						}
 					} else {
 						fmt.Fprintf(w, "Gemini Key\t[OK]\tConfigured in secret '%s'\n", rootFlags.SecretName)
 					}

--- a/factory/pkg/envd/client.go
+++ b/factory/pkg/envd/client.go
@@ -337,7 +337,7 @@ func (c *Client) RunTaskResilient(ctx context.Context, cmdStr string, envs map[s
 			defer killCancel()
 
 			fmt.Printf("Terminating process in pod...\n")
-			killCmd := fmt.Sprintf("if [ -f %s ]; then kill $(cat %s) 2>/dev/null || true; fi", pidFile, pidFile)
+			killCmd := fmt.Sprintf("if [ -f %s ]; then pids=\"$(cat %s) $(pgrep -P $(cat %s) 2>/dev/null)\"; kill $pids 2>/dev/null || true; fi", pidFile, pidFile, pidFile)
 			_ = c.Exec(killCtx, killCmd, "/workspaces", nil, nil, nil, nil)
 			return loopCtx.Err()
 

--- a/factory/pkg/envd/client.go
+++ b/factory/pkg/envd/client.go
@@ -28,6 +28,12 @@ type Client struct {
 	baseURL       string
 	processClient processconnect.ProcessClient
 	closePF       func()
+
+	// For reconnection
+	namespace   string
+	sandboxName string
+	localPort   int
+	pfCmd       *exec.Cmd
 }
 
 func (c *Client) WriteFile(ctx context.Context, destPath string, data []byte) error {
@@ -141,6 +147,8 @@ func Connect(ctx context.Context, namespace, sandboxName string) (*Client, error
 			baseURL:       baseURL,
 			processClient: processClient,
 			closePF:       func() {},
+			namespace:     namespace,
+			sandboxName:   sandboxName,
 		}, nil
 	}
 
@@ -185,6 +193,10 @@ func Connect(ctx context.Context, namespace, sandboxName string) (*Client, error
 		baseURL:       baseURL,
 		processClient: processClient,
 		closePF:       closeFunc,
+		namespace:     namespace,
+		sandboxName:   sandboxName,
+		localPort:     localPort,
+		pfCmd:         pfCmd,
 	}, nil
 }
 
@@ -192,6 +204,57 @@ func (c *Client) Close() {
 	if c.closePF != nil {
 		c.closePF()
 	}
+	if c.pfCmd != nil && c.pfCmd.Process != nil {
+		_ = c.pfCmd.Process.Kill()
+	}
+}
+
+func (c *Client) ReconnectPortForward(ctx context.Context) error {
+	if c.pfCmd == nil {
+		return nil
+	}
+
+	// First, check if the connection is already healthy
+	resp, err := http.Get(c.baseURL + "/health")
+	if err == nil && resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		resp.Body.Close()
+		return nil // Already healthy
+	}
+
+	klog.Infof("Re-establishing port-forward to service for sandbox %s...", c.sandboxName)
+
+	if c.pfCmd.Process != nil {
+		_ = c.pfCmd.Process.Kill()
+		_ = c.pfCmd.Wait()
+	}
+
+	serviceName := c.sandboxName + "-lb"
+	c.pfCmd = exec.CommandContext(context.Background(), "kubectl", "port-forward", fmt.Sprintf("svc/%s", serviceName), fmt.Sprintf("%d:49983", c.localPort), "-n", c.namespace)
+	if err := c.pfCmd.Start(); err != nil {
+		return fmt.Errorf("restarting port-forward: %w", err)
+	}
+
+	ready := false
+	for i := 0; i < 40; i++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		time.Sleep(500 * time.Millisecond)
+		resp, err := http.Get(c.baseURL + "/health")
+		if err == nil && resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			resp.Body.Close()
+			ready = true
+			break
+		}
+	}
+	if !ready {
+		return fmt.Errorf("timed out waiting for restarted port-forward to become ready")
+	}
+
+	klog.Infof("Port-forward successfully re-established on port %d", c.localPort)
+	return nil
 }
 
 func (c *Client) Exec(ctx context.Context, cmdStr, cwd string, envs map[string]string, stdin io.Reader, stdout, stderr io.Writer) error {
@@ -355,6 +418,9 @@ func (c *Client) RunTaskResilient(ctx context.Context, cmdStr string, envs map[s
 				}
 			} else {
 				klog.Warningf("Log streaming connection flaked: %v. Reconnecting...", err)
+				if reconnectErr := c.ReconnectPortForward(loopCtx); reconnectErr != nil {
+					klog.Errorf("Failed to reconnect port-forward: %v", reconnectErr)
+				}
 			}
 
 			// Check if exit code file exists
@@ -383,6 +449,11 @@ func (c *Client) RunTaskResilient(ctx context.Context, cmdStr string, envs map[s
 						return fmt.Errorf("task failed with exit code %d", code)
 					}
 					return nil
+				}
+			} else {
+				klog.Warningf("Status check connection flaked: %v. Reconnecting...", err)
+				if reconnectErr := c.ReconnectPortForward(loopCtx); reconnectErr != nil {
+					klog.Errorf("Failed to reconnect port-forward: %v", reconnectErr)
 				}
 			}
 		}

--- a/factory/pkg/envd/client.go
+++ b/factory/pkg/envd/client.go
@@ -21,6 +21,7 @@ import (
 	"connectrpc.com/connect"
 	process "github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/envd/spec/process"
 	processconnect "github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/envd/spec/process/processconnect"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/geminitokens"
 	"k8s.io/klog/v2"
 )
 
@@ -415,6 +416,14 @@ func (c *Client) RunTaskResilient(ctx context.Context, cmdStr string, envs map[s
 				if len(newData) > 0 {
 					_, _ = os.Stdout.Write(newData)
 					offset += int64(len(newData))
+
+					if geminitokens.ContainsQuotaError(newData) {
+						if key := envs["GEMINI_API_KEY"]; key != "" {
+							if err := geminitokens.AddQuotaExceededKey(key, 4*time.Hour); err != nil {
+								klog.Errorf("Failed to mark key as quota exceeded: %v", err)
+							}
+						}
+					}
 				}
 			} else {
 				klog.Warningf("Log streaming connection flaked: %v. Reconnecting...", err)

--- a/factory/pkg/geminitokens/geminitokens.go
+++ b/factory/pkg/geminitokens/geminitokens.go
@@ -1,0 +1,307 @@
+package geminitokens
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+const KeyGeminiAPIKey = "GEMINI_API_KEY"
+
+var listMutex sync.Mutex
+
+func getQuotaExceededFilePath() string {
+	// 1. If FACTORY_CONFIG or .factory.cfg is used, put it in the same directory
+	configPath := ""
+	if _, err := os.Stat(".factory.cfg"); err == nil {
+		configPath = ".factory.cfg"
+	} else if envVal := os.Getenv("FACTORY_CONFIG"); envVal != "" {
+		fi, err := os.Stat(envVal)
+		if err == nil {
+			if fi.IsDir() {
+				configPath = filepath.Join(envVal, ".factory.cfg")
+			} else {
+				configPath = envVal
+			}
+		}
+	}
+	if configPath != "" {
+		absPath, err := filepath.Abs(configPath)
+		if err == nil {
+			return filepath.Join(filepath.Dir(absPath), ".factory_quota_exceeded_keys.json")
+		}
+	}
+
+	// 2. Otherwise use user config dir
+	dir, err := os.UserConfigDir()
+	if err == nil {
+		return filepath.Join(dir, "factory", "quota_exceeded_keys.json")
+	}
+
+	// 3. Fallback to /tmp
+	return "/tmp/.factory_quota_exceeded_keys.json"
+}
+
+func loadQuotaExceededList() (map[string]time.Time, error) {
+	filePath := getQuotaExceededFilePath()
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(map[string]time.Time), nil
+		}
+		return nil, err
+	}
+
+	var rawMap map[string]string
+	if err := json.Unmarshal(data, &rawMap); err != nil {
+		return nil, err
+	}
+
+	list := make(map[string]time.Time)
+	for k, v := range rawMap {
+		t, err := time.Parse(time.RFC3339, v)
+		if err == nil {
+			list[k] = t
+		}
+	}
+	return list, nil
+}
+
+func saveQuotaExceededList(list map[string]time.Time) error {
+	filePath := getQuotaExceededFilePath()
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		return err
+	}
+
+	rawMap := make(map[string]string)
+	for k, v := range list {
+		rawMap[k] = v.Format(time.RFC3339)
+	}
+
+	data, err := json.MarshalIndent(rawMap, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filePath, data, 0644)
+}
+
+func IsKeyQuotaExceeded(key string) bool {
+	if key == "" {
+		return false
+	}
+
+	listMutex.Lock()
+	defer listMutex.Unlock()
+
+	list, err := loadQuotaExceededList()
+	if err != nil {
+		klog.Errorf("Failed to load quota exceeded list: %v", err)
+		return false
+	}
+
+	exp, exists := list[key]
+	if !exists {
+		return false
+	}
+
+	if time.Now().After(exp) {
+		// Clean up expired entry
+		delete(list, key)
+		_ = saveQuotaExceededList(list)
+		return false
+	}
+
+	return true
+}
+
+func AddQuotaExceededKey(key string, duration time.Duration) error {
+	if key == "" {
+		return nil
+	}
+
+	listMutex.Lock()
+	defer listMutex.Unlock()
+
+	list, err := loadQuotaExceededList()
+	if err != nil {
+		return fmt.Errorf("loading quota exceeded list: %w", err)
+	}
+
+	expiration := time.Now().Add(duration)
+	list[key] = expiration
+
+	keyDesc := key
+	if len(keyDesc) > 8 {
+		keyDesc = keyDesc[:8] + "..."
+	}
+	klog.Infof("Adding key starting with '%s' to quota exceeded list until %s (%s)", keyDesc, expiration.Format(time.RFC3339), duration)
+
+	if err := saveQuotaExceededList(list); err != nil {
+		return fmt.Errorf("saving quota exceeded list: %w", err)
+	}
+	return nil
+}
+
+func ContainsQuotaError(data []byte) bool {
+	str := string(data)
+	return strings.Contains(str, "RESOURCE_EXHAUSTED") ||
+		strings.Contains(str, "exceeded your current quota") ||
+		strings.Contains(str, "status: 429") ||
+		strings.Contains(str, "statusCode: 429") ||
+		strings.Contains(str, "status\": 429") ||
+		strings.Contains(str, "status: \"Too Many Requests\"")
+}
+
+func GetGeminiAPIKey(secret *corev1.Secret) string {
+	if token, err := getTokenFromScript(); err == nil && token != "" {
+		return token
+	}
+	if secret != nil {
+		return string(secret.Data[KeyGeminiAPIKey])
+	}
+	return ""
+}
+
+func getTokenFromScript() (string, error) {
+	dir := os.Getenv("TOKENSCRIPT_DIR")
+	if dir == "" {
+		return "", nil
+	}
+
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		return "", fmt.Errorf("failed to read tokenscript dir: %w", err)
+	}
+
+	var scriptPath string
+	for _, f := range files {
+		if f.IsDir() || strings.HasPrefix(f.Name(), "..") {
+			continue
+		}
+		scriptPath = filepath.Join(dir, f.Name())
+		break
+	}
+
+	if scriptPath == "" {
+		return "", nil
+	}
+
+	// Try up to 30 times to get a non-quota-exceeded token from the script
+	for attempt := 0; attempt < 30; attempt++ {
+		cmd := exec.Command(scriptPath)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return "", fmt.Errorf("failed to run tokenscript %s: %w", scriptPath, err)
+		}
+
+		token := strings.TrimSpace(out.String())
+		if token == "" {
+			return "", nil
+		}
+
+		if !IsKeyQuotaExceeded(token) {
+			return token, nil
+		}
+	}
+
+	return "", fmt.Errorf("failed to find a non-quota-exceeded token from script after 30 attempts")
+}
+
+func TimeUntilNextMidnight() time.Duration {
+	now := time.Now()
+	nextMidnight := time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, now.Location())
+	return nextMidnight.Sub(now)
+}
+
+func DiscoverTokensFromScript() ([]string, error) {
+	dir := os.Getenv("TOKENSCRIPT_DIR")
+	if dir == "" {
+		return nil, nil
+	}
+
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read tokenscript dir: %w", err)
+	}
+
+	var scriptPath string
+	for _, f := range files {
+		if f.IsDir() || strings.HasPrefix(f.Name(), "..") {
+			continue
+		}
+		scriptPath = filepath.Join(dir, f.Name())
+		break
+	}
+
+	if scriptPath == "" {
+		return nil, nil
+	}
+
+	uniqueTokens := make(map[string]bool)
+	// Run the script 100 times to collect all unique tokens
+	for i := 0; i < 100; i++ {
+		cmd := exec.Command(scriptPath)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err == nil {
+			token := strings.TrimSpace(out.String())
+			if token != "" {
+				uniqueTokens[token] = true
+			}
+		}
+	}
+
+	tokens := make([]string, 0, len(uniqueTokens))
+	for t := range uniqueTokens {
+		tokens = append(tokens, t)
+	}
+	return tokens, nil
+}
+
+type TokensStatus struct {
+	Total             int
+	QuotaExceeded     int
+	Active            int
+	ActiveList        []string
+	QuotaExceededList []string
+}
+
+func GetTokensStatus() (*TokensStatus, error) {
+	allTokens, err := DiscoverTokensFromScript()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(allTokens) == 0 {
+		return nil, nil
+	}
+
+	status := &TokensStatus{}
+	for _, t := range allTokens {
+		obscured := t
+		if len(obscured) > 8 {
+			obscured = obscured[:8] + "..."
+		}
+		if IsKeyQuotaExceeded(t) {
+			status.QuotaExceeded++
+			status.QuotaExceededList = append(status.QuotaExceededList, obscured)
+		} else {
+			status.Active++
+			status.ActiveList = append(status.ActiveList, obscured)
+		}
+	}
+	status.Total = len(allTokens)
+	return status, nil
+}


### PR DESCRIPTION
### 1. Connection Resilience & Auto-Reconnection
* **Reconnection Handling**: Implemented a `ReconnectPortForward` mechanism on the `envd` client struct. If the connection fails, it kills the dead port-forward command, starts a new `kubectl port-forward` child process, and waits for `/health` to become responsive.
* **Stream & Status Checking Retry**: Integrated this reconnection logic into `RunTaskResilient` (the log streaming and status checking loop). If a VPN flake or port-forward timeout occurs during a running task, the client automatically re-establishes the connection and resumes streaming logs from the exact byte offset without aborting or killing the active task inside the pod.
* **Process Cleanup**: Modified the client `Close()` method to clean up and kill any dynamically restarted port-forward subprocesses.

### 2. Quota Exhaustion Tracking (`geminitokens` package)
* **New Package**: Introduced the [geminitokens](file:///usr/local/google/home/barni/workspace/src/github.com/barney-s/gemini-for-kubernetes-development/factory/pkg/geminitokens/geminitokens.go) package to encapsulate token script execution, API key extraction, and tracking.
* **Tracking File**: Tracks exhausted keys by persisting them to a local JSON list (`.factory_quota_exceeded_keys.json`).
* **Midnight Reset**: When a `429 RESOURCE_EXHAUSTED` error is detected in the log stream:
  - The client automatically adds the active key to the quota exceeded list.
  - The expiration is set to the **upcoming midnight**, after which the entry automatically clean-deletes itself during key resolution.
* **Script Integration**: Refactored `GetGeminiAPIKey` (used by workflow tasks) to query the tokenscript up to 30 times to dynamically find a non-quota-exceeded token.

### 3. Diagnostic Commands
* **`factory status` Command**: Updated to query and list key status details when dynamic token scripts are enabled. It prints:
  - Total tokens count, active count, and quota-exceeded count.
  - List of obscured quota-exceeded keys currently waiting for midnight resets (e.g. `AIzaSyCc...`).