### PR TITLE
Splitting greenfield generation into it's own workflow

### DIFF
--- a/.agents/workflows/kcc-example.txt
+++ b/.agents/workflows/kcc-example.txt
@@ -72,25 +72,8 @@ Only declare the PR as fully passed/verified if no failures are returned across 
 The resource must have a direct KRM type (`_types.go`) scaffolded and updated via `generate.sh` using the controllerbuilder tool, ensuring strict schema compatibility with the existing CRD.
 
 1. Check if the resource already has direct types under `apis/` and a `generate.sh` script configured for the resource's service.
-2. If not, determine if the resource is an existing Terraform/DCL resource or a greenfield resource:
-   * **Existing Terraform/DCL Resource**: Open a GitHub issue referencing `.gemini/skills/crd-mapper-fuzzer-existing-type/SKILL.md`.
-   * **Greenfield/New Resource**: Open a GitHub issue referencing `.gemini/skills/kcc-direct-greenfield-types-implementer/SKILL.md`.
-
-**GitHub Issue Details for Greenfield Resource:**
-*   **Title:** `Implement direct KRM types and generate.sh for {kind}`
-*   **Assignee:** `factorybot-robot`
-*   **Labels:** `overseer`
-*   **Body:**
-    ```
-    Please follow the skill .gemini/skills/kcc-direct-greenfield-types-implementer/SKILL.md for {kind}.
-
-    Make sure to configure/update `generate.sh` in the resource's service directory (e.g., `apis/{service}/{version}/generate.sh`), ensuring that the direct KRM type is strictly schema-compatible with the existing CRD.
-
-    For reference on setting up `generate.sh`, renaming files/fields to match acronyms, handling pointers, and ensuring proper directory structure, please also refer to the skill .gemini/skills/generate-sh-checker/SKILL.md.
-
-    If you find any shortcomings in the skill (that likely apply to other resources), you may update SKILL.md. Also keep a journal of any less general observations etc. To avoid git merge conflicts, use a file under .gemini/skills/kcc-direct-greenfield-types-implementer/journal/, named after the kind or a similarly unique name. You may grep journal entries to identify learnings from other resources; if you find an important pattern by doing that you may also update the SKILL.md itself.
-    ```
-
+2. Existing Terraform/DCL Resource**: Open a GitHub issue referencing `.gemini/skills/crd-mapper-fuzzer-existing-type/SKILL.md`.
+   
 **GitHub Issue Details for Existing Terraform/DCL Resource:**
 *   **Title:** `Implement direct KRM types and generate.sh for {kind}`
 *   **Assignee:** `factorybot-robot`

--- a/.agents/workflows/kcc-greenfield.txt
+++ b/.agents/workflows/kcc-greenfield.txt
@@ -1,0 +1,122 @@
+---
+description: A meta-skill for KCC Greenfield resources that describes the steps we need to take to get them to be "production ready" direct controllers at v1alpha1 at least.
+name: checklist-for-kind
+schedule: never
+mode: workflow
+---
+
+# Checklist for KCC Greenfield Resource Migration
+
+This is a meta-skill describing the steps to migrate a KCC greenfield resource kind to a production-ready direct controller at `v1alpha1`.
+Greenfield resources are API resources that have not yet been implemented in KCC, they can be part of a brand new API or new resources in an existing API. 
+Compare to Brownfield resources which are already implemented in KCC.
+
+Instead of doing the coding yourself under this skill, you will coordinate and orchestrate:
+1. Planning the migration steps.
+2. Opening GitHub issues for each step, labeling them with `overseer`, and assigning them to `factorybot-robot`.
+3. Monitoring progress of the Pull Requests.
+   * **Requesting PR changes**: If you need `factorybot-robot` to make changes to an open PR (such as rebasing it on master after dependent changes are merged, or addressing review feedback), you can comment directly on the PR outlining the required changes and reassign it back to `factorybot-robot` by adding `/assign factorybot-robot` in your comment.
+4. Opening subsequent issues once the prior steps are successfully completed.
+
+
+## Journaling and Progress Tracking
+
+To track the progress of each resource kind, maintain a journal file in `.agents/workflows/greenfield-checklist-for-kind/journal/{kind}.md` (using the CamelCase Kind name).
+
+The journal should contain:
+1. The current step of the migration.
+2. A table tracking:
+   * Step Number and Name
+   * GitHub Issue link/number
+   * GitHub Pull Request link/number
+   * Status (e.g. `Open`, `PR Created`, `Merged`, `Completed`)
+   * Date Started and Date Completed
+
+Only proceed to the next step once the PR for the current step is merged successfully.
+
+3. In addition to the local journal file, **update the parent issue description** (using the issue ID/number extracted from `${SESSION_ID#issue-}`) or fall back to updating a comment:
+   * **Formatting the GitHub Description/Comment**: To keep the parent GitHub issue clean and avoid excessively chatty updates, the body posted to GitHub (description or comment) must **only** include the current step, the progress tracking table, and **at most the 3 most recent status update notes**. Do not include the entire historical list of check logs or updates under the table in the GitHub description/comment; all older history must remain in the local journal file on the branch only.
+   * Edit/create the description or comment using the `gh` CLI:
+     ```bash
+     gh issue edit ${SESSION_ID#issue-} --body "<updated_body>"
+     ```
+     If editing the issue description fails (due to write permissions on public repositories), **fall back to updating a comment**:
+     * Search the comments on the issue for an existing comment posted by yourself (`factorybot-robot`) that contains the text `Migration Progress`.
+     * If such a comment exists, edit it with the updated progress using:
+       ```bash
+       gh issue comment edit <comment-id> --body "<updated_comment_body>"
+       ```
+     * If no such comment exists, create a new comment:
+       ```bash
+       gh issue comment create ${SESSION_ID#issue-} --body "<updated_comment_body>"
+       ```
+4. Once all steps of the migration for the resource kind are successfully completed and verified merged, update the parent issue description to show completion, and close the parent issue:
+   ```bash
+   gh issue close ${SESSION_ID#issue-}
+   ```
+
+### Verifying PR CI Checks Status
+When checking if all CI check-runs have passed for a pull request, do NOT rely on a single unpaginated `gh api .../check-runs` call (since GitHub defaults to 30 items per page and might hide failing runs). Instead, use the `--paginate` option to ensure all runs are checked:
+```bash
+gh api repos/GoogleCloudPlatform/k8s-config-connector/commits/<head-sha>/check-runs --paginate --jq '.check_runs[] | select(.conclusion != "success" and .conclusion != "neutral" and .conclusion != "skipped") | {name: .name, conclusion: .conclusion}'
+```
+Or check via GitHub CLI:
+```bash
+gh pr checks <pr-number> --repo GoogleCloudPlatform/k8s-config-connector
+```
+Only declare the PR as fully passed/verified if no failures are returned across all pages of checks.
+
+## Steps
+
+
+### Step 1: Direct API Types and Identity and Reference Types Pattern
+
+The resource must have a direct KRM type (`_types.go`) scaffolded and updated via `generate.sh` using the controllerbuilder tool, ensuring strict schema compatibility with the existing CRD.
+
+1. Check if the resource already has direct types under `apis/` and a `generate.sh` script configured for the resource's service.
+2. Open a GitHub issue referencing `.gemini/skills/kcc-direct-greenfield-types-implementer/SKILL.md` for type generation and 
+   `.gemini/skills/kcc-direct-identity-implementer/SKILL.md` for identity generation.
+3. Check if apis/<group>/<api_version>/<kind_lowercase>_identity_test.go exists. If it is missing (or incomplete), implement it now to ensure full coverage of the IdentityV2 interface.
+4. Validate your changes locally by:
+   * Running scripts/validate-prereqs.sh, if the script fails the output will contain agent hints for fixing the errors.
+   * Running ./dev/ci/presubmits/tests-e2e-fixtures-<kind_lowercase>
+   * Journaling findings, use skill `.gemini/skills/kcc-agentic-journaler/SKILL.md` to capture quirks and update knowledge.
+
+**GitHub Issue Details for Greenfield Resource:**
+*   **Title:** `Greenfield: Implement direct KRM types and generate.sh for {kind}`
+*   **Assignee:** `factorybot-robot`
+*   **Labels:** `overseer`, `greenfield`,`step/gen-types`
+*   **Body:**
+    ```
+    Please follow the skill `.gemini/skills/kcc-direct-greenfield-types-implementer/SKILL.md` for generating types for {kind}.
+    Please follow the skill `.gemini/skills/kcc-direct-identity-implementer/SKILL.md` for generating identity for {kind}.
+    Please ensure that unit test have been added for `_identity.go` files, please ensure these tests ensure full coverage of the IdentityV2 interface.
+
+    Make sure to configure/update `generate.sh` in the resource's service directory (e.g., `apis/{service}/{version}/generate.sh`), ensuring that the direct KRM type is strictly schema-compatible with the existing CRD.
+
+    For reference on setting up `generate.sh`, renaming files/fields to match acronyms, handling pointers, and ensuring proper directory structure, please also refer to the skill .gemini/skills/generate-sh-checker/SKILL.md.
+
+    If you find any shortcomings in the skill (that likely apply to other resources), you may update SKILL.md. Also keep a journal of any less general observations etc. To avoid git merge conflicts, use a file under .gemini/skills/kcc-direct-greenfield-types-implementer/journal/, named after the kind or a similarly unique name. You may grep journal entries to identify learnings from other resources; if you find an important pattern by doing that you may also update the SKILL.md itself.
+    ```
+
+### Step 2: Direct Controller, E2E fixtures and Fuzzer 
+
+The direct controller must be implemented to manage reconciliation logic (Adapter: Find, Create, Update, Delete) and E2E fixtures must be created and recorded against mockgcp/real GCP to verify functionality.
+
+1. Open a GitHub issue assigned to `factorybot-robot` to implement the direct controller and E2E fixtures.
+2. Generate controller Scaffolding & Mappers: Follow .gemini/skills/kcc-direct-controller-implementer/SKILL.md
+3. Implement controller Logic & E2E Fixtures: Follow .gemini/skills/kcc-direct-controller-logic-implementer/SKILL.md
+
+**GitHub Issue Details:**
+*   **Title:** `Greenfield: Implement direct controller and E2E fixtures for {kind}`
+*   **Assignee:** `factorybot-robot`
+*   **Labels:** `overseer`, `greenfield`, `step:controller`
+*   **Body:**
+    ```
+    Please follow the skills:
+    - .gemini/skills/kcc-direct-controller-implementer/SKILL.md
+    - .gemini/skills/kcc-direct-controller-logic-implementer/SKILL.md
+    to implement the direct controller and record/verify E2E fixtures for {kind}.
+
+    If you find any shortcomings in these skills (that likely apply to other resources), you may update them. Also keep a journal of any less general observations etc. To avoid git merge conflicts, use a file under their respective journal/ folders, named after the kind or a similarly unique name.
+    ```


### PR DESCRIPTION
What the label says: Splitting workflows/kcc-example.txt into brownfield instructions and putting greenfield instructions in a different workflow file.