### PR TITLE
feat(watch): implement task timeouts, self-healing sandbox recovery, and branch isolation

### DIFF
--- a/.agents/workflows/kcc-example.txt
+++ b/.agents/workflows/kcc-example.txt
@@ -11,7 +11,7 @@ This is a meta-skill describing the steps to migrate a KCC resource kind to a pr
 
 Instead of doing the coding yourself under this skill, you will coordinate and orchestrate:
 1. Planning the migration steps.
-2. Opening GitHub issues for each step and assigning them to `factorybot-robot`.
+2. Opening GitHub issues for each step, labeling them with `overseer`, and assigning them to `factorybot-robot`.
 3. Monitoring progress of the Pull Requests.
    * **Requesting PR changes**: If you need `factorybot-robot` to make changes to an open PR (such as rebasing it on master after dependent changes are merged, or addressing review feedback), you can comment directly on the PR outlining the required changes and reassign it back to `factorybot-robot` by adding `/assign factorybot-robot` in your comment.
 4. Opening subsequent issues once the prior steps are successfully completed.
@@ -51,6 +51,17 @@ Only proceed to the next step once the PR for the current step is merged success
    gh issue close ${SESSION_ID#issue-}
    ```
 
+### Verifying PR CI Checks Status
+When checking if all CI check-runs have passed for a pull request, do NOT rely on a single unpaginated `gh api .../check-runs` call (since GitHub defaults to 30 items per page and might hide failing runs). Instead, use the `--paginate` option to ensure all runs are checked:
+```bash
+gh api repos/GoogleCloudPlatform/k8s-config-connector/commits/<head-sha>/check-runs --paginate --jq '.check_runs[] | select(.conclusion != "success" and .conclusion != "neutral" and .conclusion != "skipped") | {name: .name, conclusion: .conclusion}'
+```
+Or check via GitHub CLI:
+```bash
+gh pr checks <pr-number> --repo GoogleCloudPlatform/k8s-config-connector
+```
+Only declare the PR as fully passed/verified if no failures are returned across all pages of checks.
+
 ## Steps
 
 
@@ -66,6 +77,7 @@ The resource must have a direct KRM type (`_types.go`) scaffolded and updated vi
 **GitHub Issue Details for Greenfield Resource:**
 *   **Title:** `Implement direct KRM types and generate.sh for {kind}`
 *   **Assignee:** `factorybot-robot`
+*   **Labels:** `overseer`
 *   **Body:**
     ```
     Please follow the skill .gemini/skills/kcc-direct-greenfield-types-implementer/SKILL.md for {kind}.
@@ -80,6 +92,7 @@ The resource must have a direct KRM type (`_types.go`) scaffolded and updated vi
 **GitHub Issue Details for Existing Terraform/DCL Resource:**
 *   **Title:** `Implement direct KRM types and generate.sh for {kind}`
 *   **Assignee:** `factorybot-robot`
+*   **Labels:** `overseer`
 *   **Body:**
     ```
     Please follow the skill .gemini/skills/crd-mapper-fuzzer-existing-type/SKILL.md for {kind}.
@@ -101,6 +114,7 @@ The resource kind must have an identity and reference type that follow our canon
 **GitHub Issue Details:**
 *   **Title:** `Move {kind} to identity and refs pattern`
 *   **Assignee:** `factorybot-robot`
+*   **Labels:** `overseer`
 *   **Body:**
     ```
     Please follow the skill .gemini/skills/kcc-identity-reference/SKILL.md for {kind}
@@ -117,6 +131,7 @@ For existing resources transitioning to a direct controller, a round-trip KRM fu
 **GitHub Issue Details:**
 *   **Title:** `Implement round-trip KRM fuzzer for {kind}`
 *   **Assignee:** `factorybot-robot`
+*   **Labels:** `overseer`
 *   **Body:**
     ```
     Please follow the skill .gemini/skills/create-fuzzer/skill.md to implement a round-trip KRM fuzzer for {kind}.
@@ -135,6 +150,7 @@ The direct controller must be implemented to manage reconciliation logic (Adapte
 **GitHub Issue Details:**
 *   **Title:** `Implement direct controller and E2E fixtures for {kind}`
 *   **Assignee:** `factorybot-robot`
+*   **Labels:** `overseer`
 *   **Body:**
     ```
     Please follow the skills:

--- a/.agents/workflows/kcc-example.txt
+++ b/.agents/workflows/kcc-example.txt
@@ -7,7 +7,7 @@ mode: workflow
 
 # Checklist for KCC Resource Kind Migration
 
-This is a meta-skill describinsg the steps to migrate a KCC resource kind to a production-ready direct controller at `v1beta1` (or higher).
+This is a meta-skill describing the steps to migrate a KCC resource kind to a production-ready direct controller at `v1beta1` (or higher).
 
 Instead of doing the coding yourself under this skill, you will coordinate and orchestrate:
 1. Planning the migration steps.

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -43,6 +43,7 @@ type WatchFlags struct {
 	PRMode       string
 	ChoresMode   string
 	ScanLimit    int
+	TaskTimeout  time.Duration
 }
 
 func NewWatchCommand(ctx context.Context) *cobra.Command {
@@ -98,7 +99,7 @@ func NewWatchCommand(ctx context.Context) *cobra.Command {
 				choresMode = "enabled"
 			}
 
-			return runWatch(ctx, parts[0], parts[1], flags.PollInterval, flags.Assignee, cmd.Flags().Changed("assignee"), flags.Labels, flags.DryRun, flags.WatchTimeout, flags.MaxActions, flags.MaxPending, flags.Mode, flags.QueueDir, flags.Once, issueMode, prMode, choresMode, rootFlags.EphemeralStorage, rootFlags.ResolvedSecrets, flags.ScanLimit)
+			return runWatch(ctx, parts[0], parts[1], flags.PollInterval, flags.Assignee, cmd.Flags().Changed("assignee"), flags.Labels, flags.DryRun, flags.WatchTimeout, flags.MaxActions, flags.MaxPending, flags.Mode, flags.QueueDir, flags.Once, issueMode, prMode, choresMode, rootFlags.EphemeralStorage, rootFlags.ResolvedSecrets, flags.ScanLimit, flags.TaskTimeout)
 		},
 	}
 
@@ -117,6 +118,7 @@ func NewWatchCommand(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringVar(&flags.PRMode, "pr-mode", "", "PR mode: enabled or disabled (defaults to PR_MODE env or enabled)")
 	cmd.Flags().StringVar(&flags.ChoresMode, "chores-mode", "", "Chores mode: enabled or disabled (defaults to CHORES_MODE env or enabled)")
 	cmd.Flags().IntVar(&flags.ScanLimit, "scan-limit", 100, "Maximum number of issues/PRs to fetch from GitHub API in a scan cycle")
+	cmd.Flags().DurationVar(&flags.TaskTimeout, "task-timeout", 3*time.Hour, "Timeout for each task execution (default 3h)")
 
 	return cmd
 }
@@ -630,7 +632,7 @@ func writeTaskJournalEvent(queueDir string, taskFilename string, task *QueueTask
 	}
 }
 
-func runWatch(ctx context.Context, owner, repo string, interval time.Duration, assignee string, assigneeChanged bool, labels []string, dryRun bool, watchTimeout time.Duration, maxActions int, maxPending int, mode string, queueDir string, once bool, issueMode string, prMode string, choresMode string, ephemeralStorage string, secrets []factorysandbox.SecretMount, scanLimit int) error {
+func runWatch(ctx context.Context, owner, repo string, interval time.Duration, assignee string, assigneeChanged bool, labels []string, dryRun bool, watchTimeout time.Duration, maxActions int, maxPending int, mode string, queueDir string, once bool, issueMode string, prMode string, choresMode string, ephemeralStorage string, secrets []factorysandbox.SecretMount, scanLimit int, taskTimeout time.Duration) error {
 	cfg, err := config.LoadConfig()
 	if err != nil {
 		klog.Warningf("Failed to load factory config: %v", err)
@@ -1419,6 +1421,9 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 					fmt.Printf("Starting task %s (Type: %s, URL: %s)...\n", taskFilename, t.Type, t.URL)
 					startTime := time.Now()
 
+					taskCtx, taskCancel := context.WithTimeout(ctx, taskTimeout)
+					defer taskCancel()
+
 					if t.Number > 0 {
 						if (t.Type == "issue-fix" || t.Type == "agent-chore") && t.Assignee != "" {
 							klog.Infof("Assigning issue #%d to %s as claimed", t.Number, t.Assignee)
@@ -1492,7 +1497,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 					}
 					args = append(args, "--abort-on-cancel=false")
 
-					cmd := exec.Command(executable, args...)
+					cmd := exec.CommandContext(taskCtx, executable, args...)
 
 					logFilename := strings.TrimSuffix(taskFilename, ".yaml") + ".log"
 					processingLogPath := filepath.Join(processingLogDir, logFilename)
@@ -1518,6 +1523,35 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 						t.Status = "Failed"
 						t.Error = taskErr.Error()
 						writeTaskJournalEvent(queueDir, taskFilename, t, "Failed", duration)
+
+						// Force clean up sandbox if the task timed out
+						if taskCtx.Err() == context.DeadlineExceeded {
+							var sandboxName string
+							switch t.Type {
+							case "issue-fix":
+								if t.SessionID != "" {
+									sandboxName = fmt.Sprintf("wf-issue-%d", t.Number)
+								} else {
+									sandboxName = fmt.Sprintf("fix-%s-%d", repo, t.Number)
+								}
+							case "agent-chore":
+								if t.SessionID != "" {
+									sandboxName = fmt.Sprintf("wf-issue-%d", t.Number)
+								} else {
+									sandboxName = fmt.Sprintf("agent-%s-%d", repo, t.Number)
+								}
+							case "pr-investigate", "pr-comments", "pr-iterate", "pr-review":
+								sandboxName = fmt.Sprintf("factory-pr-%d", t.Number)
+							}
+
+							if sandboxName != "" {
+								klog.Warningf("Task %s timed out after %s! Force cleaning up sandbox '%s'...", taskFilename, taskTimeout, sandboxName)
+								manager := k8s.NewManager(kubeClient)
+								if err := manager.DeleteSandbox(ctx, rootFlags.Namespace, sandboxName); err != nil {
+									klog.Errorf("Failed to delete sandbox '%s' on timeout: %v", sandboxName, err)
+								}
+							}
+						}
 					} else {
 						fmt.Printf("Task %s completed successfully.\n", taskFilename)
 						t.Status = "Completed"
@@ -1562,8 +1596,17 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 			state.mu.Unlock()
 
 			fmt.Println("Waiting for active tasks to complete...")
-			wg.Wait()
-			fmt.Println("All tasks completed. Exiting.")
+			doneChan := make(chan struct{})
+			go func() {
+				wg.Wait()
+				close(doneChan)
+			}()
+			select {
+			case <-doneChan:
+				fmt.Println("All tasks completed. Exiting.")
+			case <-time.After(2 * time.Minute):
+				fmt.Println("Timeout waiting for active tasks to complete. Exiting.")
+			}
 			return nil
 		case <-time.After(10 * time.Second):
 			checkRepo()

--- a/factory/pkg/tasks/investigate_failures.txt
+++ b/factory/pkg/tasks/investigate_failures.txt
@@ -36,15 +36,23 @@ Below are the existing comments on the PR since the last commit. Look for "### I
    - Check if the code changes in the PR are related to the failure.
    - Distinguish between code errors, test failures, linting issues, and infrastructure flakes.
 
-3. **Fix Issues (if applicable)**:
-   - If the failure is caused by the code in the PR, attempt to fix it.
-   - Make code changes, run tests (if you can verify locally), and commit the changes.
-   - **Maintain a clean commit history:**
-     - Structure your commits well, separating out changes to different modules or generated code into separate commits.
-     - Commits must be relevant and cleanly encapsulate the stated changes. Avoid creating excessive, tiny, or transient commits. Use `git commit --amend` or `git commit --fixup` when applying minor fixes to previous work.
-     - **Prefer rebases:** Always prefer rebasing (e.g., `git rebase` or `git pull --rebase`) over merging/pulling in commits from upstream and re-writing or co-authoring them.
-     - **Introspection Litmus Test:** Before finalizing or updating your Pull Request, perform a self-check. If your PR contains a large number of commits (e.g., more than 10, 20, or 30 commits) or touches hundreds of files, you MUST stop and introspect: *Am I following the instructions to maintain a clean commit history? Do I need to rebase or squash my commits to clean this up?* If needed, perform a rebase or squash to keep the history clean and readable.
-   - If the failure is a flake or infrastructure issue, DO NOT change the code.
+3. **Fix or Rerun Issues (if applicable)**:
+   - If the failure is caused by the code in the PR, attempt to fix it:
+     - Make code changes, run tests (if you can verify locally), and commit the changes.
+     - **Maintain a clean commit history:**
+       - Structure your commits well, separating out changes to different modules or generated code into separate commits.
+       - Commits must be relevant and cleanly encapsulate the stated changes. Avoid creating excessive, tiny, or transient commits. Use `git commit --amend` or `git commit --fixup` when applying minor fixes to previous work.
+       - **Prefer rebases:** Always prefer rebasing (e.g., `git rebase` or `git pull --rebase`) over merging/pulling in commits from upstream and re-writing or co-authoring them.
+       - **Introspection Litmus Test:** Before finalizing or updating your Pull Request, perform a self-check. If your PR contains a large number of commits (e.g., more than 10, 20, or 30 commits) or touches hundreds of files, you MUST stop and introspect: *Am I following the instructions to maintain a clean commit history? Do I need to rebase or squash my commits to clean this up?* If needed, perform a rebase or squash to keep the history clean and readable.
+   - If the failure is a flake or infrastructure issue (NOT caused by code changes in the PR):
+     - DO NOT change the code.
+     - Try to rerun the failed workflow run using the GitHub CLI:
+       ```bash
+       gh run rerun <run-id> --failed
+       ```
+       (If the `--failed` flag is not supported by the CLI version, fallback to `gh run rerun <run-id>` to rerun the entire workflow run).
+     - If it is a Prow / repository status check (without a run-id), trigger a rerun by commenting on the PR (e.g. `/retest` or `/test <job-name>`).
+     - In your report comment, state that you triggered a rerun and explain why you believe it is a flake.
 
 4. **Report**:
    - Provide a summary of your investigation.
@@ -59,7 +67,7 @@ Below are the existing comments on the PR since the last commit. Look for "### I
    Name: `[Name]`
    Cause: `[Code Error / Test Failure / Flake / Infrastructure]`
    Details: [Explanation of the failure]
-   Action Taken: [Fix applied / None]
+   Action Taken: [Fix applied / Rerun triggered / None]
    ```
 
 5. **Respond on GitHub**:

--- a/factory/pkg/tasks/run_agent.sh
+++ b/factory/pkg/tasks/run_agent.sh
@@ -69,6 +69,9 @@ EOF
     echo "running gh auth setup-git"
     gh auth setup-git
 
+    echo "Configuring git pull rebase"
+    git config --global pull.rebase true
+
     echo "Configuring global git ignore"
     git config --global core.excludesfile "${HOME}/.gitignore_global"
     cat <<EOF > "${HOME}/.gitignore_global"
@@ -231,8 +234,12 @@ function runAgent {
             echo "SkipPR is true. Running on default branch ${BASE_BRANCH}"
             BRANCH_NAME="${BASE_BRANCH}"
         elif [ "$AGENT_MODE" = "workflow" ]; then
-            echo "Agent mode is workflow. Checking out factory branch..."
-            BRANCH_NAME="factory"
+            if [ -n "$SESSION_ID" ] && [[ "$SESSION_ID" == issue-* ]]; then
+                BRANCH_NAME="factory-${SESSION_ID#issue-}"
+            else
+                BRANCH_NAME="factory"
+            fi
+            echo "Agent mode is workflow. Checking out branch ${BRANCH_NAME}..."
             (cd "/workspaces/${REPO_NAME}" && git rebase --abort 2>/dev/null || true)
             (cd "/workspaces/${REPO_NAME}" && git merge --abort 2>/dev/null || true)
             (cd "/workspaces/${REPO_NAME}" && git cherry-pick --abort 2>/dev/null || true)

--- a/factory/pkg/tasks/run_agent.sh
+++ b/factory/pkg/tasks/run_agent.sh
@@ -128,6 +128,17 @@ EOF
 
 function commitChanges {
     if [ "$AGENT_MODE" = "workflow" ]; then
+        if [ -n "$SESSION_ID" ] && [[ "$SESSION_ID" == issue-* ]]; then
+            ISSUE_NUM="${SESSION_ID#issue-}"
+            ISSUE_STATE=$(gh issue view "${ISSUE_NUM}" --json state --jq .state 2>/dev/null || echo "OPEN")
+            if [ "${ISSUE_STATE}" = "CLOSED" ]; then
+                echo "Parent issue #${ISSUE_NUM} is closed. Deleting remote branch ${BRANCH_NAME}..."
+                git push origin --delete "${BRANCH_NAME}" || true
+                echo "Cleaned up remote branch for completed workflow." > "$(dirname "${PROMPT_FILE}")/agent-output.txt"
+                return
+            fi
+        fi
+
         if [ -n "$(git status --porcelain)" ]; then
             echo "Committing workflow changes..."
             git add .


### PR DESCRIPTION
### 1. Robustness & Self-Healing Watch Daemon
*   **Graceful Watch Timeout**: Added a 2-minute timeout to `wg.Wait()` on shutdown, preventing the daemon from hanging indefinitely if background tasks get stuck.
*   **Task Subprocess Timeout**: Added a configurable `--task-timeout` flag to `factory watch` (defaulting to **3 hours**), executing task commands with `CommandContext` to cleanly terminate them if they exceed this limit.
*   **Automated Sandbox Recovery**: When a task times out (indicating a frozen/corrupted environment), `watch.go` automatically triggers a force deletion of the sandbox CR. This allows the next scheduled retry loop to spin up a clean sandbox from scratch.

### 2. Isolate Git Workflows & Automated Cleanups
*   **Isolated Git Branching**: Configured `run_agent.sh` to dynamically isolate Git branches per issue/session (e.g. `factory-{issue_num}`) rather than sharing a single branch.
*   **Pull Rebase Mode**: Enabled `pull.rebase true` by default inside the sandboxes to avoid merge conflict failures during Git synchronizations.
*   **Clean Up Remote Branches**: Added automatic deletion of remote tracking branches (`git push origin --delete`) once their parent issue changes state to `CLOSED`.

### 3. Orchestration Workflow Improvements
*   **Issue Tracking Activation**: Updated the KCC checklist workflow to instruct the orchestrator agent to apply the `overseer` label to all created GitHub issues. This ensures the watch daemon successfully picks them up.
*   **PR Check Pagination Fix**: Instructed orchestrator agents to use paginated `gh api` queries or the `gh pr checks` command when verifying PR statuses. This resolves a bug where the agent missed failing checks that fell outside the first page of results (30 items).

### 4. Flake Detection and Automatic Re-Testing
*   **Flake Re-Testing**: Updated the investigator agent instructions to identify tests failing due to environment flakes/infra issues rather than code changes.
*   **GitHub/Prow Rerun Actions**: Instructed the agent to trigger reruns of flaky runs directly via GitHub CLI (`gh run rerun --failed`) or by commenting `/retest` or `/test <job-name>` on the PR.
*   **PR Comment Logs**: Standardized report comments to output `Action Taken: Rerun triggered` so that subsequent cycles pay more attention if the rerun fails again.
