### PR TITLE
feat(overseer): support remote workflows and rich issue/PR prompt context

### DIFF
--- a/.agents/workflows/kcc-example.txt
+++ b/.agents/workflows/kcc-example.txt
@@ -36,7 +36,16 @@ Only proceed to the next step once the PR for the current step is merged success
    ```bash
    gh issue edit ${SESSION_ID#issue-} --body "<updated_body>"
    ```
-   The updated body should reflect the current progress table, step status, and any active PR/Issue links.
+   If editing the issue description fails (due to write permissions on public repositories), **fall back to updating a comment**:
+   * Search the comments on the issue for an existing comment posted by yourself (`factorybot-robot`) that contains the text `Migration Progress`.
+   * If such a comment exists, edit it with the updated progress using:
+     ```bash
+     gh issue comment edit <comment-id> --body "<updated_comment_body>"
+     ```
+   * If no such comment exists, create a new comment:
+     ```bash
+     gh issue comment create ${SESSION_ID#issue-} --body "<updated_comment_body>"
+     ```
 4. Once all steps of the migration for the resource kind are successfully completed and verified merged, update the parent issue description to show completion, and close the parent issue:
    ```bash
    gh issue close ${SESSION_ID#issue-}

--- a/.agents/workflows/kcc-example.txt
+++ b/.agents/workflows/kcc-example.txt
@@ -1,13 +1,13 @@
 ---
-name: checklist-for-kind
 description: A meta-skill for KCC kinds that describes the steps we need to take to get them to be "production ready" direct controllers at v1beta1 at least.
-schedule: "@weekly"
+name: checklist-for-kind
+schedule: never
 mode: workflow
 ---
 
 # Checklist for KCC Resource Kind Migration
 
-This is a meta-skill describing the steps to migrate a KCC resource kind to a production-ready direct controller at `v1beta1` (or higher).
+This is a meta-skill describinsg the steps to migrate a KCC resource kind to a production-ready direct controller at `v1beta1` (or higher).
 
 Instead of doing the coding yourself under this skill, you will coordinate and orchestrate:
 1. Planning the migration steps.
@@ -32,13 +32,15 @@ The journal should contain:
 
 Only proceed to the next step once the PR for the current step is merged successfully.
 
-### Visual Dashboard
-
-To compile and update the visual HTML dashboard of all tracked resource migration pipelines, run the Python generator script:
-```bash
-python3 .agents/workflows/checklist-for-kind/scripts/generate_dashboard.py
-```
-This generates the dashboard at `.agents/workflows/checklist-for-kind/journal/migration_dashboard.html` and copies it to the App Data directory so it is viewable as an HTML artifact.
+3. In addition to the local journal file, **update the parent issue description** (using the issue ID/number extracted from `${SESSION_ID#issue-}`) using the `gh` CLI:
+   ```bash
+   gh issue edit ${SESSION_ID#issue-} --body "<updated_body>"
+   ```
+   The updated body should reflect the current progress table, step status, and any active PR/Issue links.
+4. Once all steps of the migration for the resource kind are successfully completed and verified merged, update the parent issue description to show completion, and close the parent issue:
+   ```bash
+   gh issue close ${SESSION_ID#issue-}
+   ```
 
 ## Steps
 

--- a/factory/pkg/commands/agent.go
+++ b/factory/pkg/commands/agent.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strconv"
@@ -148,7 +149,13 @@ func RunAgent(ctx context.Context, flags AgentFlags, ephemeralStorage string, se
 	// Get agent definition
 	var content []byte
 	agentPath := flags.Agent
-	if flags.Local {
+	if strings.HasPrefix(agentPath, "http://") || strings.HasPrefix(agentPath, "https://") {
+		fmt.Printf("Fetching agent definition from URL: %s...\n", agentPath)
+		content, err = fetchWorkflowContent(ctx, ghClient, agentPath)
+		if err != nil {
+			return fmt.Errorf("fetching agent from URL %s: %w", agentPath, err)
+		}
+	} else if flags.Local {
 		fmt.Printf("Loading local agent definition: %s...\n", agentPath)
 		content, err = os.ReadFile(agentPath)
 		if err != nil {
@@ -358,4 +365,59 @@ func Slugify(s string) string {
 		}
 	}
 	return res.String()
+}
+
+func parseGitHubURL(urlStr string) (owner, repo, branch, path string, ok bool) {
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return "", "", "", "", false
+	}
+	if u.Host != "github.com" {
+		return "", "", "", "", false
+	}
+	parts := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
+	if len(parts) < 4 || (parts[2] != "blob" && parts[2] != "raw") {
+		return "", "", "", "", false
+	}
+	owner = parts[0]
+	repo = parts[1]
+	branch = parts[3]
+	path = strings.Join(parts[4:], "/")
+	return owner, repo, branch, path, true
+}
+
+func fetchWorkflowContent(ctx context.Context, ghClient *githubv39.Client, urlStr string) ([]byte, error) {
+	if owner, repo, branch, path, ok := parseGitHubURL(urlStr); ok {
+		klog.Infof("Fetching agent from GitHub repository %s/%s at branch/ref %s, path %s", owner, repo, branch, path)
+		fileContent, _, _, err := ghClient.Repositories.GetContents(ctx, owner, repo, path, &githubv39.RepositoryContentGetOptions{Ref: branch})
+		if err != nil {
+			return nil, fmt.Errorf("fetching content from GitHub repo: %w", err)
+		}
+		contentStr, err := fileContent.GetContent()
+		if err != nil {
+			return nil, fmt.Errorf("decoding GitHub content: %w", err)
+		}
+		return []byte(contentStr), nil
+	}
+
+	klog.Infof("Fetching agent from HTTP URL %s", urlStr)
+	req, err := http.NewRequestWithContext(ctx, "GET", urlStr, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP GET request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP GET returned status %d", resp.StatusCode)
+	}
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(resp.Body); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }

--- a/factory/pkg/commands/agent.go
+++ b/factory/pkg/commands/agent.go
@@ -131,13 +131,24 @@ func RunAgent(ctx context.Context, flags AgentFlags, ephemeralStorage string, se
 
 	var prNum int
 	isPR := false
+	isIssue := false
+	targetNum := 0
 	cloneURL := fmt.Sprintf("https://github.com/%s/%s.git", owner, repo)
 
-	if len(parts) >= 4 && parts[2] == "pull" {
-		isPR = true
-		prNum, err = strconv.Atoi(parts[3])
-		if err != nil {
-			return fmt.Errorf("invalid PR number in URL: %s", parts[3])
+	if len(parts) >= 4 {
+		if parts[2] == "pull" {
+			isPR = true
+			targetNum, err = strconv.Atoi(parts[3])
+			if err != nil {
+				return fmt.Errorf("invalid PR number in URL: %s", parts[3])
+			}
+			prNum = targetNum
+		} else if parts[2] == "issues" {
+			isIssue = true
+			targetNum, err = strconv.Atoi(parts[3])
+			if err != nil {
+				return fmt.Errorf("invalid issue number in URL: %s", parts[3])
+			}
 		}
 	}
 
@@ -202,7 +213,9 @@ func RunAgent(ctx context.Context, flags AgentFlags, ephemeralStorage string, se
 	if flags.SessionID != "" {
 		taskID = fmt.Sprintf("%s-%s", taskID, flags.SessionID)
 	} else if isPR {
-		taskID = fmt.Sprintf("pr-%d-%s", prNum, taskID)
+		taskID = fmt.Sprintf("pr-%d-%s", targetNum, taskID)
+	} else if isIssue {
+		taskID = fmt.Sprintf("issue-%d-%s", targetNum, taskID)
 	}
 	taskTitle := fmt.Sprintf("Agent: %s", agentDef.Name)
 
@@ -226,12 +239,40 @@ func RunAgent(ctx context.Context, flags AgentFlags, ephemeralStorage string, se
 	}
 	defer client.Close()
 
+	var prompt string
+	if isPR || isIssue {
+		fmt.Printf("Fetching details for #%d from GitHub...\n", targetNum)
+		issue, _, err := ghClient.Issues.Get(ctx, owner, repo, targetNum)
+		if err != nil {
+			return fmt.Errorf("fetching issue/PR details: %w", err)
+		}
+
+		fmt.Printf("Fetching comments for #%d from GitHub...\n", targetNum)
+		comments, _, err := ghClient.Issues.ListComments(ctx, owner, repo, targetNum, &githubv39.IssueListCommentsOptions{})
+		if err != nil {
+			return fmt.Errorf("fetching comments: %w", err)
+		}
+		var commentMsgs []string
+		for _, c := range comments {
+			commentMsgs = append(commentMsgs, fmt.Sprintf("Comment from %s:\n%s", c.GetUser().GetLogin(), c.GetBody()))
+		}
+
+		prompt = fmt.Sprintf("%s\n\nOriginal GitHub Context:\nTitle: %s\n\nDescription:\n%s\n\nComments:\n%s",
+			agentDef.Prompt,
+			issue.GetTitle(),
+			issue.GetBody(),
+			strings.Join(commentMsgs, "\n\n"),
+		)
+	} else {
+		prompt = agentDef.Prompt
+	}
+
 	taskDir := fmt.Sprintf("/workspaces/tasks/agent-%s-%s", Slugify(agentDef.Name), time.Now().Format("20060102-150405"))
 	promptPath := fmt.Sprintf("%s/agent-prompt.txt", taskDir)
 	scriptPath := fmt.Sprintf("%s/pre-script.sh", taskDir)
 
 	params := tasks.AgentParams{
-		AgentPrompt: agentDef.Prompt,
+		AgentPrompt: prompt,
 		AgentName:   agentDef.Name,
 		AgentFile:   agentPath,
 		RepoName:    repo,

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -284,9 +284,16 @@ func getPRPriority(prIssue *githubv39.Issue) string {
 	return getIssuePriority(prIssue)
 }
 
+var workflowURLRegex = regexp.MustCompile(`(?:\s|^)(https?://[^\s\)]+(?:\.(?:md|txt|yaml)|/(?:workflows|agents)/)[^\s\)]*)`)
+
 var workflowFileRegex = regexp.MustCompile(`(?:\s|^)(\.?\.?/?(?:\.?agents?|\.gemini)/[a-zA-Z0-9_\-\./]+)\b`)
 
 func findWorkflowPath(body string) string {
+	urlMatch := workflowURLRegex.FindStringSubmatch(body)
+	if len(urlMatch) > 1 {
+		return strings.TrimSpace(urlMatch[1])
+	}
+
 	matches := workflowFileRegex.FindStringSubmatch(body)
 	if len(matches) > 1 {
 		return matches[1]
@@ -295,6 +302,10 @@ func findWorkflowPath(body string) string {
 }
 
 func isWorkflowDefinition(ctx context.Context, ghClient *githubv39.Client, owner, repo, path string) bool {
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		return true
+	}
+
 	// 1. Directory convention: any path containing "/workflows/" is treated as a workflow
 	if strings.Contains(path, "/workflows/") {
 		return true

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -303,7 +303,27 @@ func findWorkflowPath(body string) string {
 
 func isWorkflowDefinition(ctx context.Context, ghClient *githubv39.Client, owner, repo, path string) bool {
 	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
-		return true
+		// 1. Path/URL convention check
+		if strings.Contains(path, "/workflows/") || strings.Contains(path, "/agents/") {
+			return true
+		}
+
+		// 2. Download and verify headers
+		content, err := fetchWorkflowContent(ctx, ghClient, path)
+		if err != nil {
+			klog.V(4).Infof("Failed to fetch content from workflow URL %s: %v", path, err)
+			return false
+		}
+
+		limit := 2000
+		if len(content) < limit {
+			limit = len(content)
+		}
+		header := string(content[:limit])
+		if strings.Contains(header, "mode: workflow") || strings.Contains(header, "mode: \"workflow\"") || strings.Contains(header, "AGENT_MODE=workflow") {
+			return true
+		}
+		return false
 	}
 
 	// 1. Directory convention: any path containing "/workflows/" is treated as a workflow

--- a/factory/pkg/tasks/run_agent.sh
+++ b/factory/pkg/tasks/run_agent.sh
@@ -237,11 +237,17 @@ function runAgent {
             (cd "/workspaces/${REPO_NAME}" && git merge --abort 2>/dev/null || true)
             (cd "/workspaces/${REPO_NAME}" && git cherry-pick --abort 2>/dev/null || true)
             (cd "/workspaces/${REPO_NAME}" && git reset --hard HEAD && git clean -fd)
-            (cd "/workspaces/${REPO_NAME}" && git checkout "${BRANCH_NAME}" -- || git checkout -b "${BRANCH_NAME}")
-            if (cd "/workspaces/${REPO_NAME}" && git ls-remote --heads origin "${BRANCH_NAME}" | grep -q "refs/heads/${BRANCH_NAME}"); then
+            (cd "/workspaces/${REPO_NAME}" && git fetch origin)
+            if (cd "/workspaces/${REPO_NAME}" && git show-ref --verify --quiet "refs/heads/${BRANCH_NAME}"); then
+                echo "Local branch ${BRANCH_NAME} already exists. Checking out and pulling latest..."
+                (cd "/workspaces/${REPO_NAME}" && git checkout "${BRANCH_NAME}")
                 (cd "/workspaces/${REPO_NAME}" && git pull origin "${BRANCH_NAME}")
+            elif (cd "/workspaces/${REPO_NAME}" && git ls-remote --heads origin "${BRANCH_NAME}" | grep -q "refs/heads/${BRANCH_NAME}"); then
+                echo "Remote branch ${BRANCH_NAME} exists. Checking out with tracking..."
+                (cd "/workspaces/${REPO_NAME}" && git checkout -b "${BRANCH_NAME}" --track "origin/${BRANCH_NAME}")
             else
-                echo "Remote branch ${BRANCH_NAME} does not exist on origin yet. Skipping pull."
+                echo "Remote branch ${BRANCH_NAME} does not exist on origin yet. Creating new branch..."
+                (cd "/workspaces/${REPO_NAME}" && git checkout -b "${BRANCH_NAME}")
             fi
         else
             SLUGIFIED_NAME=$(echo "${AGENT_NAME}" | tr '[:upper:]' '[:lower:]' | tr -c '[:alnum:]' '-' | sed 's/^-//;s/-$//')

--- a/factory/pkg/tasks/run_agent.sh
+++ b/factory/pkg/tasks/run_agent.sh
@@ -303,11 +303,11 @@ function runAgent {
     for MODEL in $MODELS_LIST; do
         echo "Trying model: $MODEL"
         if [ "${DRY_RUN:-false}" = "true" ]; then
-            echo "[dry-run] Would run: gemini --yolo --model \"$MODEL\" ${RESUME_FLAG} --output-format json < \"${PROMPT_FILE}\""
+            echo "[dry-run] Would run: gemini --yolo --model \"$MODEL\" ${RESUME_FLAG} --include-directories \"$(dirname "${PROMPT_FILE}")\" --output-format json < \"${PROMPT_FILE}\""
             SUCCESS=true
             break
         fi
-        if gemini --yolo --model "$MODEL" ${RESUME_FLAG} --output-format json < "${PROMPT_FILE}" > "$(dirname "${PROMPT_FILE}")/gemini-output.json"; then
+        if gemini --yolo --model "$MODEL" ${RESUME_FLAG} --include-directories "$(dirname "${PROMPT_FILE}")" --output-format json < "${PROMPT_FILE}" > "$(dirname "${PROMPT_FILE}")/gemini-output.json"; then
             echo "Gemini execution successful with model: $MODEL"
             SUCCESS=true
             break

--- a/overseer/images/overseer/run.sh
+++ b/overseer/images/overseer/run.sh
@@ -222,6 +222,8 @@ function runWatchCycle {
     if git remote | grep -q "^upstream$"; then
         REMOTE_MAIN="upstream"
     fi
+    git reset --hard HEAD || true
+    git clean -fd || true
     git checkout $DEFAULT_BRANCH -- || git checkout -b $DEFAULT_BRANCH
     git fetch $REMOTE_MAIN
     git reset --hard $REMOTE_MAIN/$DEFAULT_BRANCH


### PR DESCRIPTION
### 1. Remote Workflows Support
*   **Remote URL Fetching ([agent.go](file:///usr/local/google/home/barni/workspace/src/github.com/barney-s/gemini-for-kubernetes-development/factory/pkg/commands/agent.go#L380-L424))**: Added support inside `factory agent` to download workflow definitions directly from remote HTTP/HTTPS URLs, including smart resolution of GitHub blob/raw links via authenticated API requests or generic HTTP fallback.
*   **Workflow Verification ([watch.go](file:///usr/local/google/home/barni/workspace/src/github.com/barney-s/gemini-for-kubernetes-development/factory/pkg/commands/watch.go#L295-L330))**: Enhanced the issue/PR scanner watcher to automatically download and inspect the first 2KB of any referenced URL to verify it contains the `mode: workflow` header before parsing it as a workflow.

### 2. Prompt Context Enrichment
*   **Enriched Issue/PR Context ([agent.go](file:///usr/local/google/home/barni/workspace/src/github.com/barney-s/gemini-for-kubernetes-development/factory/pkg/commands/agent.go#L241-L268))**: Updated the prompt compiler to fetch the original GitHub Issue/PR Title, Description Body, and Comments, appending them as a rich markdown context prefix inside the compiled prompt so the workflow agent knows exactly what resource/problem to target.

### 3. Bootstrap & Git Reliability Fixes
*   **Divergent Branch Checkout Fix ([run_agent.sh](file:///usr/local/google/home/barni/workspace/src/github.com/barney-s/gemini-for-kubernetes-development/factory/pkg/tasks/run_agent.sh#L240-L251))**: Overhauled the branch setup logic inside the sandbox bootstrap. It now properly detects whether the target branch exists locally, exists only on the remote fork (configuring `--track origin/factory`), or needs new branch creation—fully resolving git divergent pull aborts.
*   **Dirty State Checkout Crash Recovery ([run.sh](file:///usr/local/google/home/barni/workspace/src/github.com/barney-s/gemini-for-kubernetes-development/overseer/images/overseer/run.sh#L225-L226))**: Added local state cleanup (`git reset --hard HEAD` and `git clean -fd`) inside the controller's bootstrap sequence before checking out branches to prevent `overseer-kcc` container crashes when local tracking files are dirty on container restarts.

### 4. Workflow Orchestration Progress Dashboard
*   **Comment Reuse and Updates ([kcc-example.txt](file:///usr/local/google/home/barni/workspace/src/github.com/barney-s/gemini-for-kubernetes-development/.agents/workflows/kcc-example.txt#L35-L48))**: Refined the orchestration instructions. If description edits fail (due to repo write permissions), the agent is instructed to find its existing progress dashboard comment and update it via `gh issue comment edit` rather than appending duplicate comment rows.