### PR TITLE
fix(factory): resolve stuck sandbox task and improve resiliency

### DIFF
--- a/factory/design/resilient-task-execution.md
+++ b/factory/design/resilient-task-execution.md
@@ -89,3 +89,23 @@ In interactive (default) mode, the client performs the following loop:
 | **Log Polling Overhead** | Downloading the entire log file recursively wastes CPU/bandwidth. | Used `tail -c +<offset>` to retrieve only the delta bytes since the last read. |
 | **Log Truncation** | The process might exit, but the client breaks the loop before reading final log lines. | Perform one final `tail -c +<offset>` check after detecting the `exit_code` file. |
 | **Orphaned Processes** | Forgotten tasks run forever. | Deleting the sandbox pod via standard controller methods cleans up all resources. |
+
+---
+
+## Execution Modes & Cancellation Semantics
+
+Below is a comparison of how `--background`, `--detached`, and `--abort-on-cancel` control task execution and monitoring:
+
+| Flag / Mode | Run Location | Monitoring Mechanism | Sandbox Status Updates | Resiliency to Overseer Restart |
+| :--- | :--- | :--- | :--- | :--- |
+| **`--background`** | **Host (Overseer container)** | Local CLI daemon runs in background on the host; port-forwards and streams logs. | Yes, the host CLI process updates annotations to `Completed`/`Failed` on task completion. | **Aborted.** Overseer restart kills the host process, which sends a kill signal to the sandbox. |
+| **`--detached`** | **Sandbox Pod** | runs via `nohup ... &` in the sandbox pod. Local CLI exits immediately. | **No.** CLI exits immediately and stops tracking, leaving task status as `Running` in annotations indefinitely. | **Resilient.** Task inside sandbox runs completely independently. |
+| **`--abort-on-cancel`** (default `true`) | **N/A** (Cleanup policy) | Controls whether local CLI should send a `kill` signal to the sandbox pod if context is canceled or CLI process is killed. | N/A | If `false`, killing the CLI process leaves the task running inside the sandbox pod. |
+
+### Orchestrator (Watch Daemon) Resiliency Pattern
+
+To prevent restarts of the `overseer-kcc` container/pod from disrupting active subagent tasks while keeping execution state updated in Kubernetes:
+1. `factory watch` runs child commands synchronously on the host container to stream logs and monitor completion.
+2. It passes `--abort-on-cancel=false` to these child commands. If `factory watch` exits or restarts, the child processes terminate without killing the background tasks in the sandbox pods.
+3. On restart, `factory watch` dynamically reconciles any sandboxes in a `Running` task state by executing a lightweight check inside the pod for the task's `exit_code` file, updating the metadata annotations to `Completed`/`Failed` retroactively.
+

--- a/factory/pkg/commands/agent.go
+++ b/factory/pkg/commands/agent.go
@@ -271,7 +271,7 @@ func RunAgent(ctx context.Context, flags AgentFlags, ephemeralStorage string, se
 	fmt.Println("Running agent task via envd...")
 	cmdStr := fmt.Sprintf("bash -c 'set -o pipefail; bash %s'", scriptPath)
 	_ = factorysandbox.UpdateSandboxTaskAnnotation(ctx, kubeClient, rootFlags.Namespace, sandboxName, "agent", "Running")
-	if err := client.RunTaskResilient(ctx, cmdStr, envMap, taskDir, rootFlags.Detached); err != nil {
+	if err := client.RunTaskResilient(ctx, cmdStr, envMap, taskDir, rootFlags.Detached, rootFlags.AbortOnCancel); err != nil {
 		_ = factorysandbox.UpdateSandboxTaskAnnotation(ctx, kubeClient, rootFlags.Namespace, sandboxName, "agent", "Failed")
 		return fmt.Errorf("running task: %w", err)
 	}

--- a/factory/pkg/commands/agent.go
+++ b/factory/pkg/commands/agent.go
@@ -195,7 +195,7 @@ func RunAgent(ctx context.Context, flags AgentFlags, ephemeralStorage string, se
 	taskTitle := fmt.Sprintf("Agent: %s", agentDef.Name)
 
 	fmt.Printf("Ensuring sandbox for task %s...\n", taskID)
-	sandboxName, err := factorysandbox.EnsureAgentSandbox(ctx, kubeClient, rootFlags.Namespace, repo, taskID, cloneURL, taskTitle, rootFlags.Image, rootFlags.DiskSize, ephemeralStorage, secrets, rootFlags.ResolvedEnvs)
+	sandboxName, err := factorysandbox.EnsureAgentSandbox(ctx, kubeClient, rootFlags.Namespace, repo, taskID, cloneURL, flags.URL, taskTitle, rootFlags.Image, rootFlags.DiskSize, ephemeralStorage, secrets, rootFlags.ResolvedEnvs)
 	if err != nil {
 		return fmt.Errorf("ensuring agent sandbox: %w", err)
 	}
@@ -307,7 +307,7 @@ func RunAgent(ctx context.Context, flags AgentFlags, ephemeralStorage string, se
 
 	if createdPRNum > 0 {
 		fmt.Printf("Aliasing sandbox %s to PR #%d...\n", sandboxName, createdPRNum)
-		if err := factorysandbox.AliasSandboxToPR(ctx, kubeClient, rootFlags.Namespace, sandboxName, createdPRNum); err != nil {
+		if err := factorysandbox.AliasSandboxToPR(ctx, kubeClient, rootFlags.Namespace, sandboxName, createdPRNum, prURL); err != nil {
 			klog.Warningf("Failed to alias sandbox to PR #%d: %v", createdPRNum, err)
 		}
 		fmt.Printf("PR created/updated: %s\n", prURL)

--- a/factory/pkg/commands/fix.go
+++ b/factory/pkg/commands/fix.go
@@ -290,7 +290,7 @@ func runFix(ctx context.Context, targetURL, prompt, name string, noPR, watch boo
 	fmt.Println("Running fix-issue task via envd...")
 	cmdStr := fmt.Sprintf("bash -c 'set -o pipefail; bash %s'", scriptPath)
 	_ = factorysandbox.UpdateSandboxTaskAnnotation(ctx, kubeClient, rootFlags.Namespace, sandboxName, "fix-issue", "Running")
-	if err := client.RunTaskResilient(ctx, cmdStr, envMap, taskDir, rootFlags.Detached); err != nil {
+	if err := client.RunTaskResilient(ctx, cmdStr, envMap, taskDir, rootFlags.Detached, rootFlags.AbortOnCancel); err != nil {
 		_ = factorysandbox.UpdateSandboxTaskAnnotation(ctx, kubeClient, rootFlags.Namespace, sandboxName, "fix-issue", "Failed")
 		return fmt.Errorf("running task: %w", err)
 	}

--- a/factory/pkg/commands/fix.go
+++ b/factory/pkg/commands/fix.go
@@ -173,10 +173,10 @@ func runFix(ctx context.Context, targetURL, prompt, name string, noPR, watch boo
 	var sandboxName string
 	if isIssue {
 		fmt.Printf("Ensuring sandbox for issue #%d...\n", issueNum)
-		sandboxName, err = factorysandbox.EnsureFixSandbox(ctx, kubeClient, rootFlags.Namespace, repo, strconv.Itoa(issueNum), cloneURL, issueTitle, rootFlags.Image, rootFlags.DiskSize, ephemeralStorage, secrets, rootFlags.ResolvedEnvs)
+		sandboxName, err = factorysandbox.EnsureFixSandbox(ctx, kubeClient, rootFlags.Namespace, repo, strconv.Itoa(issueNum), cloneURL, targetURL, issueTitle, rootFlags.Image, rootFlags.DiskSize, ephemeralStorage, secrets, rootFlags.ResolvedEnvs)
 	} else {
 		fmt.Printf("Ensuring sandbox for task %s on repo %s/%s...\n", name, owner, repo)
-		sandboxName, err = factorysandbox.EnsureFixSandbox(ctx, kubeClient, rootFlags.Namespace, repo, name, cloneURL, issueTitle, rootFlags.Image, rootFlags.DiskSize, ephemeralStorage, secrets, rootFlags.ResolvedEnvs)
+		sandboxName, err = factorysandbox.EnsureFixSandbox(ctx, kubeClient, rootFlags.Namespace, repo, name, cloneURL, targetURL, issueTitle, rootFlags.Image, rootFlags.DiskSize, ephemeralStorage, secrets, rootFlags.ResolvedEnvs)
 	}
 	if err != nil {
 		return fmt.Errorf("ensuring sandbox: %w", err)
@@ -324,7 +324,7 @@ func runFix(ctx context.Context, targetURL, prompt, name string, noPR, watch boo
 
 	if prNum > 0 {
 		fmt.Printf("Aliasing sandbox %s to PR #%d...\n", sandboxName, prNum)
-		if err := factorysandbox.AliasSandboxToPR(ctx, kubeClient, rootFlags.Namespace, sandboxName, prNum); err != nil {
+		if err := factorysandbox.AliasSandboxToPR(ctx, kubeClient, rootFlags.Namespace, sandboxName, prNum, prURL); err != nil {
 			klog.Warningf("Failed to alias sandbox to PR #%d: %v", prNum, err)
 		}
 

--- a/factory/pkg/commands/pr.go
+++ b/factory/pkg/commands/pr.go
@@ -255,7 +255,7 @@ func runInvestigate(ctx context.Context, prURL, prompt string, continueSession b
 	fmt.Println("Running investigate task via envd...")
 	cmdStr := fmt.Sprintf("bash -c 'set -o pipefail; bash %s'", scriptPath)
 	_ = factorysandbox.UpdateSandboxTaskAnnotation(ctx, kubeClient, rootFlags.Namespace, sandboxName, "investigate", "Running")
-	if err := client.RunTaskResilient(ctx, cmdStr, envMap, taskDir, rootFlags.Detached); err != nil {
+	if err := client.RunTaskResilient(ctx, cmdStr, envMap, taskDir, rootFlags.Detached, rootFlags.AbortOnCancel); err != nil {
 		_ = factorysandbox.UpdateSandboxTaskAnnotation(ctx, kubeClient, rootFlags.Namespace, sandboxName, "investigate", "Failed")
 		return fmt.Errorf("running task: %w", err)
 	}
@@ -505,7 +505,7 @@ func runAddressComments(ctx context.Context, prURL, prompt string, continueSessi
 	fmt.Println("Running address-comments task via envd...")
 	cmdStr := fmt.Sprintf("bash -c 'set -o pipefail; bash %s'", scriptPath)
 	_ = factorysandbox.UpdateSandboxTaskAnnotation(ctx, kubeClient, rootFlags.Namespace, sandboxName, "address-comments", "Running")
-	if err := client.RunTaskResilient(ctx, cmdStr, envMap, taskDir, rootFlags.Detached); err != nil {
+	if err := client.RunTaskResilient(ctx, cmdStr, envMap, taskDir, rootFlags.Detached, rootFlags.AbortOnCancel); err != nil {
 		_ = factorysandbox.UpdateSandboxTaskAnnotation(ctx, kubeClient, rootFlags.Namespace, sandboxName, "address-comments", "Failed")
 		return fmt.Errorf("running task: %w", err)
 	}
@@ -918,7 +918,7 @@ func runIterate(ctx context.Context, prURL, prompt string, continueSession bool,
 	fmt.Println("Running iterate task via envd...")
 	cmdStr := fmt.Sprintf("bash -c 'set -o pipefail; bash %s'", scriptPath)
 	_ = factorysandbox.UpdateSandboxTaskAnnotation(ctx, kubeClient, rootFlags.Namespace, sandboxName, "iterate", "Running")
-	if err := client.RunTaskResilient(ctx, cmdStr, envMap, taskDir, rootFlags.Detached); err != nil {
+	if err := client.RunTaskResilient(ctx, cmdStr, envMap, taskDir, rootFlags.Detached, rootFlags.AbortOnCancel); err != nil {
 		_ = factorysandbox.UpdateSandboxTaskAnnotation(ctx, kubeClient, rootFlags.Namespace, sandboxName, "iterate", "Failed")
 		return fmt.Errorf("running task: %w", err)
 	}

--- a/factory/pkg/commands/review.go
+++ b/factory/pkg/commands/review.go
@@ -289,7 +289,7 @@ func runReview(ctx context.Context, prURL string, publishPolicy string, instruct
 	fmt.Println("Running review task via envd...")
 	cmdStr := fmt.Sprintf("bash -c 'set -o pipefail; bash %s'", scriptPath)
 	_ = factorysandbox.UpdateSandboxTaskAnnotation(ctx, kubeClient, rootFlags.Namespace, sandboxName, "review", "Running")
-	if err := client.RunTaskResilient(ctx, cmdStr, envMap, taskDir, rootFlags.Detached); err != nil {
+	if err := client.RunTaskResilient(ctx, cmdStr, envMap, taskDir, rootFlags.Detached, rootFlags.AbortOnCancel); err != nil {
 		_ = factorysandbox.UpdateSandboxTaskAnnotation(ctx, kubeClient, rootFlags.Namespace, sandboxName, "review", "Failed")
 		return fmt.Errorf("running task: %w", err)
 	}

--- a/factory/pkg/commands/root.go
+++ b/factory/pkg/commands/root.go
@@ -38,6 +38,7 @@ type RootFlags struct {
 	Envs             []string
 	ResolvedEnvs     []factorysandbox.EnvVar
 	Detached         bool
+	AbortOnCancel    bool
 }
 
 var rootFlags RootFlags
@@ -63,6 +64,7 @@ coding tasks without local side effects or host dependencies.`,
 	cmd.PersistentFlags().StringSliceVar(&rootFlags.Secrets, "secret", nil, "Inject a secret with format secretName:mountPath (can be specified multiple times)")
 	cmd.PersistentFlags().StringArrayVar(&rootFlags.Envs, "env", nil, "Inject an environment variable with format KEY=VALUE (can be specified multiple times)")
 	cmd.PersistentFlags().BoolVar(&rootFlags.Detached, "detached", false, "Run the task in the background of the sandbox pod and return immediately")
+	cmd.PersistentFlags().BoolVar(&rootFlags.AbortOnCancel, "abort-on-cancel", true, "Abort the background task in the sandbox pod if the local CLI command is canceled or killed")
 
 	cmd.PersistentPreRun = func(_ *cobra.Command, _ []string) {
 		if rootFlags.Namespace == "" {

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/clients"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/config"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/envd"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/github"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/k8s"
 	factorysandbox "github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/sandbox"
@@ -147,6 +149,31 @@ func isSandboxTaskRunning(ctx context.Context, kubeClient *clients.KubernetesCli
 
 	state := annotations["sandbox.gemini.google.com/last-task-state"]
 	if state == "" || strings.EqualFold(state, "Running") {
+		// Verify if the task has actually finished by connecting to the sandbox via envd
+		client, err := envd.Connect(ctx, namespace, name)
+		if err == nil {
+			defer client.Close()
+			var buf bytes.Buffer
+			// Check exit_code of the latest task
+			checkCmd := "cat $(ls -td /workspaces/tasks/* 2>/dev/null | head -1)/exit_code 2>/dev/null"
+			if err := client.Exec(ctx, checkCmd, "/workspaces", nil, nil, &buf, nil); err == nil {
+				exitStr := strings.TrimSpace(buf.String())
+				if exitStr != "" {
+					// Task has finished!
+					taskState := "Completed"
+					if exitStr != "0" {
+						taskState = "Failed"
+					}
+					taskType := annotations["sandbox.gemini.google.com/last-task-type"]
+					if taskType == "" {
+						taskType = "task"
+					}
+					klog.Infof("Detected completed task %s inside sandbox %s with exit code %s. Updating sandbox annotation to %s.", taskType, name, exitStr, taskState)
+					_ = factorysandbox.UpdateSandboxTaskAnnotation(ctx, kubeClient, namespace, name, taskType, taskState)
+					return false, nil
+				}
+			}
+		}
 		return true, nil
 	}
 
@@ -1286,6 +1313,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 					if rootFlags.EphemeralStorage != "" {
 						args = append(args, "--ephemeral-storage", rootFlags.EphemeralStorage)
 					}
+					args = append(args, "--abort-on-cancel=false")
 
 					cmd := exec.Command(executable, args...)
 

--- a/factory/pkg/envd/client.go
+++ b/factory/pkg/envd/client.go
@@ -343,7 +343,7 @@ func (c *Client) RunTask(ctx context.Context, cmdStr string, envs map[string]str
 	return c.Exec(ctx, cmdStr, "/workspaces", envs, nil, os.Stdout, os.Stderr)
 }
 
-func (c *Client) RunTaskResilient(ctx context.Context, cmdStr string, envs map[string]string, taskDir string, detached bool) error {
+func (c *Client) RunTaskResilient(ctx context.Context, cmdStr string, envs map[string]string, taskDir string, detached bool, abortOnCancel bool) error {
 	pidFile := fmt.Sprintf("%s/pid", taskDir)
 	logFile := fmt.Sprintf("%s/execution.log", taskDir)
 	exitCodeFile := fmt.Sprintf("%s/exit_code", taskDir)
@@ -395,14 +395,15 @@ func (c *Client) RunTaskResilient(ctx context.Context, cmdStr string, envs map[s
 		select {
 		case <-loopCtx.Done():
 			// The context was canceled (either Ctrl+C, timeout, or external cancellation).
-			// We must kill the process in the pod before exiting!
-			// We use context.Background() since loopCtx is canceled.
-			killCtx, killCancel := context.WithTimeout(context.Background(), 15*time.Second)
-			defer killCancel()
+			// We must kill the process in the pod before exiting if abortOnCancel is true!
+			if abortOnCancel {
+				killCtx, killCancel := context.WithTimeout(context.Background(), 15*time.Second)
+				defer killCancel()
 
-			fmt.Printf("Terminating process in pod...\n")
-			killCmd := fmt.Sprintf("if [ -f %s ]; then pids=\"$(cat %s) $(pgrep -P $(cat %s) 2>/dev/null)\"; kill $pids 2>/dev/null || true; fi", pidFile, pidFile, pidFile)
-			_ = c.Exec(killCtx, killCmd, "/workspaces", nil, nil, nil, nil)
+				fmt.Printf("Terminating process in pod...\n")
+				killCmd := fmt.Sprintf("if [ -f %s ]; then pids=\"$(cat %s) $(pgrep -P $(cat %s) 2>/dev/null)\"; kill $pids 2>/dev/null || true; fi", pidFile, pidFile, pidFile)
+				_ = c.Exec(killCtx, killCmd, "/workspaces", nil, nil, nil, nil)
+			}
 			return loopCtx.Err()
 
 		case <-ticker.C:

--- a/factory/pkg/sandbox/sandbox.go
+++ b/factory/pkg/sandbox/sandbox.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/clients"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/k8s"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func EnsureFixSandbox(ctx context.Context, kubeClient *clients.KubernetesClient, namespace, repoName, taskID, cloneURL, taskTitle, image, diskSize, ephemeralStorage string, secrets []SecretMount, envs []EnvVar) (string, error) {
+func EnsureFixSandbox(ctx context.Context, kubeClient *clients.KubernetesClient, namespace, repoName, taskID, cloneURL, htmlURL, taskTitle, image, diskSize, ephemeralStorage string, secrets []SecretMount, envs []EnvVar) (string, error) {
 	name := fmt.Sprintf("fix-%s-%s", repoName, taskID)
 
 	_, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
@@ -36,6 +37,7 @@ func EnsureFixSandbox(ctx context.Context, kubeClient *clients.KubernetesClient,
 			Annotations: map[string]string{
 				"repo":     repoName,
 				"cloneURL": cloneURL,
+				"htmlURL":  htmlURL,
 			},
 			Image:             image,
 			Replicas:          1,
@@ -61,7 +63,7 @@ func EnsureFixSandbox(ctx context.Context, kubeClient *clients.KubernetesClient,
 	return name, nil
 }
 
-func EnsureAgentSandbox(ctx context.Context, kubeClient *clients.KubernetesClient, namespace, repoName, taskID, cloneURL, taskTitle, image, diskSize, ephemeralStorage string, secrets []SecretMount, envs []EnvVar) (string, error) {
+func EnsureAgentSandbox(ctx context.Context, kubeClient *clients.KubernetesClient, namespace, repoName, taskID, cloneURL, htmlURL, taskTitle, image, diskSize, ephemeralStorage string, secrets []SecretMount, envs []EnvVar) (string, error) {
 	name := fmt.Sprintf("agent-%s-%s", repoName, taskID)
 
 	_, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
@@ -87,6 +89,7 @@ func EnsureAgentSandbox(ctx context.Context, kubeClient *clients.KubernetesClien
 			Annotations: map[string]string{
 				"repo":     repoName,
 				"cloneURL": cloneURL,
+				"htmlURL":  htmlURL,
 			},
 			Image:             image,
 			Replicas:          1,
@@ -112,7 +115,7 @@ func EnsureAgentSandbox(ctx context.Context, kubeClient *clients.KubernetesClien
 	return name, nil
 }
 
-func AliasSandboxToPR(ctx context.Context, kubeClient *clients.KubernetesClient, namespace, sandboxName string, prNum int) error {
+func AliasSandboxToPR(ctx context.Context, kubeClient *clients.KubernetesClient, namespace, sandboxName string, prNum int, prURL string) error {
 	unstructObj, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Get(ctx, sandboxName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("getting sandbox %s: %w", sandboxName, err)
@@ -130,6 +133,9 @@ func AliasSandboxToPR(ctx context.Context, kubeClient *clients.KubernetesClient,
 		annotations = make(map[string]string)
 	}
 	annotations["pr"] = fmt.Sprintf("%d", prNum)
+	if prURL != "" {
+		annotations["htmlURL"] = prURL
+	}
 	unstructObj.SetAnnotations(annotations)
 
 	_, err = kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Update(ctx, unstructObj, metav1.UpdateOptions{})
@@ -204,6 +210,12 @@ func EnsureReviewSandbox(ctx context.Context, kubeClient *clients.KubernetesClie
 }
 
 func UpdateSandboxTaskAnnotation(ctx context.Context, kubeClient *clients.KubernetesClient, namespace, sandboxName, taskType, taskState string) error {
+	if ctx.Err() != nil {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+	}
+
 	unstructObj, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Get(ctx, sandboxName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("getting sandbox %s: %w", sandboxName, err)


### PR DESCRIPTION
### 1. Stuck Sandbox status & Missing annotations
* **Fix Sandbox Annotation Timeout Bug:** When a task timed out (deadline exceeded), the client would try to mark the task as `Failed` in Kubernetes. However, it passed the timed-out context (`ctx`), which made the API request itself fail instantly, leaving sandboxes stuck in the `Running` state indefinitely.
  * **Implementation:** Updated [UpdateSandboxTaskAnnotation](file:///usr/local/google/home/barni/workspace/src/github.com/barney-s/gemini-for-kubernetes-development/factory/pkg/sandbox/sandbox.go#L210) to automatically fallback to an independent `context.Background()` with a 15-second timeout when the incoming context is expired or canceled.
* **Missing HTML URL State:** Fix and Agent chore sandboxes were not displaying their PR/Issue URLs under the `PR/ISSUE URL` column because `htmlURL` was not written on creation or updated during PR aliasing.
  * **Implementation:** Modified [EnsureFixSandbox](file:///usr/local/google/home/barni/workspace/src/github.com/barney-s/gemini-for-kubernetes-development/factory/pkg/sandbox/sandbox.go#L13), [EnsureAgentSandbox](file:///usr/local/google/home/barni/workspace/src/github.com/barney-s/gemini-for-kubernetes-development/factory/pkg/sandbox/sandbox.go#L63) and [AliasSandboxToPR](file:///usr/local/google/home/barni/workspace/src/github.com/barney-s/gemini-for-kubernetes-development/factory/pkg/sandbox/sandbox.go#L115) to populate and update the `htmlURL` annotation.

### 2. Task Resiliency (Preventing Aborts on Overseer restart)
* **New `--abort-on-cancel` flag:** Added a persistent root CLI flag `--abort-on-cancel` (defaults to `true`). 
  * **Implementation:** Updated the client's [RunTaskResilient](file:///usr/local/google/home/barni/workspace/src/github.com/barney-s/gemini-for-kubernetes-development/factory/pkg/envd/client.go#L343) function to only kill/abort the task inside the sandbox pod on cancellation if `abortOnCancel` is `true`.
* **Resilient Watch Tasks:** Updated `factory watch` to invoke its child subprocesses with `--abort-on-cancel=false`. Now, if the overseer pod restarts, the tasks inside the sandbox pods continue running.
* **Self-Healing status Check:** Updated the `isSandboxTaskRunning` function inside [watch.go](file:///usr/local/google/home/barni/workspace/src/github.com/barney-s/gemini-for-kubernetes-development/factory/pkg/commands/watch.go#L145) to connect to sandbox pods, check for the presence of the `exit_code` file, and dynamically recover the `Completed`/`Failed` annotations of finished tasks.

### 3. Documentation
* **Comparison Table:** Appended a detailed section to the end of the design doc [resilient-task-execution.md](file:///usr/local/google/home/barni/workspace/src/github.com/barney-s/gemini-for-kubernetes-development/factory/design/resilient-task-execution.md#L93) contrasting `--background`, `--detached`, and `--abort-on-cancel` execution semantics.