### PR TITLE
redesign adopt to work from sandbox using bot identity

### DIFF
--- a/factory/README.md
+++ b/factory/README.md
@@ -46,7 +46,8 @@ factory
  │    ├── investigate (Investigate CI check failures for a PR in a sandbox)
  │    ├── address-comments (Address review feedback and comments for a PR)
  │    ├── iterate (Iterate on code / resolve merge conflicts for a PR)
- │    └── watch (Continuously monitor a PR for CI failures or new feedback)
+ │    ├── watch (Continuously monitor a PR for CI failures or new feedback)
+ │    └── adopt (Adopt a third-party PR under the bot user identity in a sandbox)
  ├── agent
  │    └── create (Run a custom agent definition in a sandbox)
  ├── watch (Continuously monitor a GitHub repo for failures and assigned issues)
@@ -206,9 +207,6 @@ factory pr review --pr-url https://github.com/owner/repo/pull/1 \
 Spin up a review sandbox to analyze failed CI check logs, review previous investigation comments, and attempt to fix the failure or report root causes. Use `--continue-session` to preserve LLM conversation history across multiple PR operations in the same sandbox:
 ```bash
 factory pr investigate --pr-url https://github.com/owner/repo/pull/1 --continue-session
-
-# Adopt the PR (owned by someone else) and close the original after adopting
-factory pr investigate --pr-url https://github.com/owner/repo/pull/1 --adopt close
 ```
 
 ### Addressing Review Comments (`factory pr address-comments`)
@@ -221,19 +219,29 @@ factory pr address-comments --pr-url https://github.com/owner/repo/pull/1 --cont
 Spin up a sandbox to resolve merge conflicts, rebase, or run manual code iterations:
 ```bash
 factory pr iterate --pr-url https://github.com/owner/repo/pull/1 --prompt "Please rebase onto latest master"
-
-# Adopt the PR before iterating
-factory pr iterate --pr-url https://github.com/owner/repo/pull/1 --adopt open --prompt "Refactor the auth handler"
 ```
 
 ### Watching Pull Requests (`factory pr watch`)
 Continuously monitor a specific PR in the foreground, automatically triggering `investigate` on CI failures or `address-comments` on new review feedback. Use `--continue-session` to ensure all dispatched tasks inherit the ongoing chat session. The watch loop logs explicit sleep intervals and cleanly terminates when the PR is merged, closed, or timeout expires:
 ```bash
 factory pr watch --pr-url https://github.com/owner/repo/pull/1 --watch-timeout 1h --cleanup
-
-# Adopt the PR and watch the adopted PR
-factory pr watch --pr-url https://github.com/owner/repo/pull/1 --adopt close --cleanup
 ```
+
+### Adopting Pull Requests (`factory pr adopt`)
+When collaborating on a shared repository, you often need the bot to work on a PR created by another developer. Since your bot's token cannot push directly to their personal fork, you must "adopt" the PR first. The adopt command runs in a sandbox and forks the base repository under the bot user identity, copies the commits or re-implements them, and opens a new adopted PR on GitHub.
+
+```bash
+# Adopt a PR using the git 'reuse' strategy (git fetch/push to preserve author history) and close the original
+factory pr adopt close --pr-url https://github.com/owner/repo/pull/1 --strategy reuse
+
+# Adopt a PR and leave the original open (linking to the new adopted PR via comment)
+factory pr adopt open --pr-url https://github.com/owner/repo/pull/1 --strategy reuse
+
+# Adopt a PR using the 'reimplement' strategy (LLM-based re-implementation on top of latest master/main) and close original
+factory pr adopt close --pr-url https://github.com/owner/repo/pull/1 --strategy reimplement
+```
+
+**Note**: The legacy `--adopt` flag on other commands (`investigate`, `iterate`, and `watch`) has been removed. Those commands will now fail immediately with a descriptive error if the PR does not belong to the factory bot, requiring you to adopt it first.
 
 ### Running Custom Agents (`factory agent create`)
 Automatically spin up a sandbox, clone the repository (or PR branch), retrieve a custom agent definition file, execute its prompt instructions inside the sandbox, and automatically commit/push/create/update a Pull Request depending on your configuration and whether it was triggered on a PR or a repository:

--- a/factory/design/pr-adopt.md
+++ b/factory/design/pr-adopt.md
@@ -1,0 +1,125 @@
+# Design Note: PR Adoption Workflows (Git-based & LLM-based)
+
+This design note outlines the architecture and execution flow for adopting third-party Pull Requests under the onboarded factory-user identity.
+
+---
+
+## Background & Problem Statement
+
+When the `factory` is used in a collaborative repository, it needs to watch, iterate, or investigate PRs authored by external developers. However:
+1. Standard user tokens/credentials do not have push access to external user forks.
+2. If we try to push changes to the original author's fork branch, GitHub will reject the push with `permission denied`.
+3. To work around this, we must "adopt" the PR first by forking the base repository under the factory-user's account, creating a new branch, pushing the commits there, creating a new PR from the bot's fork, and commenting/closing the original PR.
+4. Performing git operations directly on the developer's local machine tries to use the developer's credentials rather than the bot credentials (which only reside in the Kubernetes namespace secret), resulting in permission failures.
+
+Therefore, the adoption process **must execute entirely inside the sandbox environment** where the correct bot credentials are mounted and configured automatically.
+
+---
+
+## Proposed Architecture: Sandbox-Bound PR Adoption
+
+We implement a dedicated `factory pr adopt` command that handles sandbox scheduling and runs the adoption logic inside it.
+
+We support two adoption strategies:
+1. **`reuse`**: A git-based approach that fetches the original PR history and pushes it directly to the factory-user's fork to preserve history and git authorship.
+2. **`reimplement`**: An LLM-based approach that pulls the latest main/master branch, downloads the original PR diff, and instructs the LLM (Gemini) to use the diff as inspiration/guidelines to re-implement the fix/feature from scratch on top of the latest base.
+
+---
+
+## Execution Flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Developer
+    participant Host as factory (Local Dev Machine)
+    participant Sandbox as adopt-repo-123 (Sandbox Pod)
+    participant Git as GitHub / Git Branch
+
+    Developer->>Host: factory pr adopt close --pr-url https://github.com/owner/repo/pull/123 --strategy reuse
+    Note over Host: Validates PR owner isn't already the bot.<br/>Resolves credentials & namespace.
+    Host->>Sandbox: Spawns Sandbox & mounts bot credentials
+    Host->>Sandbox: Executes "/workspaces/tasks/adopt/pre-script.sh" via envd
+    
+    alt Strategy: reuse
+        Sandbox->>Git: Fork repository under bot account
+        Sandbox->>Git: Fetch original PR's head ref locally
+        Sandbox->>Git: Push branch to bot's fork repository
+        Sandbox->>Git: Create new adopted PR on base repo
+    else Strategy: reimplement
+        Sandbox->>Git: Fork repository under bot account
+        Sandbox->>Git: Fetch original PR's diff and PR description
+        Sandbox->>Sandbox: Run Gemini with prompt + original diff + base branch
+        Sandbox->>Git: Commit and push generated changes to bot's fork
+        Sandbox->>Git: Create new adopted PR on base repo
+    end
+    
+    Sandbox->>Git: Leave comment on original PR #123
+    Sandbox->>Git: Close original PR #123 (since "close" was specified)
+    Sandbox-->>Host: Logs and final adopted PR URL streamed back
+    Host-->>Developer: Prints new adopted PR URL
+```
+
+---
+
+## CLI Command Interface
+
+### `factory pr adopt`
+```bash
+factory pr adopt <open|close> --pr-url <url> [flags]
+```
+
+#### Positional Arguments
+* `<open|close>` (Required): Specifies the post-adoption state action for the original PR.
+  * `open`: Comments on the original PR linking to the new one, but leaves the original open.
+  * `close`: Comments on the original PR, links to the new one, and closes the original PR.
+
+#### Flags
+* `--pr-url <string>` (Required): The URL of the incoming PR to adopt (e.g. `https://github.com/owner/repo/pull/123`).
+* `--strategy <reuse|reimplement>` (String, default: `reuse`):
+  * `reuse`: Direct git fetch/push (preserves commit history).
+  * `reimplement`: Re-apply changes using LLM on the latest base branch.
+* Standard Sandbox configuration flags (e.g., `--namespace`, `--secret-name`, `--workspace-disk-size`, `--image`, `--ephemeral-storage`).
+
+### Reverting `--adopt` flag on other subcommands
+The `--adopt` flag will be removed from `factory pr watch`, `factory pr iterate`, and `factory pr investigate`. These commands will verify ownership of the PR and error out immediately if it does not belong to the factory user:
+```
+PR was not created by the factory user (bot). It is owned by <author>. Use 'factory pr adopt <open|close> --pr-url <url>' to adopt it first.
+```
+
+---
+
+## Task Implementation Inside the Sandbox
+
+We introduce a new task type `adopt` inside `factory/pkg/tasks/`:
+
+### 1. `adopt.sh` (Shell script executed inside sandbox)
+Executes the git and GitHub API steps.
+* Uses the mounted `GITHUB_TOKEN` secret to configure `git credential.helper` and authenticate `gh`.
+* Performs `gh repo fork --remote` to ensure the fork exists under the bot account.
+* If `reuse`:
+  * Fetches the original PR head from upstream.
+  * Pushes the branch to `origin` (the bot's fork).
+  * Creates the new PR using `gh pr create`.
+* If `reimplement`:
+  * Fetches original PR diff (`gh pr diff`).
+  * Runs the `gemini` command passing the prompt template.
+  * Commits and pushes the modified code to the fork.
+  * Creates the new PR.
+* Comments on and optionally closes the original PR.
+* Outputs the new PR URL to `agent-output.txt`.
+
+### 2. `adopt.txt` (LLM prompt template for reimplement strategy)
+```
+You are the PR Adoption agent. We want to adopt a third-party PR under our factory user identity.
+To do this, you should re-apply the changes from the original PR as inspiration, but implement them on top of the latest base branch.
+
+Original PR Title: {{ .Title }}
+Original PR Description:
+{{ .Body }}
+
+Original PR Diff:
+{{ .Diff }}
+
+Please implement the same fix/feature on the current repository, ensuring all tests pass and following the repository's guidelines.
+```

--- a/factory/pkg/commands/pr.go
+++ b/factory/pkg/commands/pr.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -1274,16 +1273,5 @@ func runAdopt(ctx context.Context, prURL, adoptAction, strategy string, ephemera
 		fmt.Printf("\nAdopted PR output:\n%s\n", buf.String())
 	}
 
-	return nil
-}
-
-func runCmd(ctx context.Context, dir string, name string, args ...string) error {
-	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Dir = dir
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to run %s %v: %w (stderr: %s)", name, args, err, stderr.String())
-	}
 	return nil
 }

--- a/factory/pkg/commands/pr.go
+++ b/factory/pkg/commands/pr.go
@@ -1246,22 +1246,21 @@ func runAdopt(ctx context.Context, prURL, adoptAction, strategy string, ephemera
 	fmt.Println("\nAdopt execution completed.")
 
 	var buf bytes.Buffer
+	var createdPRURL string
 	if err := client.Exec(ctx, fmt.Sprintf("cat %s/agent-output.txt", taskDir), "/workspaces", nil, nil, &buf, os.Stderr); err != nil {
 		klog.Warningf("Could not read agent-output.txt: %v", err)
 	} else {
-		fmt.Printf("\nAdopted PR URL:\n%s\n", buf.String())
-	}
-
-	var createdPRURL string
-	for _, line := range strings.Split(buf.String(), "\n") {
-		line = strings.TrimSpace(line)
-		if strings.Contains(line, "/pull/") {
-			createdPRURL = line
-			break
+		for _, line := range strings.Split(buf.String(), "\n") {
+			line = strings.TrimSpace(line)
+			if strings.Contains(line, "/pull/") {
+				createdPRURL = line
+				break
+			}
 		}
 	}
 
 	if createdPRURL != "" {
+		fmt.Printf("\nSuccessfully adopted PR! New PR URL: %s\n", createdPRURL)
 		parts := strings.Split(createdPRURL, "/")
 		if len(parts) > 0 {
 			if createdPRNum, err := strconv.Atoi(parts[len(parts)-1]); err == nil {
@@ -1271,6 +1270,8 @@ func runAdopt(ctx context.Context, prURL, adoptAction, strategy string, ephemera
 				}
 			}
 		}
+	} else {
+		fmt.Printf("\nAdopted PR output:\n%s\n", buf.String())
 	}
 
 	return nil

--- a/factory/pkg/commands/pr.go
+++ b/factory/pkg/commands/pr.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -34,6 +36,7 @@ func NewPRCommand(ctx context.Context) *cobra.Command {
 	cmd.AddCommand(NewAddressCommentsCommand(ctx))
 	cmd.AddCommand(NewIterateCommand(ctx))
 	cmd.AddCommand(NewPRWatchCommand(ctx))
+	cmd.AddCommand(NewAdoptCommand(ctx))
 	return cmd
 }
 
@@ -41,7 +44,6 @@ type InvestigateFlags struct {
 	PRURL           string
 	Prompt          string
 	ContinueSession bool
-	Adopt           string
 }
 
 func NewInvestigateCommand(ctx context.Context) *cobra.Command {
@@ -62,13 +64,13 @@ func NewInvestigateCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("--pr-url is required")
 			}
 
-			resolvedPRURL, err := ensureAdoptedPR(ctx, flags.PRURL, flags.Adopt)
+			err = verifyPROwnership(ctx, flags.PRURL)
 			if err != nil {
 				return err
 			}
 
 			sessionName := "factory-pr-unknown-investigate"
-			u, err := url.Parse(resolvedPRURL)
+			u, err := url.Parse(flags.PRURL)
 			if err == nil {
 				parts := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
 				if len(parts) >= 4 && parts[2] == "pull" {
@@ -88,14 +90,13 @@ func NewInvestigateCommand(ctx context.Context) *cobra.Command {
 
 			ctx, cancel := context.WithTimeout(ctx, rootFlags.Timeout)
 			defer cancel()
-			return runInvestigate(ctx, resolvedPRURL, flags.Prompt, flags.ContinueSession, rootFlags.EphemeralStorage, rootFlags.ResolvedSecrets)
+			return runInvestigate(ctx, flags.PRURL, flags.Prompt, flags.ContinueSession, rootFlags.EphemeralStorage, rootFlags.ResolvedSecrets)
 		},
 	}
 
 	cmd.Flags().StringVar(&flags.PRURL, "pr-url", "", "GitHub PR URL (e.g. https://github.com/owner/repo/pull/123)")
 	cmd.Flags().StringVar(&flags.Prompt, "prompt", "Investigate check failures for this PR", "Custom prompt for the investigate task")
 	cmd.Flags().BoolVar(&flags.ContinueSession, "continue-session", false, "Continue the Gemini session from previous runs in the sandbox")
-	cmd.Flags().StringVar(&flags.Adopt, "adopt", "", "Adopt the PR: 'open' to keep the original PR open, 'close' to close it after adopting")
 
 	return cmd
 }
@@ -558,7 +559,6 @@ type PRWatchFlags struct {
 	DryRun          bool
 	ContinueSession bool
 	WatchTimeout    time.Duration
-	Adopt           string
 }
 
 func NewPRWatchCommand(ctx context.Context) *cobra.Command {
@@ -579,12 +579,12 @@ func NewPRWatchCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("--pr-url is required")
 			}
 
-			resolvedPRURL, err := ensureAdoptedPR(ctx, flags.PRURL, flags.Adopt)
+			err = verifyPROwnership(ctx, flags.PRURL)
 			if err != nil {
 				return err
 			}
 
-			return runPRWatch(ctx, resolvedPRURL, flags.PollInterval, flags.DryRun, flags.ContinueSession, flags.WatchTimeout, rootFlags.EphemeralStorage, rootFlags.ResolvedSecrets)
+			return runPRWatch(ctx, flags.PRURL, flags.PollInterval, flags.DryRun, flags.ContinueSession, flags.WatchTimeout, rootFlags.EphemeralStorage, rootFlags.ResolvedSecrets)
 		},
 	}
 
@@ -593,7 +593,6 @@ func NewPRWatchCommand(ctx context.Context) *cobra.Command {
 	cmd.Flags().BoolVar(&flags.DryRun, "dryrun", false, "Print actions without creating sandboxes or executing tasks")
 	cmd.Flags().BoolVar(&flags.ContinueSession, "continue-session", false, "Continue the Gemini session from previous runs in the sandbox")
 	cmd.Flags().DurationVar(&flags.WatchTimeout, "watch-timeout", 0, "Timeout for watching (default forever)")
-	cmd.Flags().StringVar(&flags.Adopt, "adopt", "", "Adopt the PR: 'open' to keep the original PR open, 'close' to close it after adopting")
 
 	return cmd
 }
@@ -805,7 +804,6 @@ type IterateFlags struct {
 	PRURL           string
 	Prompt          string
 	ContinueSession bool
-	Adopt           string
 }
 
 func NewIterateCommand(ctx context.Context) *cobra.Command {
@@ -826,13 +824,13 @@ func NewIterateCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("--pr-url is required")
 			}
 
-			resolvedPRURL, err := ensureAdoptedPR(ctx, flags.PRURL, flags.Adopt)
+			err = verifyPROwnership(ctx, flags.PRURL)
 			if err != nil {
 				return err
 			}
 
 			sessionName := "factory-pr-unknown-iterate"
-			u, err := url.Parse(resolvedPRURL)
+			u, err := url.Parse(flags.PRURL)
 			if err == nil {
 				parts := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
 				if len(parts) >= 4 && parts[2] == "pull" {
@@ -852,14 +850,13 @@ func NewIterateCommand(ctx context.Context) *cobra.Command {
 
 			ctx, cancel := context.WithTimeout(ctx, rootFlags.Timeout)
 			defer cancel()
-			return runIterate(ctx, resolvedPRURL, flags.Prompt, flags.ContinueSession, rootFlags.EphemeralStorage, rootFlags.ResolvedSecrets)
+			return runIterate(ctx, flags.PRURL, flags.Prompt, flags.ContinueSession, rootFlags.EphemeralStorage, rootFlags.ResolvedSecrets)
 		},
 	}
 
 	cmd.Flags().StringVar(&flags.PRURL, "pr-url", "", "GitHub PR URL (e.g. https://github.com/owner/repo/pull/123)")
 	cmd.Flags().StringVar(&flags.Prompt, "prompt", "Resolve merge conflicts and iterate on code", "Custom prompt for the iterate task")
 	cmd.Flags().BoolVar(&flags.ContinueSession, "continue-session", false, "Continue the Gemini session from previous runs in the sandbox")
-	cmd.Flags().StringVar(&flags.Adopt, "adopt", "", "Adopt the PR: 'open' to keep the original PR open, 'close' to close it after adopting")
 
 	return cmd
 }
@@ -1005,179 +1002,278 @@ func getWorkflowRunID(checkRun *githubv39.CheckRun) int64 {
 	return checkRun.GetID()
 }
 
-func ensureAdoptedPR(ctx context.Context, prURL string, adoptFlag string) (string, error) {
-	if adoptFlag != "" && adoptFlag != "open" && adoptFlag != "close" {
-		return "", fmt.Errorf("invalid value for --adopt: %s. Must be one of [open, close]", adoptFlag)
-	}
-
+func verifyPROwnership(ctx context.Context, prURL string) error {
 	u, err := url.Parse(prURL)
 	if err != nil {
-		return "", fmt.Errorf("invalid PR URL: %w", err)
+		return fmt.Errorf("invalid PR URL: %w", err)
 	}
 	parts := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
 	if len(parts) < 4 || parts[2] != "pull" {
-		return "", fmt.Errorf("expected URL format https://github.com/owner/repo/pull/123, got %s", prURL)
+		return fmt.Errorf("expected URL format https://github.com/owner/repo/pull/123, got %s", prURL)
 	}
 	owner, repo := parts[0], parts[1]
 	prNum, err := strconv.Atoi(parts[3])
 	if err != nil {
-		return "", fmt.Errorf("invalid PR number in URL: %s", parts[3])
+		return fmt.Errorf("invalid PR number in URL: %s", parts[3])
 	}
 
 	ghClient, err := github.NewClient(ctx)
 	if err != nil {
-		return "", fmt.Errorf("creating github client: %w", err)
+		return fmt.Errorf("creating github client: %w", err)
 	}
 
 	pr, _, err := ghClient.PullRequests.Get(ctx, owner, repo, prNum)
 	if err != nil {
-		return "", fmt.Errorf("fetching github PR #%d: %w", prNum, err)
+		return fmt.Errorf("fetching github PR #%d: %w", prNum, err)
 	}
 
 	kubeClient, err := clients.NewKubernetesClient()
 	if err != nil {
-		return "", fmt.Errorf("creating k8s client: %w", err)
+		return fmt.Errorf("creating k8s client: %w", err)
 	}
 
 	secret, err := kubeClient.Clientset.CoreV1().Secrets(rootFlags.Namespace).Get(ctx, rootFlags.SecretName, metav1.GetOptions{})
 	if err != nil {
-		return "", fmt.Errorf("fetching %s secret in namespace %s: %w (make sure to run 'factory user onboard' first)", rootFlags.SecretName, rootFlags.Namespace, err)
+		return fmt.Errorf("fetching %s secret in namespace %s: %w (make sure to run 'factory user onboard' first)", rootFlags.SecretName, rootFlags.Namespace, err)
 	}
 	githubLogin := string(secret.Data[KeyGithubLogin])
 
 	prAuthor := pr.GetUser().GetLogin()
-
-	if adoptFlag == "" {
-		// Verify that the PR is owned by the factory user
-		if prAuthor != githubLogin {
-			return "", fmt.Errorf("PR was not created by the factory user (%s). It is owned by %s. Use --adopt [open|close] to adopt it", githubLogin, prAuthor)
-		}
-		return prURL, nil
+	if !strings.EqualFold(prAuthor, githubLogin) {
+		return fmt.Errorf("PR is not owned by the factory user (%s). It is owned by %s. Please run 'factory pr adopt <open|close> --pr-url %s' to adopt it first", githubLogin, prAuthor, prURL)
 	}
 
-	// adoptFlag is either "open" or "close"
-	if prAuthor == githubLogin {
-		return "", fmt.Errorf("PR is already owned by the factory user (%s). Do not use --adopt", githubLogin)
+	return nil
+}
+
+type AdoptFlags struct {
+	PRURL    string
+	Strategy string
+}
+
+func NewAdoptCommand(ctx context.Context) *cobra.Command {
+	var flags AdoptFlags
+
+	cmd := &cobra.Command{
+		Use:   "adopt <open|close>",
+		Short: "Adopt a third-party PR under the bot user identity in a sandbox",
+		Args:  cobra.ExactArgs(1),
+		Example: `  # Adopt a PR and comment on it, leaving it open
+  factory pr adopt open --pr-url https://github.com/owner/repo/pull/1
+
+  # Adopt a PR and comment/close it
+  factory pr adopt close --pr-url https://github.com/owner/repo/pull/1 --strategy reimplement`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, err := ResolveRootFlags(cmd)
+			if err != nil {
+				return err
+			}
+
+			adoptAction := args[0]
+			if adoptAction != "open" && adoptAction != "close" {
+				return fmt.Errorf("invalid argument '%s'. Must be one of [open, close]", adoptAction)
+			}
+
+			if flags.PRURL == "" {
+				return fmt.Errorf("--pr-url is required")
+			}
+
+			if flags.Strategy != "reuse" && flags.Strategy != "reimplement" {
+				return fmt.Errorf("invalid strategy '%s'. Must be one of [reuse, reimplement]", flags.Strategy)
+			}
+
+			return runAdopt(ctx, flags.PRURL, adoptAction, flags.Strategy, rootFlags.EphemeralStorage, rootFlags.ResolvedSecrets)
+		},
 	}
 
-	fmt.Printf("Adopting PR #%d under user %s...\n", prNum, githubLogin)
+	cmd.Flags().StringVar(&flags.PRURL, "pr-url", "", "GitHub PR URL (e.g. https://github.com/owner/repo/pull/123)")
+	cmd.Flags().StringVar(&flags.Strategy, "strategy", "reuse", "Adoption strategy: 'reuse' (git-based) or 'reimplement' (LLM-based)")
 
-	fmt.Printf("Ensuring fork of %s/%s for user %s...\n", owner, repo, githubLogin)
-	_, resp, err := ghClient.Repositories.CreateFork(ctx, owner, repo, nil)
-	if err != nil && resp != nil && resp.StatusCode != 202 {
-		return "", fmt.Errorf("creating fork: %w", err)
-	}
+	return cmd
+}
 
-	// Wait for fork to be ready
-	fmt.Println("Waiting for fork to be ready...")
-	forkReady := false
-	for i := 0; i < 15; i++ {
-		_, resp, err := ghClient.Repositories.Get(ctx, githubLogin, repo)
-		if err == nil {
-			forkReady = true
-			break
-		}
-		if resp != nil && resp.StatusCode == 404 {
-			time.Sleep(2 * time.Second)
-			continue
-		}
-		return "", fmt.Errorf("checking fork: %w", err)
-	}
-	if !forkReady {
-		return "", fmt.Errorf("timeout waiting for fork of %s/%s to be created under %s", owner, repo, githubLogin)
-	}
-
-	tmpDir, err := os.MkdirTemp("", "factory-pr-adopt-*")
+func runAdopt(ctx context.Context, prURL, adoptAction, strategy string, ephemeralStorage string, secrets []factorysandbox.SecretMount) error {
+	u, err := url.Parse(prURL)
 	if err != nil {
-		return "", fmt.Errorf("creating temp directory: %w", err)
+		return fmt.Errorf("invalid PR URL: %w", err)
 	}
-	defer os.RemoveAll(tmpDir)
-
-	fmt.Println("Initializing temporary git repository...")
-	if err := runCmd(ctx, tmpDir, "git", "init"); err != nil {
-		return "", err
+	parts := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
+	if len(parts) < 4 || parts[2] != "pull" {
+		return fmt.Errorf("expected URL format https://github.com/owner/repo/pull/123, got %s", prURL)
 	}
-	if err := runCmd(ctx, tmpDir, "git", "config", "credential.helper", "!gh auth git-credential"); err != nil {
-		return "", err
-	}
-	if err := runCmd(ctx, tmpDir, "git", "remote", "add", "origin", pr.GetBase().GetRepo().GetCloneURL()); err != nil {
-		return "", err
-	}
-
-	fmt.Printf("Fetching PR history from %s...\n", pr.GetBase().GetRepo().GetCloneURL())
-	if err := runCmd(ctx, tmpDir, "git", "fetch", "origin", fmt.Sprintf("pull/%d/head:adopt-pr-%d", prNum, prNum)); err != nil {
-		return "", err
-	}
-
-	forkURL := fmt.Sprintf("https://github.com/%s/%s.git", githubLogin, repo)
-	if err := runCmd(ctx, tmpDir, "git", "remote", "add", "fork", forkURL); err != nil {
-		return "", err
-	}
-
-	fmt.Printf("Pushing branch adopt-pr-%d to fork...\n", prNum)
-	var pushErr error
-	for i := 0; i < 5; i++ {
-		pushErr = runCmd(ctx, tmpDir, "git", "push", "-f", "fork", fmt.Sprintf("adopt-pr-%d", prNum))
-		if pushErr == nil {
-			break
-		}
-		fmt.Printf("Push failed (may be due to async fork creation), retrying in 2s: %v\n", pushErr)
-		time.Sleep(2 * time.Second)
-	}
-	if pushErr != nil {
-		return "", fmt.Errorf("failed to push to fork: %w", pushErr)
-	}
-
-	fmt.Println("Creating new adopted Pull Request on GitHub...")
-	newPRBody := fmt.Sprintf("This PR was adopted from %s\n\n---\n\n%s", prURL, pr.GetBody())
-	newPR := &githubv39.NewPullRequest{
-		Title:               githubv39.String(pr.GetTitle()),
-		Head:                githubv39.String(fmt.Sprintf("%s:adopt-pr-%d", githubLogin, prNum)),
-		Base:                githubv39.String(pr.GetBase().GetRef()),
-		Body:                githubv39.String(newPRBody),
-		MaintainerCanModify: githubv39.Bool(true),
-	}
-
-	createdPR, _, err := ghClient.PullRequests.Create(ctx, owner, repo, newPR)
+	owner, repo := parts[0], parts[1]
+	prNum, err := strconv.Atoi(parts[3])
 	if err != nil {
-		return "", fmt.Errorf("creating adopted PR: %w", err)
+		return fmt.Errorf("invalid PR number in URL: %s", parts[3])
 	}
 
-	fmt.Println("Leaving comment on the original PR...")
-	var commentBody string
-	closeOriginal := (adoptFlag == "close")
-	if closeOriginal {
-		commentBody = fmt.Sprintf("This PR has been adopted/forked here: %s and closed.", createdPR.GetHTMLURL())
-	} else {
-		commentBody = fmt.Sprintf("This PR has been adopted/forked here: %s", createdPR.GetHTMLURL())
-	}
-	comment := &githubv39.IssueComment{
-		Body: githubv39.String(commentBody),
-	}
-	_, _, err = ghClient.Issues.CreateComment(ctx, owner, repo, prNum, comment)
+	ghClient, err := github.NewClient(ctx)
 	if err != nil {
-		// Log comment error but don't fail, as the PR was already successfully created
-		fmt.Printf("Warning: failed to comment on original PR: %v\n", err)
+		return fmt.Errorf("creating github client: %w", err)
 	}
 
-	if closeOriginal {
-		fmt.Println("Closing the original PR...")
-		updatePR := &githubv39.PullRequest{
-			State: githubv39.String("closed"),
-		}
-		_, _, err = ghClient.PullRequests.Edit(ctx, owner, repo, prNum, updatePR)
+	pr, _, err := ghClient.PullRequests.Get(ctx, owner, repo, prNum)
+	if err != nil {
+		return fmt.Errorf("fetching github PR #%d: %w", prNum, err)
+	}
+
+	kubeClient, err := clients.NewKubernetesClient()
+	if err != nil {
+		return fmt.Errorf("creating k8s client: %w", err)
+	}
+
+	secret, err := kubeClient.Clientset.CoreV1().Secrets(rootFlags.Namespace).Get(ctx, rootFlags.SecretName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("fetching %s secret in namespace %s: %w (make sure to run 'factory user onboard' first)", rootFlags.SecretName, rootFlags.Namespace, err)
+	}
+	githubLogin := string(secret.Data[KeyGithubLogin])
+	githubEmail := string(secret.Data[KeyGithubEmail])
+
+	prAuthor := pr.GetUser().GetLogin()
+	if strings.EqualFold(prAuthor, githubLogin) {
+		return fmt.Errorf("PR is already owned by the factory user (%s)", githubLogin)
+	}
+
+	sandboxName := fmt.Sprintf("adopt-%s-%d", repo, prNum)
+	cloneURL := fmt.Sprintf("https://github.com/%s/%s.git", owner, repo)
+
+	fmt.Printf("Ensuring adopt sandbox '%s'...\n", sandboxName)
+	sandboxName, err = factorysandbox.EnsureAdoptSandbox(ctx, kubeClient, rootFlags.Namespace, repo, prNum, cloneURL, prURL, rootFlags.Image, rootFlags.DiskSize, ephemeralStorage, secrets, rootFlags.ResolvedEnvs)
+	if err != nil {
+		return fmt.Errorf("ensuring adopt sandbox: %w", err)
+	}
+
+	fmt.Printf("Connecting to sandbox %s via envd...\n", sandboxName)
+	client, err := envd.Connect(ctx, rootFlags.Namespace, sandboxName)
+	if err != nil {
+		return fmt.Errorf("connecting to sandbox: %w", err)
+	}
+	defer client.Close()
+
+	taskDir := fmt.Sprintf("/workspaces/tasks/adopt-%s-%s", strategy, time.Now().Format("20060102-150405"))
+	promptPath := fmt.Sprintf("%s/adopt-prompt.txt", taskDir)
+	scriptPath := fmt.Sprintf("%s/pre-script.sh", taskDir)
+
+	var promptBytes []byte
+	var prDiff string
+
+	if strategy == "reimplement" {
+		fmt.Println("Downloading PR diff to construct prompt...")
+		diffURL := pr.GetDiffURL()
+		req, err := http.NewRequestWithContext(ctx, "GET", diffURL, nil)
 		if err != nil {
-			fmt.Printf("Warning: failed to close original PR: %v\n", err)
+			return fmt.Errorf("creating request for PR diff: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+string(secret.Data[KeyGithubToken]))
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("fetching PR diff: %w", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("failed to fetch PR diff: status code %d", resp.StatusCode)
+		}
+		var diffBuf bytes.Buffer
+		if _, err := io.Copy(&diffBuf, resp.Body); err != nil {
+			return fmt.Errorf("reading PR diff response: %w", err)
+		}
+		prDiff = diffBuf.String()
+	}
+
+	params := tasks.AdoptParams{
+		RepoOwner: owner,
+		RepoName:  repo,
+		CloneURL:  cloneURL,
+		PRNumber:  prNum,
+		PRURL:     prURL,
+		AdoptFlag: adoptAction,
+		Strategy:  strategy,
+		Title:     pr.GetTitle(),
+		Body:      pr.GetBody(),
+		Diff:      prDiff,
+		Models:    []string{"gemini-3.5-flash", "gemini-3-flash-preview", "gemini-3.1-pro-preview", "gemini-2.5-pro"},
+	}
+
+	promptBytes, err = tasks.RenderAdoptPrompt(params)
+	if err != nil {
+		return fmt.Errorf("rendering adopt prompt: %w", err)
+	}
+
+	scriptBytes, err := tasks.GetAdoptScript()
+	if err != nil {
+		return fmt.Errorf("getting adopt script: %w", err)
+	}
+
+	fmt.Println("Writing prompt and script into sandbox...")
+	if err := client.WriteFile(ctx, promptPath, promptBytes); err != nil {
+		return fmt.Errorf("writing prompt: %w", err)
+	}
+	if err := client.WriteFile(ctx, scriptPath, scriptBytes); err != nil {
+		return fmt.Errorf("writing script: %w", err)
+	}
+
+	envMap := map[string]string{
+		"GITHUB_TOKEN":               string(secret.Data[KeyGithubToken]),
+		"GEMINI_API_KEY":             getGeminiAPIKey(secret),
+		"GEMINI_CLI_TRUST_WORKSPACE": "true",
+		"REPO_OWNER":                 owner,
+		"REPO_NAME":                  repo,
+		"CLONE_URL":                  cloneURL,
+		"PROMPT_FILE":                promptPath,
+		"GITHUB_USER_ID":             githubLogin,
+		"GITHUB_USER_EMAIL":          githubEmail,
+		"GITHUB_USER_NAME":           githubLogin,
+		"PR_NUMBER":                  strconv.Itoa(prNum),
+		"PR_URL":                     prURL,
+		"ADOPT_FLAG":                 adoptAction,
+		"STRATEGY":                   strategy,
+		"MODELS":                     "gemini-3.5-flash gemini-3-flash-preview gemini-3.1-pro-preview gemini-2.5-pro",
+	}
+
+	fmt.Println("Running adopt task via envd...")
+	cmdStr := fmt.Sprintf("bash -c 'set -o pipefail; bash %s'", scriptPath)
+	_ = factorysandbox.UpdateSandboxTaskAnnotation(ctx, kubeClient, rootFlags.Namespace, sandboxName, "adopt", "Running")
+	if err := client.RunTaskResilient(ctx, cmdStr, envMap, taskDir, rootFlags.Detached, rootFlags.AbortOnCancel); err != nil {
+		_ = factorysandbox.UpdateSandboxTaskAnnotation(ctx, kubeClient, rootFlags.Namespace, sandboxName, "adopt", "Failed")
+		return fmt.Errorf("running task: %w", err)
+	}
+	if rootFlags.Detached {
+		return nil
+	}
+	_ = factorysandbox.UpdateSandboxTaskAnnotation(ctx, kubeClient, rootFlags.Namespace, sandboxName, "adopt", "Completed")
+
+	fmt.Println("\nAdopt execution completed.")
+
+	var buf bytes.Buffer
+	if err := client.Exec(ctx, fmt.Sprintf("cat %s/agent-output.txt", taskDir), "/workspaces", nil, nil, &buf, os.Stderr); err != nil {
+		klog.Warningf("Could not read agent-output.txt: %v", err)
+	} else {
+		fmt.Printf("\nAdopted PR URL:\n%s\n", buf.String())
+	}
+
+	var createdPRURL string
+	for _, line := range strings.Split(buf.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.Contains(line, "/pull/") {
+			createdPRURL = line
+			break
 		}
 	}
 
-	fmt.Printf("\nSuccessfully adopted PR #%d!\n", prNum)
-	fmt.Println("To check out this PR locally, run:")
-	fmt.Printf("  gh pr checkout %d\n", createdPR.GetNumber())
-	fmt.Println(createdPR.GetHTMLURL())
-	fmt.Println()
+	if createdPRURL != "" {
+		parts := strings.Split(createdPRURL, "/")
+		if len(parts) > 0 {
+			if createdPRNum, err := strconv.Atoi(parts[len(parts)-1]); err == nil {
+				fmt.Printf("Aliasing sandbox %s to PR #%d...\n", sandboxName, createdPRNum)
+				if err := factorysandbox.AliasSandboxToPR(ctx, kubeClient, rootFlags.Namespace, sandboxName, createdPRNum, createdPRURL); err != nil {
+					klog.Warningf("Failed to alias sandbox to PR #%d: %v", createdPRNum, err)
+				}
+			}
+		}
+	}
 
-	return createdPR.GetHTMLURL(), nil
+	return nil
 }
 
 func runCmd(ctx context.Context, dir string, name string, args ...string) error {

--- a/factory/pkg/sandbox/sandbox.go
+++ b/factory/pkg/sandbox/sandbox.go
@@ -123,6 +123,58 @@ func EnsureAgentSandbox(ctx context.Context, kubeClient *clients.KubernetesClien
 	return name, nil
 }
 
+func EnsureAdoptSandbox(ctx context.Context, kubeClient *clients.KubernetesClient, namespace, repoName string, prNum int, cloneURL, htmlURL, image, diskSize, ephemeralStorage string, secrets []SecretMount, envs []EnvVar) (string, error) {
+	name := fmt.Sprintf("adopt-%s-%d", repoName, prNum)
+
+	_, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err == nil {
+		return name, nil
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		return "", fmt.Errorf("checking sandbox existence: %w", err)
+	}
+
+	if diskSize == "" {
+		diskSize = "10Gi"
+	}
+
+	opt := AgentSandboxOptions{
+		DevSandboxOptions: DevSandboxOptions{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"sandbox.gemini.google.com/type":    "adopt",
+				"factory.gemini.google.com/managed": "true",
+			},
+			Annotations: map[string]string{
+				"repo":     repoName,
+				"cloneURL": cloneURL,
+				"htmlURL":  htmlURL,
+			},
+			Image:             image,
+			Replicas:          1,
+			WorkspaceDiskSize: diskSize,
+			EphemeralStorage:  ephemeralStorage,
+			Secrets:           secrets,
+			Env:               envs,
+		},
+	}
+
+	sb, svc := NewAgentSandbox(opt)
+
+	_, err = kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Create(ctx, sb, metav1.CreateOptions{})
+	if err != nil {
+		return "", fmt.Errorf("creating sandbox CR: %w", err)
+	}
+
+	_, err = kubeClient.Clientset.CoreV1().Services(namespace).Create(ctx, svc, metav1.CreateOptions{})
+	if err != nil {
+		return "", fmt.Errorf("creating sandbox service: %w", err)
+	}
+
+	return name, nil
+}
+
 func AliasSandboxToPR(ctx context.Context, kubeClient *clients.KubernetesClient, namespace, sandboxName string, prNum int, prURL string) error {
 	unstructObj, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Get(ctx, sandboxName, metav1.GetOptions{})
 	if err != nil {

--- a/factory/pkg/tasks/adopt.go
+++ b/factory/pkg/tasks/adopt.go
@@ -1,0 +1,41 @@
+package tasks
+
+import (
+	"bytes"
+	"fmt"
+)
+
+type AdoptParams struct {
+	RepoOwner     string
+	RepoName      string
+	CloneURL      string
+	PRNumber      int
+	PRURL         string
+	AdoptFlag     string // "open" or "close"
+	Strategy      string // "reuse" or "reimplement"
+	Title         string
+	Body          string
+	Diff          string
+	Models        []string
+}
+
+func GetAdoptScript() ([]byte, error) {
+	return scriptsFS.ReadFile("adopt.sh")
+}
+
+func RenderAdoptPrompt(params AdoptParams) ([]byte, error) {
+	if len(params.Models) == 0 {
+		params.Models = []string{"gemini-3.5-flash", "gemini-3-flash-preview", "gemini-3.1-pro-preview", "gemini-2.5-pro"}
+	}
+
+	promptTmpl, err := getPromptTemplate("adopt.txt")
+	if err != nil {
+		return nil, fmt.Errorf("getting prompt template: %w", err)
+	}
+	var pBuf bytes.Buffer
+	if err := promptTmpl.Execute(&pBuf, params); err != nil {
+		return nil, fmt.Errorf("executing prompt template: %w", err)
+	}
+
+	return pBuf.Bytes(), nil
+}

--- a/factory/pkg/tasks/adopt.go
+++ b/factory/pkg/tasks/adopt.go
@@ -6,17 +6,17 @@ import (
 )
 
 type AdoptParams struct {
-	RepoOwner     string
-	RepoName      string
-	CloneURL      string
-	PRNumber      int
-	PRURL         string
-	AdoptFlag     string // "open" or "close"
-	Strategy      string // "reuse" or "reimplement"
-	Title         string
-	Body          string
-	Diff          string
-	Models        []string
+	RepoOwner string
+	RepoName  string
+	CloneURL  string
+	PRNumber  int
+	PRURL     string
+	AdoptFlag string // "open" or "close"
+	Strategy  string // "reuse" or "reimplement"
+	Title     string
+	Body      string
+	Diff      string
+	Models    []string
 }
 
 func GetAdoptScript() ([]byte, error) {

--- a/factory/pkg/tasks/adopt.sh
+++ b/factory/pkg/tasks/adopt.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+set -e
+set -o pipefail
+set -x
+
+USER_HOME="${HOME:-/root}"
+mkdir -p "${USER_HOME}"
+
+export GITHUB_USER_TOKEN="${GITHUB_USER_TOKEN:-${GITHUB_TOKEN}}"
+if [ -z "$GITHUB_USER_TOKEN" ]; then
+    GITHUB_USER_TOKEN="${MANUAL_PAT:-${OAUTH_PAT}}"
+fi
+
+if [ -n "${GITHUB_BOT_LOGIN}" ]; then
+    if [ -n "${GITHUB_BOT_TOKEN}" ] || [ -n "${GITHUB_BOT_OAUTH_PAT}" ] || [ -n "${GITHUB_BOT_MANUAL_PAT}" ]; then
+        GITHUB_USER_TOKEN="${GITHUB_BOT_TOKEN:-${GITHUB_BOT_MANUAL_PAT:-${GITHUB_BOT_OAUTH_PAT}}}"
+    fi
+fi
+
+function setupGit {
+    echo "Running setupGit..."
+
+    echo "creating ${USER_HOME}/.config/gh directory"
+    mkdir -p "${USER_HOME}/.config/gh"
+
+    local GH_USER="${GITHUB_USER_ID}"
+    if [ -n "${GITHUB_BOT_LOGIN}" ]; then
+        GH_USER="${GITHUB_BOT_LOGIN}"
+    fi
+
+    echo "writing gh config"
+    cat <<EOF > "${USER_HOME}/.config/gh/hosts.yml"
+github.com:
+    users:
+        ${GH_USER}:
+            oauth_token: ${GITHUB_USER_TOKEN}
+    git_protocol: https
+    oauth_token: ${GITHUB_USER_TOKEN}
+    user: ${GH_USER}
+EOF
+
+    echo "running git config user.email"
+    if [ -n "$GITHUB_BOT_EMAIL" ]; then
+        git config --global user.email "${GITHUB_BOT_EMAIL}"
+    else
+        git config --global user.email "${GITHUB_USER_EMAIL}"
+    fi
+
+    echo "running git config user.name"
+    if [ -n "$GITHUB_BOT_NAME" ]; then
+        git config --global user.name "${GITHUB_BOT_NAME}"
+    else
+        git config --global user.name "${GITHUB_USER_NAME}"
+    fi
+
+    echo "running gh auth setup-git"
+    gh auth setup-git
+
+    echo "Configuring global git ignore"
+    git config --global core.excludesfile "${USER_HOME}/.gitignore_global"
+    cat <<EOF > "${USER_HOME}/.gitignore_global"
+manager
+bin/
+EOF
+}
+
+setupGit
+
+# Fork the repository if it doesn't already exist under the bot user account
+local GH_USER="${GITHUB_USER_ID}"
+if [ -n "${GITHUB_BOT_LOGIN}" ]; then
+    GH_USER="${GITHUB_BOT_LOGIN}"
+fi
+
+echo "Ensuring fork of ${REPO_OWNER}/${REPO_NAME} for user ${GH_USER}..."
+gh repo fork "${REPO_OWNER}/${REPO_NAME}" --clone=false || true
+
+if [ "$STRATEGY" = "reuse" ]; then
+    echo "Executing 'reuse' strategy (git-based history preservation)..."
+    
+    # We clone to a temp dir to do the git checkout/fetch/push without polluting workspaces
+    TMP_GIT_DIR=$(mktemp -d -t factory-pr-adopt-XXXXXX)
+    cd "${TMP_GIT_DIR}"
+    
+    git init
+    git config credential.helper "!gh auth git-credential"
+    git remote add origin "${CLONE_URL}"
+    
+    echo "Fetching PR head commit..."
+    git fetch origin "pull/${PR_NUMBER}/head:adopt-pr-${PR_NUMBER}"
+    
+    FORK_URL="https://github.com/${GH_USER}/${REPO_NAME}.git"
+    git remote add fork "${FORK_URL}"
+    
+    echo "Pushing branch adopt-pr-${PR_NUMBER} to fork..."
+    git push -f fork "adopt-pr-${PR_NUMBER}"
+    
+    cd /workspaces
+    rm -rf "${TMP_GIT_DIR}"
+    
+    # Switch to the workspaces repository directory (if any) and register git branch
+    if [ -d "/workspaces/${REPO_NAME}" ]; then
+        cd "/workspaces/${REPO_NAME}"
+        git remote add fork "${FORK_URL}" || true
+        git fetch fork "adopt-pr-${PR_NUMBER}" || true
+    fi
+
+elif [ "$STRATEGY" = "reimplement" ]; then
+    echo "Executing 'reimplement' strategy (LLM-based re-implementation)..."
+    
+    # Clone the repository if it doesn't exist under /workspaces
+    if [ ! -d "/workspaces/${REPO_NAME}" ]; then
+        (cd /workspaces/ && git clone "${CLONE_URL}")
+    fi
+    
+    cd "/workspaces/${REPO_NAME}"
+    git remote add fork "https://github.com/${GH_USER}/${REPO_NAME}.git" || true
+    git fetch origin
+    
+    BASE_BRANCH=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
+    
+    git rebase --abort 2>/dev/null || true
+    git merge --abort 2>/dev/null || true
+    git cherry-pick --abort 2>/dev/null || true
+    git reset --hard HEAD
+    git clean -fd
+    git checkout "${BASE_BRANCH}"
+    
+    BRANCH_NAME="adopt-reimplement-pr-${PR_NUMBER}"
+    git checkout -B "${BRANCH_NAME}"
+    
+    echo "Running Gemini in YOLO mode..."
+    set +x
+    export GEMINI_API_KEY="${GEMINI_API_KEY}"
+    
+    MODELS_LIST="${MODELS:-gemini-3.5-flash gemini-3-flash-preview gemini-3.1-pro-preview gemini-2.5-pro}"
+    SUCCESS=false
+    for MODEL in $MODELS_LIST; do
+        echo "Trying model: $MODEL"
+        if gemini --yolo --model "$MODEL" --output-format json < "${PROMPT_FILE}" > "$(dirname "${PROMPT_FILE}")/gemini-output.json"; then
+            echo "Gemini execution successful with model: $MODEL"
+            SUCCESS=true
+            break
+        else
+            echo "Gemini execution encountered errors with model: $MODEL. Retrying next model..."
+        fi
+    done
+    
+    if [ "$SUCCESS" = false ]; then
+        echo "All models failed to implement changes."
+        exit 1
+    fi
+    set -x
+    
+    if [ -n "$(git status --porcelain)" ]; then
+        echo "Committing reimplemented changes..."
+        git add .
+        git commit -m "chore: adopt PR #${PR_NUMBER} by reimplementing changes on latest ${BASE_BRANCH}"
+        git push -f fork "${BRANCH_NAME}"
+    else
+        echo "Error: No changes were implemented by the model."
+        exit 1
+    fi
+    
+else
+    echo "Unknown strategy: $STRATEGY"
+    exit 1
+fi
+
+# ----------------- Create New Adopted PR -----------------
+cd "/workspaces"
+if [ -d "/workspaces/${REPO_NAME}" ]; then
+    cd "/workspaces/${REPO_NAME}"
+fi
+
+NEW_PR_TITLE=$(gh pr view "${PR_URL}" --json title --jq .title)
+ORIGINAL_PR_BODY=$(gh pr view "${PR_URL}" --json body --jq .body)
+NEW_PR_BODY="This Pull Request was adopted from original PR ${PR_URL}
+
+---
+### Original Description:
+${ORIGINAL_PR_BODY}"
+
+if [ "$STRATEGY" = "reuse" ]; then
+    HEAD_BRANCH="${GH_USER}:adopt-pr-${PR_NUMBER}"
+else
+    HEAD_BRANCH="${GH_USER}:adopt-reimplement-pr-${PR_NUMBER}"
+fi
+
+BASE_BRANCH=$(gh repo view "${CLONE_URL}" --json defaultBranchRef --jq .defaultBranchRef.name)
+
+echo "Creating adopted PR on GitHub..."
+CREATED_PR_URL=$(gh pr create --title "adopt: ${NEW_PR_TITLE}" --body "${NEW_PR_BODY}" --head "${HEAD_BRANCH}" --base "${BASE_BRANCH}" || true)
+
+if [ -n "${CREATED_PR_URL}" ] && [[ "${CREATED_PR_URL}" == http* ]]; then
+    echo "PR successfully created: ${CREATED_PR_URL}"
+    # Write to agent output so host can extract it
+    echo "${CREATED_PR_URL}" > "$(dirname "${PROMPT_FILE}")/agent-output.txt"
+    
+    # ----------------- Comment & Close Original PR -----------------
+    if [ "$ADOPT_FLAG" = "close" ]; then
+        COMMENT_BODY="This PR has been adopted/forked here: ${CREATED_PR_URL} and closed."
+        gh pr comment "${PR_URL}" --body "${COMMENT_BODY}" || true
+        gh pr close "${PR_URL}" || true
+    else
+        COMMENT_BODY="This PR has been adopted/forked here: ${CREATED_PR_URL}"
+        gh pr comment "${PR_URL}" --body "${COMMENT_BODY}" || true
+    fi
+else
+    echo "Failed to create PR"
+    exit 1
+fi

--- a/factory/pkg/tasks/adopt.sh
+++ b/factory/pkg/tasks/adopt.sh
@@ -75,47 +75,30 @@ fi
 echo "Ensuring fork of ${REPO_OWNER}/${REPO_NAME} for user ${GH_USER}..."
 gh repo fork "${REPO_OWNER}/${REPO_NAME}" --clone=false || true
 
+# Clone the repository if it doesn't exist under /workspaces
+if [ ! -d "/workspaces/${REPO_NAME}" ]; then
+    echo "Cloning repository ${CLONE_URL}..."
+    (cd /workspaces/ && git clone "${CLONE_URL}")
+fi
+
+cd "/workspaces/${REPO_NAME}"
+FORK_URL="https://github.com/${GH_USER}/${REPO_NAME}.git"
+git remote add fork "${FORK_URL}" || true
+git fetch origin
+
 if [ "$STRATEGY" = "reuse" ]; then
     echo "Executing 'reuse' strategy (git-based history preservation)..."
-    
-    # We clone to a temp dir to do the git checkout/fetch/push without polluting workspaces
-    TMP_GIT_DIR=$(mktemp -d -t factory-pr-adopt-XXXXXX)
-    cd "${TMP_GIT_DIR}"
-    
-    git init
-    git config credential.helper "!gh auth git-credential"
-    git remote add origin "${CLONE_URL}"
     
     echo "Fetching PR head commit..."
     git fetch origin "pull/${PR_NUMBER}/head:adopt-pr-${PR_NUMBER}"
     
-    FORK_URL="https://github.com/${GH_USER}/${REPO_NAME}.git"
-    git remote add fork "${FORK_URL}"
-    
     echo "Pushing branch adopt-pr-${PR_NUMBER} to fork..."
     git push -f fork "adopt-pr-${PR_NUMBER}"
     
-    cd /workspaces
-    rm -rf "${TMP_GIT_DIR}"
-    
-    # Switch to the workspaces repository directory (if any) and register git branch
-    if [ -d "/workspaces/${REPO_NAME}" ]; then
-        cd "/workspaces/${REPO_NAME}"
-        git remote add fork "${FORK_URL}" || true
-        git fetch fork "adopt-pr-${PR_NUMBER}" || true
-    fi
+    git checkout "adopt-pr-${PR_NUMBER}"
 
 elif [ "$STRATEGY" = "reimplement" ]; then
     echo "Executing 'reimplement' strategy (LLM-based re-implementation)..."
-    
-    # Clone the repository if it doesn't exist under /workspaces
-    if [ ! -d "/workspaces/${REPO_NAME}" ]; then
-        (cd /workspaces/ && git clone "${CLONE_URL}")
-    fi
-    
-    cd "/workspaces/${REPO_NAME}"
-    git remote add fork "https://github.com/${GH_USER}/${REPO_NAME}.git" || true
-    git fetch origin
     
     BASE_BRANCH=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
     

--- a/factory/pkg/tasks/adopt.sh
+++ b/factory/pkg/tasks/adopt.sh
@@ -67,7 +67,7 @@ EOF
 setupGit
 
 # Fork the repository if it doesn't already exist under the bot user account
-local GH_USER="${GITHUB_USER_ID}"
+GH_USER="${GITHUB_USER_ID}"
 if [ -n "${GITHUB_BOT_LOGIN}" ]; then
     GH_USER="${GITHUB_BOT_LOGIN}"
 fi

--- a/factory/pkg/tasks/adopt.txt
+++ b/factory/pkg/tasks/adopt.txt
@@ -1,0 +1,11 @@
+You are the PR Adoption agent. We want to adopt a third-party PR under our factory user identity.
+To do this, you should re-apply the changes from the original PR as inspiration, but implement them on top of the latest base branch.
+
+Original PR Title: {{ .Title }}
+Original PR Description:
+{{ .Body }}
+
+Original PR Diff:
+{{ .Diff }}
+
+Please implement the same fix/feature on the current repository, ensuring all tests pass and following the repository's guidelines.


### PR DESCRIPTION
Fixes #1120 

### 1. New Subcommand: `factory pr adopt`
Introduced a dedicated command to adopt third-party pull requests under the bot user identity.
* **Syntax**: `factory pr adopt <open|close> --pr-url <url> --strategy <reuse|reimplement>`
* **Strategies**:
  * `reuse` (default): Git-based; fetches the original PR branch history, pushes it to the bot's fork, and submits the new PR.
  * `reimplement`: LLM-based; clones the repository, downloads the original PR diff, and runs Gemini to re-apply the changes on top of the latest base branch (`master`/`main`).
* **Sandbox Execution**: The adoption task executes entirely inside a secure sandbox where bot credentials are automatically configured and mounted.

### 2. Disambiguated Existing Subcommands
Removed the legacy `--adopt` flag from other PR subcommands:
* `factory pr watch`
* `factory pr iterate`
* `factory pr investigate`

These commands now perform a quick local check (`verifyPROwnership`) at startup. If they receive a PR URL that is not owned by the onboarded bot user, they reject the execution with a message instructing the user to run `factory pr adopt` first.

### 3. Sandbox Tasks Configuration
Created a new `adopt` task structure under `factory/pkg/tasks/`:
* **`adopt.go`**: Task schema and prompt template renderer.
* **`adopt.txt`**: Prompt template instructing the agent to reimplement the code changes from the original diff on top of the latest base branch.
* **`adopt.sh`**: Sandbox runner shell script that clones the target repo, handles the git fork/checkout/push/fetch workflows, calls Gemini (for LLM reimplementation), creates the new PR using the GitHub CLI (`gh`), comments/closes the original PR, and outputs the result.

### 4. Sandbox Management & Aliasing
* Added `EnsureAdoptSandbox` in `factory/pkg/sandbox/sandbox.go` to support provisioning sandboxes labeled for adoption tasks.
* Automatically registers a sandbox-to-PR alias once the adopted PR is successfully created, ensuring future `iterate` or `investigate` calls can target and reuse the sandbox.

### 5. Documentation
* Added a design note at `factory/design/pr-adopt.md` containing the problem statement, proposed architecture, and sequential execution flow diagram.


---------------------

```
barni@barni.c ~/workspace/src/github.com/barney-s/gemini-for-kubernetes-development/factory% ./bin/factory pr adopt close   --pr-url https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/8639   --strategy reuse -n overseer-kcc
Ensuring adopt sandbox 'adopt-k8s-config-connector-8639'...
Connecting to sandbox adopt-k8s-config-connector-8639 via envd...
Waiting for sandbox pod adopt-k8s-config-connector-8639 to become ready (and any terminating pods to exit)...
Writing prompt and script into sandbox...
Running adopt task via envd...

....
.....
.....

+ echo 'Ensuring fork of GoogleCloudPlatform/k8s-config-connector for user factorybot-robot...'
Ensuring fork of GoogleCloudPlatform/k8s-config-connector for user factorybot-robot...
+ gh repo fork GoogleCloudPlatform/k8s-config-connector --clone=false
factorybot-robot/k8s-config-connector already exists
.........
.......
.......

https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/9726 and closed.'
+ gh pr comment https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/8639 --body 'This PR has been adopted/forked here: https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/9726 and closed.'
https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/8639#issuecomment-4686246585
+ gh pr close https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/8639
✓ Closed pull request GoogleCloudPlatform/k8s-config-connector#8639 (Implement direct controller for CloudDMSConversionWorkspace)

Adopt execution completed.

Successfully adopted PR! New PR URL: https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/9726
Aliasing sandbox adopt-k8s-config-connector-8639 to PR #9726...
```