### PR TITLE
fix(factory): resolve watch daemon multi-bot conflicts, task concurrency, and recovery duplication

### DIFF
--- a/.agents/workflows/kcc-direct-migration-tracker.txt
+++ b/.agents/workflows/kcc-direct-migration-tracker.txt
@@ -26,12 +26,10 @@ This workflow runs in the context of a singleton coordinator issue.
 2. Store this issue number as `${COORDINATOR_ISSUE_NUMBER}`.
 
 ## Step 2: Audit In-Flight Migration Work
-1. Search for open issues representing active migrations in flight (either labeled `overseer` or assigned to `factorybot-robot`):
+1. Search for open issues representing active migrations in flight (labeled `overseer`):
    ```bash
    gh issue list --state open --label "overseer" --json number,title,labels,assignees,createdAt
-   gh issue list --state open --assignee "factorybot-robot" --json number,title,labels,assignees,createdAt
    ```
-   Combine and de-duplicate the results by issue number.
 2. Parse the titles to extract the resource **Kind** for each active migration (e.g., from titles like "Migrating ComputeSSLPolicy to Direct controller overseer", the Kind is `ComputeSSLPolicy`). Exclude any greenfield resources (new resources that are not legacy migrations and do not exist in `dev/migration-tracker/data.json`).
 3. For each active migration, check if it is already recorded as `"In Progress"` in `dev/migration-tracker/data.json`. If it is recorded as `"Not Started"`, update it to `"In Progress"` and record the issue.
 4. Check if any previously active migration issues have been **closed**:
@@ -47,7 +45,7 @@ To avoid duplicate work, audit GitHub for external contributions:
      gh issue list --state open --search "${KIND}" --json number,title,url,assignees,author
      gh pr list --state open --search "${KIND}" --json number,title,url,author,state
      ```
-   - Filter out issues or PRs created by yourself (`factorybot-robot`) or already tracked.
+   - Filter out issues or PRs created by the bot pool accounts (e.g. `*bot*` or `*robot*`) or already tracked.
    - If an active external PR or issue is found:
      - Record its URL in the `"notes"` or `"external_tracking"` field of that resource's JSON block in `dev/migration-tracker/data.json` (e.g. `notes: "Community PR: github.com/GoogleCloudPlatform/k8s-config-connector/pull/1234"`).
      - **In-flight tracking check**: If this resource does not have an active open `overseer` tracking issue:
@@ -56,8 +54,7 @@ To avoid duplicate work, audit GitHub for external contributions:
          gh issue create --title "Migrating ${KIND} to Direct controller overseer" \
            --body "Using the skill workflow, please complete creation of direct controller for ${KIND}\n\nhttps://raw.githubusercontent.com/gke-labs/gemini-for-kubernetes-development/refs/heads/main/.agents/workflows/kcc-example.txt" \
            --label "overseer" \
-           --label "workflow/migrate" \
-           --assignee "factorybot-robot"
+           --label "workflow/migrate"
          ```
        - Update the resource's state to `"In Progress"` in `dev/migration-tracker/data.json` and record the newly created issue number in the `"trackingIssue"` field of that resource's JSON block.
 
@@ -74,8 +71,7 @@ To avoid duplicate work, audit GitHub for external contributions:
      gh issue create --title "Migrating ${KIND} to Direct controller overseer" \
        --body "Using the skill workflow, please complete creation of direct controller for ${KIND}\n\nhttps://raw.githubusercontent.com/gke-labs/gemini-for-kubernetes-development/refs/heads/main/.agents/workflows/kcc-example.txt" \
        --label "overseer" \
-       --label "workflow/migrate" \
-       --assignee "factorybot-robot"
+       --label "workflow/migrate"
      ```
    - Update the resource's `"state"` to `"In Progress"` in `dev/migration-tracker/data.json` and save the new issue number in the `"trackingIssue"` field of that resource's JSON block.
 

--- a/.agents/workflows/kcc-example.txt
+++ b/.agents/workflows/kcc-example.txt
@@ -17,6 +17,7 @@ Instead of doing the coding yourself under this skill, you will coordinate and o
 
 > [!IMPORTANT]
 > **Safety Guardrails (Strict Enforcement)**:
+> - **Do NOT write code or create PRs directly**: You must **never** checkout code, write code, run builds/tests, commit changes, or run `gh pr create` to send/push PRs. Your role under this skill is strictly limited to planning, progress tracking, and orchestration. All code implementation, CI fixing, and triage work must be delegated to coder and reviewer bots by creating child issues or assigning PRs back to their author bots.
 > - **Do NOT comment on child Pull Requests**: You must **never** comment directly on the child Pull Requests. The watch daemon will automatically monitor and handle PR review feedback and CI check failures. If you need to request action or re-trigger a run, do so only by assigning the PR to the PR author bot (using `gh pr edit <pr> --add-assignee <author>` or assigning via `gh` CLI).
 > - **Do NOT approve, LGTM, or label PRs**: You must **never** approve, LGTM, or add approval/merging labels (such as `lgtm`, `approved`, or `automerge`) to any Pull Requests. These actions require human OWNER review and approval.
 

--- a/.agents/workflows/kcc-example.txt
+++ b/.agents/workflows/kcc-example.txt
@@ -11,13 +11,13 @@ This is a meta-skill describing the steps to migrate a KCC resource kind to a pr
 
 Instead of doing the coding yourself under this skill, you will coordinate and orchestrate:
 1. Planning the migration steps.
-2. Opening GitHub issues for each step, labeling them with `overseer`, and assigning them to `factorybot-robot`.
+2. Opening GitHub issues for each step, labeling them with `overseer`, and leaving them unassigned (or assigning them to the current bot user).
 3. Monitoring progress of the Pull Requests.
 4. Opening subsequent issues once the prior steps are successfully completed.
 
 > [!IMPORTANT]
 > **Safety Guardrails (Strict Enforcement)**:
-> - **Do NOT comment on child Pull Requests**: You must **never** comment directly on the child Pull Requests. The watch daemon will automatically monitor and handle PR review feedback and CI check failures. If you need to request action or re-trigger a run, do so only by assigning the PR to the bot (using `/assign factorybot-robot` or assigning via `gh` CLI).
+> - **Do NOT comment on child Pull Requests**: You must **never** comment directly on the child Pull Requests. The watch daemon will automatically monitor and handle PR review feedback and CI check failures. If you need to request action or re-trigger a run, do so only by assigning the PR to the PR author bot (using `gh pr edit <pr> --add-assignee <author>` or assigning via `gh` CLI).
 > - **Do NOT approve, LGTM, or label PRs**: You must **never** approve, LGTM, or add approval/merging labels (such as `lgtm`, `approved`, or `automerge`) to any Pull Requests. These actions require human OWNER review and approval.
 
 
@@ -43,7 +43,7 @@ Only proceed to the next step once the PR for the current step is merged success
      gh issue edit ${SESSION_ID#issue-} --body "<updated_body>"
      ```
      If editing the issue description fails (due to write permissions on public repositories), **fall back to updating a comment**:
-     * Search the comments on the issue for an existing comment posted by yourself (`factorybot-robot`) that contains the text `Migration Progress`.
+     * Search the comments on the issue for an existing comment posted by yourself (check for author match with your GITHUB_USER_ID) that contains the text `Migration Progress`.
      * If such a comment exists, edit it with the updated progress using:
        ```bash
        gh issue comment edit <comment-id> --body "<updated_comment_body>"
@@ -80,7 +80,7 @@ The resource must have a direct KRM type (`_types.go`) scaffolded and updated vi
    
 **GitHub Issue Details for Existing Terraform/DCL Resource:**
 *   **Title:** `Implement direct KRM types and generate.sh for {kind}`
-*   **Assignee:** `factorybot-robot`
+*   **Assignee:** (leave unassigned or assign to the current bot)
 *   **Labels:** `overseer`
 *   **Body:**
     ```
@@ -100,11 +100,11 @@ The resource must have a direct KRM type (`_types.go`) scaffolded and updated vi
 The resource kind must have an identity and reference type that follow our canonical patterns.
 
 1. Check if the resource has `_identity.go` and `_reference.go` implementing `identity.IdentityV2` and `refs.Ref` using `gcpurls.Template`.
-2. If not, open a GitHub issue assigned to `factorybot-robot` to implement/move the kind to the identity and reference pattern.
+2. If not, open a GitHub issue (unassigned or assigned to the current bot) to implement/move the kind to the identity and reference pattern.
 
 **GitHub Issue Details:**
 *   **Title:** `Move {kind} to identity and refs pattern`
-*   **Assignee:** `factorybot-robot`
+*   **Assignee:** (leave unassigned or assign to the current bot)
 *   **Labels:** `overseer`
 *   **Body:**
     ```
@@ -119,11 +119,11 @@ The resource kind must have an identity and reference type that follow our canon
 
 For existing resources transitioning to a direct controller, a round-trip KRM fuzzer must be created to verify that all field mapping conversions between KRM and GCP proto representations are lossless and fully correct.
 
-1. Open a GitHub issue assigned to `factorybot-robot` to implement the round-trip KRM fuzzer at the expected path `pkg/controller/direct/{service}/{kind}_fuzzer.go`.
+1. Open a GitHub issue (unassigned or assigned to the current bot) to implement the round-trip KRM fuzzer at the expected path `pkg/controller/direct/{service}/{kind}_fuzzer.go`.
 
 **GitHub Issue Details:**
 *   **Title:** `Implement round-trip KRM fuzzer for {kind}`
-*   **Assignee:** `factorybot-robot`
+*   **Assignee:** (leave unassigned or assign to the current bot)
 *   **Labels:** `overseer`
 *   **Body:**
     ```
@@ -140,11 +140,11 @@ For existing resources transitioning to a direct controller, a round-trip KRM fu
 
 The direct controller must be implemented to manage reconciliation logic (Adapter: Find, Create, Update, Delete) and E2E fixtures must be created and recorded against mockgcp/real GCP to verify functionality.
 
-1. Open a GitHub issue assigned to `factorybot-robot` to implement the direct controller and E2E fixtures.
+1. Open a GitHub issue (unassigned or assigned to the current bot) to implement the direct controller and E2E fixtures.
 
 **GitHub Issue Details:**
 *   **Title:** `Implement direct controller and E2E fixtures for {kind}`
-*   **Assignee:** `factorybot-robot`
+*   **Assignee:** (leave unassigned or assign to the current bot)
 *   **Labels:** `overseer`
 *   **Body:**
     ```

--- a/.agents/workflows/kcc-greenfield.txt
+++ b/.agents/workflows/kcc-greenfield.txt
@@ -19,6 +19,7 @@ Instead of doing the coding yourself under this skill, you will coordinate and o
 
 > [!IMPORTANT]
 > **Safety Guardrails (Strict Enforcement)**:
+> - **Do NOT write code or create PRs directly**: You must **never** checkout code, write code, run builds/tests, commit changes, or run `gh pr create` to send/push PRs. Your role under this skill is strictly limited to planning, progress tracking, and orchestration. All code implementation, CI fixing, and triage work must be delegated to coder and reviewer bots by creating child issues or assigning PRs back to their author bots.
 > - **Do NOT comment on child Pull Requests**: You must **never** comment directly on the child Pull Requests. The watch daemon will automatically monitor and handle PR review feedback and CI check failures. If you need to request action or re-trigger a run, do so only by assigning the PR to the PR author bot (using `gh pr edit <pr> --add-assignee <author>` or assigning via `gh` CLI).
 > - **Do NOT approve, LGTM, or label PRs**: You must **never** approve, LGTM, or add approval/merging labels (such as `lgtm`, `approved`, or `automerge`) to any Pull Requests. These actions require human OWNER review and approval.
 

--- a/.agents/workflows/kcc-greenfield.txt
+++ b/.agents/workflows/kcc-greenfield.txt
@@ -13,13 +13,13 @@ Compare to Brownfield resources which are already implemented in KCC.
 
 Instead of doing the coding yourself under this skill, you will coordinate and orchestrate:
 1. Planning the migration steps.
-2. Opening GitHub issues for each step, labeling them with `overseer`, and assigning them to `factorybot-robot`.
+2. Opening GitHub issues for each step, labeling them with `overseer`, and leaving them unassigned (or assigning them to the current bot user).
 3. Monitoring progress of the Pull Requests.
 4. Opening subsequent issues once the prior steps are successfully completed.
 
 > [!IMPORTANT]
 > **Safety Guardrails (Strict Enforcement)**:
-> - **Do NOT comment on child Pull Requests**: You must **never** comment directly on the child Pull Requests. The watch daemon will automatically monitor and handle PR review feedback and CI check failures. If you need to request action or re-trigger a run, do so only by assigning the PR to the bot (using `/assign factorybot-robot` or assigning via `gh` CLI).
+> - **Do NOT comment on child Pull Requests**: You must **never** comment directly on the child Pull Requests. The watch daemon will automatically monitor and handle PR review feedback and CI check failures. If you need to request action or re-trigger a run, do so only by assigning the PR to the PR author bot (using `gh pr edit <pr> --add-assignee <author>` or assigning via `gh` CLI).
 > - **Do NOT approve, LGTM, or label PRs**: You must **never** approve, LGTM, or add approval/merging labels (such as `lgtm`, `approved`, or `automerge`) to any Pull Requests. These actions require human OWNER review and approval.
 
 
@@ -45,7 +45,7 @@ Only proceed to the next step once the PR for the current step is merged success
      gh issue edit ${SESSION_ID#issue-} --body "<updated_body>"
      ```
      If editing the issue description fails (due to write permissions on public repositories), **fall back to updating a comment**:
-     * Search the comments on the issue for an existing comment posted by yourself (`factorybot-robot`) that contains the text `Migration Progress`.
+     * Search the comments on the issue for an existing comment posted by yourself (check for author match with your GITHUB_USER_ID) that contains the text `Migration Progress`.
      * If such a comment exists, edit it with the updated progress using:
        ```bash
        gh issue comment edit <comment-id> --body "<updated_comment_body>"
@@ -88,7 +88,7 @@ The resource must have a direct KRM type (`_types.go`) scaffolded and updated vi
 
 **GitHub Issue Details for Greenfield Resource:**
 *   **Title:** `Greenfield: Implement direct KRM types and generate.sh for {kind}`
-*   **Assignee:** `factorybot-robot`
+*   **Assignee:** (leave unassigned or assign to the current bot)
 *   **Labels:** `overseer`, `greenfield`,`step/gen-types`
 *   **Body:**
     ```
@@ -107,13 +107,13 @@ The resource must have a direct KRM type (`_types.go`) scaffolded and updated vi
 
 The direct controller must be implemented to manage reconciliation logic (Adapter: Find, Create, Update, Delete) and E2E fixtures must be created and recorded against mockgcp/real GCP to verify functionality.
 
-1. Open a GitHub issue assigned to `factorybot-robot` to implement the direct controller and E2E fixtures.
+1. Open a GitHub issue (unassigned or assigned to the current bot) to implement the direct controller and E2E fixtures.
 2. Generate controller Scaffolding & Mappers: Follow .gemini/skills/kcc-direct-controller-implementer/SKILL.md
 3. Implement controller Logic & E2E Fixtures: Follow .gemini/skills/kcc-direct-controller-logic-implementer/SKILL.md
 
 **GitHub Issue Details:**
 *   **Title:** `Greenfield: Implement direct controller and E2E fixtures for {kind}`
-*   **Assignee:** `factorybot-robot`
+*   **Assignee:** (leave unassigned or assign to the current bot)
 *   **Labels:** `overseer`, `greenfield`, `step:controller`
 *   **Body:**
     ```

--- a/factory/pkg/commands/agent.go
+++ b/factory/pkg/commands/agent.go
@@ -220,7 +220,7 @@ func RunAgent(ctx context.Context, flags AgentFlags, ephemeralStorage string, se
 	taskTitle := fmt.Sprintf("Agent: %s", agentDef.Name)
 
 	fmt.Printf("Ensuring sandbox for task %s...\n", taskID)
-	sandboxName, err := factorysandbox.EnsureAgentSandbox(ctx, kubeClient, rootFlags.Namespace, repo, taskID, cloneURL, flags.URL, taskTitle, rootFlags.Image, rootFlags.DiskSize, ephemeralStorage, secrets, rootFlags.ResolvedEnvs)
+	sandboxName, err := factorysandbox.EnsureAgentSandbox(ctx, kubeClient, rootFlags.Namespace, repo, taskID, cloneURL, flags.URL, taskTitle, rootFlags.Image, rootFlags.DiskSize, ephemeralStorage, secrets, rootFlags.ResolvedEnvs, rootFlags.User)
 	if err != nil {
 		return fmt.Errorf("ensuring agent sandbox: %w", err)
 	}

--- a/factory/pkg/commands/fix.go
+++ b/factory/pkg/commands/fix.go
@@ -184,10 +184,10 @@ func runFix(ctx context.Context, targetURL, prompt, name string, noPR, watch boo
 	var sandboxName string
 	if isIssue {
 		fmt.Printf("Ensuring sandbox for issue #%d...\n", issueNum)
-		sandboxName, err = factorysandbox.EnsureFixSandbox(ctx, kubeClient, rootFlags.Namespace, repo, strconv.Itoa(issueNum), cloneURL, targetURL, issueTitle, rootFlags.Image, rootFlags.DiskSize, ephemeralStorage, secrets, rootFlags.ResolvedEnvs)
+		sandboxName, err = factorysandbox.EnsureFixSandbox(ctx, kubeClient, rootFlags.Namespace, repo, strconv.Itoa(issueNum), cloneURL, targetURL, issueTitle, rootFlags.Image, rootFlags.DiskSize, ephemeralStorage, secrets, rootFlags.ResolvedEnvs, rootFlags.User)
 	} else {
 		fmt.Printf("Ensuring sandbox for task %s on repo %s/%s...\n", name, owner, repo)
-		sandboxName, err = factorysandbox.EnsureFixSandbox(ctx, kubeClient, rootFlags.Namespace, repo, name, cloneURL, targetURL, issueTitle, rootFlags.Image, rootFlags.DiskSize, ephemeralStorage, secrets, rootFlags.ResolvedEnvs)
+		sandboxName, err = factorysandbox.EnsureFixSandbox(ctx, kubeClient, rootFlags.Namespace, repo, name, cloneURL, targetURL, issueTitle, rootFlags.Image, rootFlags.DiskSize, ephemeralStorage, secrets, rootFlags.ResolvedEnvs, rootFlags.User)
 	}
 	if err != nil {
 		return fmt.Errorf("ensuring sandbox: %w", err)

--- a/factory/pkg/commands/pr.go
+++ b/factory/pkg/commands/pr.go
@@ -1150,7 +1150,7 @@ func runAdopt(ctx context.Context, prURL, adoptAction, strategy string, ephemera
 	cloneURL := fmt.Sprintf("https://github.com/%s/%s.git", owner, repo)
 
 	fmt.Printf("Ensuring adopt sandbox '%s'...\n", sandboxName)
-	sandboxName, err = factorysandbox.EnsureAdoptSandbox(ctx, kubeClient, rootFlags.Namespace, repo, prNum, cloneURL, prURL, rootFlags.Image, rootFlags.DiskSize, ephemeralStorage, secrets, rootFlags.ResolvedEnvs)
+	sandboxName, err = factorysandbox.EnsureAdoptSandbox(ctx, kubeClient, rootFlags.Namespace, repo, prNum, cloneURL, prURL, rootFlags.Image, rootFlags.DiskSize, ephemeralStorage, secrets, rootFlags.ResolvedEnvs, rootFlags.User)
 	if err != nil {
 		return fmt.Errorf("ensuring adopt sandbox: %w", err)
 	}

--- a/factory/pkg/commands/pr.go
+++ b/factory/pkg/commands/pr.go
@@ -1034,7 +1034,7 @@ func verifyPROwnership(ctx context.Context, prURL string) error {
 
 	prAuthor := pr.GetUser().GetLogin()
 	if rootFlags.User == "" && prAuthor != "" {
-		secretName := fmt.Sprintf("factory-user-%s", prAuthor)
+		secretName := fmt.Sprintf("user-%s", prAuthor)
 		_, err = kubeClient.Clientset.CoreV1().Secrets(rootFlags.Namespace).Get(ctx, secretName, metav1.GetOptions{})
 		if err == nil {
 			klog.Infof("Auto-resolved PR author secret: %s", secretName)

--- a/factory/pkg/commands/root.go
+++ b/factory/pkg/commands/root.go
@@ -57,7 +57,7 @@ coding tasks without local side effects or host dependencies.`,
 	cmd.PersistentFlags().StringVarP(&rootFlags.Namespace, "namespace", "n", os.Getenv("NAMESPACE"), "Kubernetes namespace (defaults to $NAMESPACE, gh user, or default)")
 	cmd.PersistentFlags().StringVar(&rootFlags.Image, "image", "ghcr.io/gke-labs/gemini-for-kubernetes-development/factory-golang:latest", "Sandbox base image")
 	cmd.PersistentFlags().StringVar(&rootFlags.DiskSize, "workspace-disk-size", "10Gi", "Workspace PVC disk size")
-	cmd.PersistentFlags().StringVarP(&rootFlags.User, "user", "u", "", "Run tasks under a specific bot user identity (looks up secret factory-user-<user>)")
+	cmd.PersistentFlags().StringVarP(&rootFlags.User, "user", "u", "", "Run tasks under a specific bot user identity (looks up secret user-<user>)")
 	cmd.PersistentFlags().DurationVar(&rootFlags.Timeout, "timeout", 30*time.Minute, "Overall execution timeout")
 	cmd.PersistentFlags().BoolVar(&rootFlags.Background, "background", false, "Run the CLI command as a background daemon process and redirect output to a log file")
 	cmd.PersistentFlags().BoolVar(&rootFlags.Cleanup, "cleanup", false, "Delete the sandbox after the task is run or watch completes")
@@ -82,7 +82,7 @@ coding tasks without local side effects or host dependencies.`,
 		}
 
 		if rootFlags.User != "" {
-			rootFlags.SecretName = fmt.Sprintf("factory-user-%s", rootFlags.User)
+			rootFlags.SecretName = fmt.Sprintf("user-%s", rootFlags.User)
 		} else {
 			rootFlags.SecretName = SecretFactoryUser
 		}

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -1115,6 +1115,9 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 						if shouldIgnoreUser(c.GetUser(), githubLogin, bots) {
 							continue
 						}
+						if strings.EqualFold(c.GetUser().GetLogin(), pr.GetUser().GetLogin()) {
+							continue
+						}
 						if c.GetCreatedAt().After(lastCommitTime) && c.GetCreatedAt().After(state.lastCommentAddressedTime) {
 							hasNewComments = true
 							break
@@ -1127,6 +1130,9 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 							if shouldIgnoreUser(r.GetUser(), githubLogin, bots) {
 								continue
 							}
+							if strings.EqualFold(r.GetUser().GetLogin(), pr.GetUser().GetLogin()) {
+								continue
+							}
 							if r.GetSubmittedAt().After(lastCommitTime) && r.GetSubmittedAt().After(state.lastCommentAddressedTime) {
 								hasNewComments = true
 								break
@@ -1136,6 +1142,9 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 							if err == nil {
 								for _, rc := range revComments {
 									if shouldIgnoreUser(rc.GetUser(), githubLogin, bots) {
+										continue
+									}
+									if strings.EqualFold(rc.GetUser().GetLogin(), pr.GetUser().GetLogin()) {
 										continue
 									}
 									if rc.GetCreatedAt().After(lastCommitTime) && rc.GetCreatedAt().After(state.lastCommentAddressedTime) {

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -146,6 +146,32 @@ func assignedBotUser(issue *githubv39.Issue, botUsers []string) string {
 	return ""
 }
 
+func resolveSandboxName(ctx context.Context, kubeClient *clients.KubernetesClient, taskType string, num int, repo string) string {
+	if taskType == "issue-fix" || taskType == "agent-chore" {
+		wfName := fmt.Sprintf("wf-issue-%d", num)
+		if kubeClient != nil {
+			if _, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(rootFlags.Namespace).Get(ctx, wfName, metav1.GetOptions{}); err == nil {
+				return wfName
+			}
+		}
+		return fmt.Sprintf("fix-%s-%d", repo, num)
+	}
+
+	// For PR tasks, check if there's an existing sandbox with the PR label
+	if kubeClient != nil {
+		listOpts := metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("factory.gemini.google.com/pr=%d", num),
+		}
+		sbs, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(rootFlags.Namespace).List(ctx, listOpts)
+		if err == nil && len(sbs.Items) > 0 {
+			return sbs.Items[0].GetName()
+		}
+	}
+
+	return fmt.Sprintf("factory-pr-%d", num)
+}
+
+
 func isSandboxTaskRunning(ctx context.Context, kubeClient *clients.KubernetesClient, namespace, name string) (bool, error) {
 	unstructObj, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
@@ -922,7 +948,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 				if isConflicting {
 					filename := fmt.Sprintf("task-pr-%d-iterate.yaml", num)
 					if !taskExists(incomingDir, processingDir, filename) {
-						sandboxName := fmt.Sprintf("factory-pr-%d", num)
+						sandboxName := resolveSandboxName(ctx, kubeClient, "pr-iterate", num, repo)
 						running, err := isSandboxTaskRunning(ctx, kubeClient, rootFlags.Namespace, sandboxName)
 						if err != nil {
 							klog.Errorf("Failed to check if sandbox %s is running: %v", sandboxName, err)
@@ -1049,7 +1075,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 					} else if state.lastSHA != headSHA || time.Since(state.lastInvestigatedTime) > 6*time.Hour {
 						filename := fmt.Sprintf("task-pr-%d-investigate.yaml", num)
 						if !taskExists(incomingDir, processingDir, filename) {
-							sandboxName := fmt.Sprintf("factory-pr-%d", num)
+							sandboxName := resolveSandboxName(ctx, kubeClient, "pr-investigate", num, repo)
 							running, err := isSandboxTaskRunning(ctx, kubeClient, rootFlags.Namespace, sandboxName)
 							if err != nil {
 								klog.Errorf("Failed to check if sandbox %s is running: %v", sandboxName, err)
@@ -1211,7 +1237,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 						}
 						filename := fmt.Sprintf("task-pr-%d-comments.yaml", num)
 						if !taskExists(incomingDir, processingDir, filename) {
-							sandboxName := fmt.Sprintf("factory-pr-%d", num)
+							sandboxName := resolveSandboxName(ctx, kubeClient, "pr-comments", num, repo)
 							running, err := isSandboxTaskRunning(ctx, kubeClient, rootFlags.Namespace, sandboxName)
 							if err != nil {
 								klog.Errorf("Failed to check if sandbox %s is running: %v", sandboxName, err)
@@ -1640,6 +1666,8 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 				}
 			}
 
+			activeSandboxesInCycle := make(map[string]bool)
+
 			for _, item := range tasksToRun {
 				if actionsTaken >= maxActions {
 					fmt.Printf("Reached maximum actions limit (%d) for this cycle. Stopping execution.\n", maxActions)
@@ -1660,11 +1688,28 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 				filename := item.filename
 				task := item.task
 
+				sandboxName := resolveSandboxName(ctx, kubeClient, task.Type, task.Number, repo)
+				if activeSandboxesInCycle[sandboxName] {
+					klog.Infof("Skipping task %s because sandbox %s is already scheduled to run a task in this cycle.", filename, sandboxName)
+					continue
+				}
+
+				running, err := isSandboxTaskRunning(ctx, kubeClient, rootFlags.Namespace, sandboxName)
+				if err != nil {
+					klog.Errorf("Failed to check if sandbox %s is running: %v", sandboxName, err)
+					continue
+				}
+				if running {
+					klog.Infof("Skipping task %s because sandbox %s is currently busy running another task.", filename, sandboxName)
+					continue
+				}
+
 				incomingPath := filepath.Join(incomingDir, filename)
 				processingPath := filepath.Join(processingDir, filename)
 
 				if dryRun {
 					fmt.Printf("[DRYRUN] Would process task %s (Type: %s, URL: %s)\n", filename, task.Type, task.URL)
+					activeSandboxesInCycle[sandboxName] = true
 					actionsTaken++
 					filesInProcessing++
 					continue
@@ -1675,6 +1720,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 					continue
 				}
 
+				activeSandboxesInCycle[sandboxName] = true
 				task.Status = "Running"
 				_ = writeTaskAtomically(processingDir, filename, task)
 				writeTaskJournalEvent(queueDir, filename, task, "Started", 0)
@@ -1828,7 +1874,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 									sandboxName = fmt.Sprintf("agent-%s-%d", repo, t.Number)
 								}
 							case "pr-investigate", "pr-comments", "pr-iterate", "pr-review":
-								sandboxName = fmt.Sprintf("factory-pr-%d", t.Number)
+								sandboxName = resolveSandboxName(ctx, kubeClient, t.Type, t.Number, repo)
 							}
 
 							if sandboxName != "" {

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -135,6 +135,17 @@ func isAssigned(issue *githubv39.Issue, assignee string) bool {
 	return false
 }
 
+func assignedBotUser(issue *githubv39.Issue, botUsers []string) string {
+	for _, u := range issue.Assignees {
+		for _, bot := range botUsers {
+			if strings.EqualFold(u.GetLogin(), bot) {
+				return u.GetLogin()
+			}
+		}
+	}
+	return ""
+}
+
 func isSandboxTaskRunning(ctx context.Context, kubeClient *clients.KubernetesClient, namespace, name string) (bool, error) {
 	unstructObj, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
@@ -363,7 +374,7 @@ func isWorkflowDefinition(ctx context.Context, ghClient *githubv39.Client, owner
 	return false
 }
 
-func queueIssueTasks(ctx context.Context, ghClient *githubv39.Client, kubeClient *clients.KubernetesClient, owner, repo string, issues []*githubv39.Issue, processedIssues map[int]time.Time, refIssues map[int]bool, targetAssignee string, incomingDir, processingDir, processedDir, queueDir string, dryRun bool, triggerLabel string) {
+func queueIssueTasks(ctx context.Context, ghClient *githubv39.Client, kubeClient *clients.KubernetesClient, owner, repo string, issues []*githubv39.Issue, processedIssues map[int]time.Time, refIssues map[int]bool, targetAssignee string, allBotUsers []string, incomingDir, processingDir, processedDir, queueDir string, dryRun bool, triggerLabel string) {
 	klog.Infof("queueIssueTasks called with %d issues", len(issues))
 	for _, issue := range issues {
 		num := issue.GetNumber()
@@ -433,19 +444,25 @@ func queueIssueTasks(ctx context.Context, ghClient *githubv39.Client, kubeClient
 				continue
 			}
 
-			if isAssigned(issue, targetAssignee) {
+			assignedBot := assignedBotUser(issue, allBotUsers)
+			if assignedBot != "" {
 				if dryRun {
-					fmt.Printf("[DRYRUN] Would unassign %s from issue #%d and add label '%s'\n", targetAssignee, num, triggerLabel)
+					fmt.Printf("[DRYRUN] Would unassign %s from issue #%d and add label '%s'\n", assignedBot, num, triggerLabel)
 				} else {
-					fmt.Printf("Unassigning %s from issue #%d...\n", targetAssignee, num)
-					if _, _, err := ghClient.Issues.RemoveAssignees(ctx, owner, repo, num, []string{targetAssignee}); err != nil {
-						klog.Errorf("Failed to unassign %s from issue #%d: %v", targetAssignee, num, err)
+					fmt.Printf("Unassigning %s from issue #%d...\n", assignedBot, num)
+					if _, _, err := ghClient.Issues.RemoveAssignees(ctx, owner, repo, num, []string{assignedBot}); err != nil {
+						klog.Errorf("Failed to unassign %s from issue #%d: %v", assignedBot, num, err)
 					}
 					klog.Infof("Adding '%s' label to issue #%d", triggerLabel, num)
 					if _, _, err := ghClient.Issues.AddLabelsToIssue(ctx, owner, repo, num, []string{triggerLabel}); err != nil {
 						klog.Errorf("Failed to add label '%s' to issue #%d: %v", triggerLabel, num, err)
 					}
 				}
+			}
+
+			taskAssignee := assignedBot
+			if taskAssignee == "" {
+				taskAssignee = targetAssignee
 			}
 
 			issueURL := fmt.Sprintf("https://github.com/%s/%s/issues/%d", owner, repo, num)
@@ -458,7 +475,7 @@ func queueIssueTasks(ctx context.Context, ghClient *githubv39.Client, kubeClient
 					Priority:  getIssuePriority(issue),
 					Phase:     4,
 					CreatedAt: issue.GetCreatedAt(),
-					Assignee:  targetAssignee,
+					Assignee:  taskAssignee,
 					Status:    "Pending",
 					AgentFile: workflowPath,
 					SessionID: fmt.Sprintf("issue-%d", num),
@@ -471,7 +488,7 @@ func queueIssueTasks(ctx context.Context, ghClient *githubv39.Client, kubeClient
 					Priority:  getIssuePriority(issue),
 					Phase:     3,
 					CreatedAt: issue.GetCreatedAt(),
-					Assignee:  targetAssignee,
+					Assignee:  taskAssignee,
 					Status:    "Pending",
 				}
 			}
@@ -664,6 +681,29 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 		targetAssignee = githubLogin
 	}
 
+	var allBotUsers []string
+	if cfg != nil {
+		for _, rCfg := range cfg.Roles {
+			for _, u := range rCfg.Users {
+				if u != "" {
+					allBotUsers = append(allBotUsers, u)
+				}
+			}
+		}
+	}
+	if targetAssignee != "" {
+		found := false
+		for _, u := range allBotUsers {
+			if strings.EqualFold(u, targetAssignee) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			allBotUsers = append(allBotUsers, targetAssignee)
+		}
+	}
+
 	incomingDir := filepath.Join(queueDir, "incoming")
 	processingDir := filepath.Join(queueDir, "processing")
 	processedDir := filepath.Join(queueDir, "processed")
@@ -835,10 +875,17 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 					continue
 				}
 
-				// Verify PR Author: Only process PRs created by the bot
+				// Verify PR Author: Only process PRs created by any bot in the pool
 				author := pr.GetUser().GetLogin()
-				if !strings.EqualFold(author, githubLogin) {
-					klog.Infof("Skipping PR #%d because it was created by %s (not %s). We do not have permission to push to external forks.", num, author, githubLogin)
+				isBotPR := false
+				for _, bot := range allBotUsers {
+					if strings.EqualFold(author, bot) {
+						isBotPR = true
+						break
+					}
+				}
+				if !isBotPR {
+					klog.Infof("Skipping PR #%d because it was created by %s (not in our bot pool). We do not have permission to push to external forks.", num, author)
 					continue
 				}
 
@@ -872,16 +919,22 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 						} else if running {
 							klog.Infof("Skipping PR #%d rebase because there is an in-flight sandbox %s.", num, sandboxName)
 						} else {
-							if isAssigned(prIssue, targetAssignee) && !unassignedPRs[num] {
+							assignedBot := assignedBotUser(prIssue, allBotUsers)
+							if assignedBot != "" && !unassignedPRs[num] {
 								if dryRun {
-									fmt.Printf("[DRYRUN] Would unassign %s from PR #%d\n", targetAssignee, num)
+									fmt.Printf("[DRYRUN] Would unassign %s from PR #%d\n", assignedBot, num)
 								} else {
-									fmt.Printf("Unassigning %s from PR #%d...\n", targetAssignee, num)
-									if _, _, err := ghClient.Issues.RemoveAssignees(ctx, owner, repo, num, []string{targetAssignee}); err != nil {
-										klog.Errorf("Failed to unassign %s from PR #%d: %v", targetAssignee, num, err)
+									fmt.Printf("Unassigning %s from PR #%d...\n", assignedBot, num)
+									if _, _, err := ghClient.Issues.RemoveAssignees(ctx, owner, repo, num, []string{assignedBot}); err != nil {
+										klog.Errorf("Failed to unassign %s from PR #%d: %v", assignedBot, num, err)
 									}
 									unassignedPRs[num] = true
 								}
+							}
+
+							taskAssignee := assignedBot
+							if taskAssignee == "" {
+								taskAssignee = targetAssignee
 							}
 
 							prURL := fmt.Sprintf("https://github.com/%s/%s/pull/%d", owner, repo, num)
@@ -892,7 +945,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 								Priority:  getPRPriority(prIssue),
 								Phase:     1,
 								CreatedAt: pr.GetCreatedAt(),
-								Assignee:  targetAssignee,
+								Assignee:  taskAssignee,
 								Status:    "Pending",
 								CommitSHA: headSHA,
 							}
@@ -943,7 +996,14 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 					investigationCount := 0
 					if listCommentsErr == nil {
 						for _, c := range comments {
-							if strings.EqualFold(c.GetUser().GetLogin(), githubLogin) &&
+							isPoolBot := false
+							for _, bot := range allBotUsers {
+								if strings.EqualFold(c.GetUser().GetLogin(), bot) {
+									isPoolBot = true
+									break
+								}
+							}
+							if isPoolBot &&
 								strings.Contains(c.GetBody(), "started investigating CI check failures") &&
 								c.GetCreatedAt().After(lastCommitTime) {
 								investigationCount++
@@ -956,7 +1016,14 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 						hasPostedGivingUp := false
 						if listCommentsErr == nil {
 							for _, c := range comments {
-								if strings.EqualFold(c.GetUser().GetLogin(), githubLogin) &&
+								isPoolBot := false
+								for _, bot := range allBotUsers {
+									if strings.EqualFold(c.GetUser().GetLogin(), bot) {
+										isPoolBot = true
+										break
+									}
+								}
+								if isPoolBot &&
 									strings.Contains(c.GetBody(), "giving up. Human assistance is required") &&
 									c.GetCreatedAt().After(lastCommitTime) {
 									hasPostedGivingUp = true
@@ -979,16 +1046,22 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 							} else if running {
 								klog.Infof("Skipping PR #%d investigate because there is an in-flight sandbox %s.", num, sandboxName)
 							} else {
-								if isAssigned(prIssue, targetAssignee) && !unassignedPRs[num] {
+								assignedBot := assignedBotUser(prIssue, allBotUsers)
+								if assignedBot != "" && !unassignedPRs[num] {
 									if dryRun {
-										fmt.Printf("[DRYRUN] Would unassign %s from PR #%d\n", targetAssignee, num)
+										fmt.Printf("[DRYRUN] Would unassign %s from PR #%d\n", assignedBot, num)
 									} else {
-										fmt.Printf("Unassigning %s from PR #%d...\n", targetAssignee, num)
-										if _, _, err := ghClient.Issues.RemoveAssignees(ctx, owner, repo, num, []string{targetAssignee}); err != nil {
-											klog.Errorf("Failed to unassign %s from PR #%d: %v", targetAssignee, num, err)
+										fmt.Printf("Unassigning %s from PR #%d...\n", assignedBot, num)
+										if _, _, err := ghClient.Issues.RemoveAssignees(ctx, owner, repo, num, []string{assignedBot}); err != nil {
+											klog.Errorf("Failed to unassign %s from PR #%d: %v", assignedBot, num, err)
 										}
 										unassignedPRs[num] = true
 									}
+								}
+
+								taskAssignee := assignedBot
+								if taskAssignee == "" {
+									taskAssignee = targetAssignee
 								}
 
 								prURL := fmt.Sprintf("https://github.com/%s/%s/pull/%d", owner, repo, num)
@@ -999,7 +1072,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 									Priority:  getPRPriority(prIssue),
 									Phase:     3,
 									CreatedAt: pr.GetCreatedAt(),
-									Assignee:  targetAssignee,
+									Assignee:  taskAssignee,
 									Status:    "Pending",
 									CommitSHA: headSHA,
 								}
@@ -1085,7 +1158,14 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 							hasPostedIgnore := false
 							ignorePrefix := "🤖 AI Factory is ignoring new comments/feedback because this PR is already approved"
 							for _, c := range comments {
-								if strings.EqualFold(c.GetUser().GetLogin(), githubLogin) &&
+								isPoolBot := false
+								for _, bot := range allBotUsers {
+									if strings.EqualFold(c.GetUser().GetLogin(), bot) {
+										isPoolBot = true
+										break
+									}
+								}
+								if isPoolBot &&
 									strings.HasPrefix(c.GetBody(), ignorePrefix) &&
 									c.GetCreatedAt().After(lastCommitTime) {
 									hasPostedIgnore = true
@@ -1104,7 +1184,8 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 						continue
 					}
 
-					if hasNewComments || (isAssigned(prIssue, targetAssignee) && !unassignedPRs[num]) {
+					assignedBot := assignedBotUser(prIssue, allBotUsers)
+					if hasNewComments || (assignedBot != "" && !unassignedPRs[num]) {
 						if os.Getenv("DRY_RUN") == "true" {
 							continue
 						}
@@ -1118,16 +1199,21 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 							} else if running {
 								klog.Infof("Skipping PR #%d address-comments because there is an in-flight sandbox %s.", num, sandboxName)
 							} else {
-								if isAssigned(prIssue, targetAssignee) && !unassignedPRs[num] {
+								if assignedBot != "" && !unassignedPRs[num] {
 									if dryRun {
-										fmt.Printf("[DRYRUN] Would unassign %s from PR #%d\n", targetAssignee, num)
+										fmt.Printf("[DRYRUN] Would unassign %s from PR #%d\n", assignedBot, num)
 									} else {
-										fmt.Printf("Unassigning %s from PR #%d...\n", targetAssignee, num)
-										if _, _, err := ghClient.Issues.RemoveAssignees(ctx, owner, repo, num, []string{targetAssignee}); err != nil {
-											klog.Errorf("Failed to unassign %s from PR #%d: %v", targetAssignee, num, err)
+										fmt.Printf("Unassigning %s from PR #%d...\n", assignedBot, num)
+										if _, _, err := ghClient.Issues.RemoveAssignees(ctx, owner, repo, num, []string{assignedBot}); err != nil {
+											klog.Errorf("Failed to unassign %s from PR #%d: %v", assignedBot, num, err)
 										}
 										unassignedPRs[num] = true
 									}
+								}
+
+								taskAssignee := assignedBot
+								if taskAssignee == "" {
+									taskAssignee = targetAssignee
 								}
 
 								prURL := fmt.Sprintf("https://github.com/%s/%s/pull/%d", owner, repo, num)
@@ -1138,7 +1224,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 									Priority:  getPRPriority(prIssue),
 									Phase:     2,
 									CreatedAt: pr.GetCreatedAt(),
-									Assignee:  targetAssignee,
+									Assignee:  taskAssignee,
 									Status:    "Pending",
 									CommitSHA: headSHA,
 								}
@@ -1260,15 +1346,15 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 
 			// Process slow issues
 			if issueMode != "disabled" {
-				queueIssueTasks(ctx, ghClient, kubeClient, owner, repo, slowIssues, processedIssues, refIssues, targetAssignee, incomingDir, processingDir, processedDir, queueDir, dryRun, triggerLabel)
+				queueIssueTasks(ctx, ghClient, kubeClient, owner, repo, slowIssues, processedIssues, refIssues, targetAssignee, allBotUsers, incomingDir, processingDir, processedDir, queueDir, dryRun, triggerLabel)
 			}
 
 			// Process Pull Requests (Scanner)
 			var prIssues []*githubv39.Issue
 			var allPRIssues []*githubv39.Issue
-			if targetAssignee != "" {
+			for _, botUser := range allBotUsers {
 				opts1 := &githubv39.IssueListByRepoOptions{
-					Assignee:    targetAssignee,
+					Assignee:    botUser,
 					State:       "open",
 					ListOptions: githubv39.ListOptions{PerPage: 100},
 				}
@@ -1332,9 +1418,9 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 				limit = 30
 			}
 
-			if targetAssignee != "" {
+			for _, botUser := range allBotUsers {
 				opts1 := &githubv39.IssueListByRepoOptions{
-					Assignee:    targetAssignee,
+					Assignee:    botUser,
 					State:       "open",
 					Sort:        "updated",
 					Direction:   "desc",
@@ -1342,9 +1428,9 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 				}
 				issues1, _, err := ghClient.Issues.ListByRepo(ctx, owner, repo, opts1)
 				if err != nil {
-					klog.Errorf("Failed to list issues for assignee %s: %v", targetAssignee, err)
+					klog.Errorf("Failed to list issues for assignee %s: %v", botUser, err)
 				} else {
-					klog.Infof("Fetched %d issues assigned to %s from GitHub API", len(issues1), targetAssignee)
+					klog.Infof("Fetched %d issues assigned to %s from GitHub API", len(issues1), botUser)
 					allItems = append(allItems, issues1...)
 				}
 			}
@@ -1377,8 +1463,13 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 
 						hasAssignee := false
 						for _, u := range issue.Assignees {
-							if strings.EqualFold(u.GetLogin(), targetAssignee) {
-								hasAssignee = true
+							for _, bot := range allBotUsers {
+								if strings.EqualFold(u.GetLogin(), bot) {
+									hasAssignee = true
+									break
+								}
+							}
+							if hasAssignee {
 								break
 							}
 						}
@@ -1425,7 +1516,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 			}
 
 			if issueMode != "disabled" {
-				queueIssueTasks(ctx, ghClient, kubeClient, owner, repo, issues, processedIssues, refIssues, targetAssignee, incomingDir, processingDir, processedDir, queueDir, dryRun, triggerLabel)
+				queueIssueTasks(ctx, ghClient, kubeClient, owner, repo, issues, processedIssues, refIssues, targetAssignee, allBotUsers, incomingDir, processingDir, processedDir, queueDir, dryRun, triggerLabel)
 			}
 
 			// Process PRs assigned to the bot in the fast cycle
@@ -1608,7 +1699,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 						}
 					}
 
-					selectedUser, sUserErr := selectUserForTask(ctx, ghClient, cfg, t.Type, t.Number, owner, repo)
+					selectedUser, sUserErr := selectUserForTask(ctx, ghClient, kubeClient, cfg, t.Type, t.Number, owner, repo)
 					if sUserErr != nil {
 						klog.Errorf("Failed to select user for task %s: %v", taskFilename, sUserErr)
 						t.Status = "Failed"
@@ -1977,7 +2068,7 @@ func cleanupClosedIssueSandboxes(ctx context.Context, ghClient *githubv39.Client
 	return nil
 }
 
-func selectUserForTask(ctx context.Context, ghClient *githubv39.Client, cfg *config.FactoryConfig, taskType string, prNum int, owner, repo string) (string, error) {
+func selectUserForTask(ctx context.Context, ghClient *githubv39.Client, kubeClient *clients.KubernetesClient, cfg *config.FactoryConfig, taskType string, prNum int, owner, repo string) (string, error) {
 	if cfg == nil || len(cfg.Roles) == 0 {
 		return "", nil // default fallback to factory-user
 	}
@@ -2028,6 +2119,36 @@ func selectUserForTask(ctx context.Context, ghClient *githubv39.Client, cfg *con
 	isIssueTask := taskType == "issue-fix" || taskType == "agent-chore"
 	if isIssueTask {
 		if prNum > 0 {
+			// A. First check if a Sandbox already exists for this task on the cluster
+			// and has been pinned to a specific user.
+			var sandboxName string
+			if taskType == "issue-fix" {
+				sandboxName = fmt.Sprintf("fix-%s-%d", repo, prNum)
+			} else if taskType == "agent-chore" {
+				sandboxName = fmt.Sprintf("wf-issue-%d", prNum)
+			}
+
+			if sandboxName != "" && kubeClient != nil {
+				sb, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(rootFlags.Namespace).Get(ctx, sandboxName, metav1.GetOptions{})
+				if err == nil {
+					labels := sb.GetLabels()
+					if user, ok := labels["factory.gemini.google.com/user"]; ok && user != "" {
+						inPool := false
+						for _, u := range roleCfg.Users {
+							if strings.EqualFold(u, user) {
+								inPool = true
+								break
+							}
+						}
+						if inPool {
+							klog.Infof("Pinned user '%s' for issue #%d from existing sandbox '%s'", user, prNum, sandboxName)
+							return user, nil
+						}
+					}
+				}
+			}
+
+			// B. Fallback to GitHub issue assignee check
 			issue, _, err := ghClient.Issues.Get(ctx, owner, repo, prNum)
 			if err == nil {
 				assignee := issue.GetAssignee().GetLogin()

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -1905,19 +1905,36 @@ func getReferencedIssues(pr *githubv39.PullRequest) map[int]bool {
 }
 
 func hasLinkedPR(ctx context.Context, client *githubv39.Client, owner, repo string, issueNum int) (bool, error) {
+	// 1. Try timeline check (quick and standard)
 	timeline, _, err := client.Issues.ListIssueTimeline(ctx, owner, repo, issueNum, nil)
-	if err != nil {
-		return false, err
-	}
-	for _, event := range timeline {
-		if event.GetEvent() == "cross-referenced" && event.Source != nil {
-			if event.Source.Issue != nil && event.Source.Issue.PullRequestLinks != nil {
-				if event.Source.Issue.GetState() == "open" {
-					return true, nil
+	if err == nil {
+		for _, event := range timeline {
+			if event.GetEvent() == "cross-referenced" && event.Source != nil {
+				if event.Source.Issue != nil && event.Source.Issue.PullRequestLinks != nil {
+					if event.Source.Issue.GetState() == "open" {
+						return true, nil
+					}
 				}
 			}
 		}
+	} else {
+		klog.Warningf("Failed to list issue timeline for #%d: %v. Falling back to search API.", issueNum, err)
 	}
+
+	// 2. Fallback to Search API: search for open PRs referencing the issue number
+	query := fmt.Sprintf("repo:%s/%s type:pr state:open \"%d\"", owner, repo, issueNum)
+	opts := &githubv39.SearchOptions{
+		ListOptions: githubv39.ListOptions{PerPage: 10},
+	}
+	result, _, err := client.Search.Issues(ctx, query, opts)
+	if err != nil {
+		return false, fmt.Errorf("failed to search PRs for issue #%d: %w", issueNum, err)
+	}
+
+	if result.GetTotal() > 0 {
+		return true, nil
+	}
+
 	return false, nil
 }
 

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -2024,9 +2024,30 @@ func selectUserForTask(ctx context.Context, ghClient *githubv39.Client, cfg *con
 		}
 	}
 
-	// 2. Select bot based on new vs existing PR
-	isNewWorkflow := prNum == 0 || taskType == "issue-fix"
-	if isNewWorkflow {
+	// 2. Select bot based on new vs existing PR/Issue
+	isIssueTask := taskType == "issue-fix" || taskType == "agent-chore"
+	if isIssueTask {
+		if prNum > 0 {
+			issue, _, err := ghClient.Issues.Get(ctx, owner, repo, prNum)
+			if err == nil {
+				assignee := issue.GetAssignee().GetLogin()
+				if assignee != "" {
+					inPool := false
+					for _, u := range roleCfg.Users {
+						if strings.EqualFold(u, assignee) {
+							inPool = true
+							break
+						}
+					}
+					if inPool {
+						return assignee, nil
+					}
+				}
+			} else {
+				klog.Warningf("Failed to fetch issue details for task %s #%d: %v", taskType, prNum, err)
+			}
+		}
+
 		idx := time.Now().UnixNano() % int64(len(roleCfg.Users))
 		return roleCfg.Users[idx], nil
 	}

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -123,18 +123,6 @@ func NewWatchCommand(ctx context.Context) *cobra.Command {
 	return cmd
 }
 
-func isAssigned(issue *githubv39.Issue, assignee string) bool {
-	if assignee == "" {
-		return false
-	}
-	for _, u := range issue.Assignees {
-		if strings.EqualFold(u.GetLogin(), assignee) {
-			return true
-		}
-	}
-	return false
-}
-
 func assignedBotUser(issue *githubv39.Issue, botUsers []string) string {
 	for _, u := range issue.Assignees {
 		for _, bot := range botUsers {
@@ -170,7 +158,6 @@ func resolveSandboxName(ctx context.Context, kubeClient *clients.KubernetesClien
 
 	return fmt.Sprintf("factory-pr-%d", num)
 }
-
 
 func isSandboxTaskRunning(ctx context.Context, kubeClient *clients.KubernetesClient, namespace, name string) (bool, error) {
 	unstructObj, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -374,7 +374,7 @@ func isWorkflowDefinition(ctx context.Context, ghClient *githubv39.Client, owner
 	return false
 }
 
-func queueIssueTasks(ctx context.Context, ghClient *githubv39.Client, kubeClient *clients.KubernetesClient, owner, repo string, issues []*githubv39.Issue, processedIssues map[int]time.Time, refIssues map[int]bool, targetAssignee string, allBotUsers []string, incomingDir, processingDir, processedDir, queueDir string, dryRun bool, triggerLabel string) {
+func queueIssueTasks(ctx context.Context, ghClient *githubv39.Client, kubeClient *clients.KubernetesClient, cfg *config.FactoryConfig, owner, repo string, issues []*githubv39.Issue, processedIssues map[int]time.Time, refIssues map[int]bool, targetAssignee string, allBotUsers []string, incomingDir, processingDir, processedDir, queueDir string, dryRun bool, triggerLabel string) {
 	klog.Infof("queueIssueTasks called with %d issues", len(issues))
 	for _, issue := range issues {
 		num := issue.GetNumber()
@@ -460,7 +460,16 @@ func queueIssueTasks(ctx context.Context, ghClient *githubv39.Client, kubeClient
 				}
 			}
 
-			taskAssignee := assignedBot
+			taskType := "issue-fix"
+			if workflowName != "" {
+				taskType = "agent-chore"
+			}
+
+			taskAssignee, err := selectUserForTask(ctx, ghClient, kubeClient, cfg, taskType, num, owner, repo)
+			if err != nil {
+				klog.Errorf("Failed to select user for issue #%d: %v", num, err)
+				taskAssignee = targetAssignee
+			}
 			if taskAssignee == "" {
 				taskAssignee = targetAssignee
 			}
@@ -1355,7 +1364,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 
 			// Process slow issues
 			if issueMode != "disabled" {
-				queueIssueTasks(ctx, ghClient, kubeClient, owner, repo, slowIssues, processedIssues, refIssues, targetAssignee, allBotUsers, incomingDir, processingDir, processedDir, queueDir, dryRun, triggerLabel)
+				queueIssueTasks(ctx, ghClient, kubeClient, cfg, owner, repo, slowIssues, processedIssues, refIssues, targetAssignee, allBotUsers, incomingDir, processingDir, processedDir, queueDir, dryRun, triggerLabel)
 			}
 
 			// Process Pull Requests (Scanner)
@@ -1525,7 +1534,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 			}
 
 			if issueMode != "disabled" {
-				queueIssueTasks(ctx, ghClient, kubeClient, owner, repo, issues, processedIssues, refIssues, targetAssignee, allBotUsers, incomingDir, processingDir, processedDir, queueDir, dryRun, triggerLabel)
+				queueIssueTasks(ctx, ghClient, kubeClient, cfg, owner, repo, issues, processedIssues, refIssues, targetAssignee, allBotUsers, incomingDir, processingDir, processedDir, queueDir, dryRun, triggerLabel)
 			}
 
 			// Process PRs assigned to the bot in the fast cycle

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -444,15 +444,17 @@ func queueIssueTasks(ctx context.Context, ghClient *githubv39.Client, kubeClient
 				continue
 			}
 
-			assignedBot := assignedBotUser(issue, allBotUsers)
-			if assignedBot != "" {
+			hasTriggerLabel := false
+			for _, label := range issue.Labels {
+				if strings.EqualFold(label.GetName(), triggerLabel) {
+					hasTriggerLabel = true
+					break
+				}
+			}
+			if !hasTriggerLabel {
 				if dryRun {
-					fmt.Printf("[DRYRUN] Would unassign %s from issue #%d and add label '%s'\n", assignedBot, num, triggerLabel)
+					fmt.Printf("[DRYRUN] Would add label '%s' to issue #%d\n", triggerLabel, num)
 				} else {
-					fmt.Printf("Unassigning %s from issue #%d...\n", assignedBot, num)
-					if _, _, err := ghClient.Issues.RemoveAssignees(ctx, owner, repo, num, []string{assignedBot}); err != nil {
-						klog.Errorf("Failed to unassign %s from issue #%d: %v", assignedBot, num, err)
-					}
 					klog.Infof("Adding '%s' label to issue #%d", triggerLabel, num)
 					if _, _, err := ghClient.Issues.AddLabelsToIssue(ctx, owner, repo, num, []string{triggerLabel}); err != nil {
 						klog.Errorf("Failed to add label '%s' to issue #%d: %v", triggerLabel, num, err)

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -1697,6 +1697,11 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 							if _, _, err := ghClient.Issues.AddAssignees(ctx, owner, repo, t.Number, []string{t.Assignee}); err != nil {
 								klog.Errorf("Failed to assign issue #%d to %s: %v", t.Number, t.Assignee, err)
 							}
+							if t.Assignee != targetAssignee {
+								if _, _, err := ghClient.Issues.RemoveAssignees(ctx, owner, repo, t.Number, []string{targetAssignee}); err != nil {
+									klog.Errorf("Failed to remove watcher bot %s from issue #%d: %v", targetAssignee, t.Number, err)
+								}
+							}
 						}
 
 						if t.Type != "agent-chore" {

--- a/factory/pkg/sandbox/sandbox.go
+++ b/factory/pkg/sandbox/sandbox.go
@@ -9,13 +9,26 @@ import (
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/clients"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/k8s"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 )
 
-func EnsureFixSandbox(ctx context.Context, kubeClient *clients.KubernetesClient, namespace, repoName, taskID, cloneURL, htmlURL, taskTitle, image, diskSize, ephemeralStorage string, secrets []SecretMount, envs []EnvVar) (string, error) {
+func EnsureFixSandbox(ctx context.Context, kubeClient *clients.KubernetesClient, namespace, repoName, taskID, cloneURL, htmlURL, taskTitle, image, diskSize, ephemeralStorage string, secrets []SecretMount, envs []EnvVar, user string) (string, error) {
 	name := fmt.Sprintf("fix-%s-%s", repoName, taskID)
 
-	_, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	sb, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err == nil {
+		labels := sb.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		if labels["factory.gemini.google.com/user"] != user && user != "" {
+			labels["factory.gemini.google.com/user"] = user
+			sb.SetLabels(labels)
+			_, err = kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Update(ctx, sb, metav1.UpdateOptions{})
+			if err != nil {
+				klog.Warningf("Failed to update sandbox labels with user '%s': %v", user, err)
+			}
+		}
 		return name, nil
 	}
 	if !strings.Contains(err.Error(), "not found") {
@@ -33,6 +46,7 @@ func EnsureFixSandbox(ctx context.Context, kubeClient *clients.KubernetesClient,
 			Labels: map[string]string{
 				"sandbox.gemini.google.com/type":    "fix",
 				"factory.gemini.google.com/managed": "true",
+				"factory.gemini.google.com/user":    user,
 			},
 			Annotations: map[string]string{
 				"repo":     repoName,
@@ -48,9 +62,9 @@ func EnsureFixSandbox(ctx context.Context, kubeClient *clients.KubernetesClient,
 		},
 	}
 
-	sb, svc := NewAgentSandbox(opt)
+	sbObj, svc := NewAgentSandbox(opt)
 
-	_, err = kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Create(ctx, sb, metav1.CreateOptions{})
+	_, err = kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Create(ctx, sbObj, metav1.CreateOptions{})
 	if err != nil {
 		return "", fmt.Errorf("creating sandbox CR: %w", err)
 	}
@@ -63,11 +77,12 @@ func EnsureFixSandbox(ctx context.Context, kubeClient *clients.KubernetesClient,
 	return name, nil
 }
 
-func EnsureAgentSandbox(ctx context.Context, kubeClient *clients.KubernetesClient, namespace, repoName, taskID, cloneURL, htmlURL, taskTitle, image, diskSize, ephemeralStorage string, secrets []SecretMount, envs []EnvVar) (string, error) {
+func EnsureAgentSandbox(ctx context.Context, kubeClient *clients.KubernetesClient, namespace, repoName, taskID, cloneURL, htmlURL, taskTitle, image, diskSize, ephemeralStorage string, secrets []SecretMount, envs []EnvVar, user string) (string, error) {
 	name := fmt.Sprintf("agent-%s-%s", repoName, taskID)
 	labels := map[string]string{
 		"sandbox.gemini.google.com/type":    "agent",
 		"factory.gemini.google.com/managed": "true",
+		"factory.gemini.google.com/user":    user,
 	}
 
 	if idx := strings.Index(taskID, "-issue-"); idx != -1 {
@@ -77,8 +92,20 @@ func EnsureAgentSandbox(ctx context.Context, kubeClient *clients.KubernetesClien
 		labels["factory.gemini.google.com/workflow"] = workflowName
 	}
 
-	_, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	sb, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err == nil {
+		labels := sb.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		if labels["factory.gemini.google.com/user"] != user && user != "" {
+			labels["factory.gemini.google.com/user"] = user
+			sb.SetLabels(labels)
+			_, err = kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Update(ctx, sb, metav1.UpdateOptions{})
+			if err != nil {
+				klog.Warningf("Failed to update sandbox labels with user '%s': %v", user, err)
+			}
+		}
 		return name, nil
 	}
 	if !strings.Contains(err.Error(), "not found") {
@@ -108,9 +135,9 @@ func EnsureAgentSandbox(ctx context.Context, kubeClient *clients.KubernetesClien
 		},
 	}
 
-	sb, svc := NewAgentSandbox(opt)
+	sbObj, svc := NewAgentSandbox(opt)
 
-	_, err = kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Create(ctx, sb, metav1.CreateOptions{})
+	_, err = kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Create(ctx, sbObj, metav1.CreateOptions{})
 	if err != nil {
 		return "", fmt.Errorf("creating sandbox CR: %w", err)
 	}
@@ -123,11 +150,23 @@ func EnsureAgentSandbox(ctx context.Context, kubeClient *clients.KubernetesClien
 	return name, nil
 }
 
-func EnsureAdoptSandbox(ctx context.Context, kubeClient *clients.KubernetesClient, namespace, repoName string, prNum int, cloneURL, htmlURL, image, diskSize, ephemeralStorage string, secrets []SecretMount, envs []EnvVar) (string, error) {
+func EnsureAdoptSandbox(ctx context.Context, kubeClient *clients.KubernetesClient, namespace, repoName string, prNum int, cloneURL, htmlURL, image, diskSize, ephemeralStorage string, secrets []SecretMount, envs []EnvVar, user string) (string, error) {
 	name := fmt.Sprintf("adopt-%s-%d", repoName, prNum)
 
-	_, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	sb, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err == nil {
+		labels := sb.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		if labels["factory.gemini.google.com/user"] != user && user != "" {
+			labels["factory.gemini.google.com/user"] = user
+			sb.SetLabels(labels)
+			_, err = kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Update(ctx, sb, metav1.UpdateOptions{})
+			if err != nil {
+				klog.Warningf("Failed to update sandbox labels with user '%s': %v", user, err)
+			}
+		}
 		return name, nil
 	}
 	if !strings.Contains(err.Error(), "not found") {
@@ -145,6 +184,7 @@ func EnsureAdoptSandbox(ctx context.Context, kubeClient *clients.KubernetesClien
 			Labels: map[string]string{
 				"sandbox.gemini.google.com/type":    "adopt",
 				"factory.gemini.google.com/managed": "true",
+				"factory.gemini.google.com/user":    user,
 			},
 			Annotations: map[string]string{
 				"repo":     repoName,
@@ -160,9 +200,9 @@ func EnsureAdoptSandbox(ctx context.Context, kubeClient *clients.KubernetesClien
 		},
 	}
 
-	sb, svc := NewAgentSandbox(opt)
+	sbObj, svc := NewAgentSandbox(opt)
 
-	_, err = kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Create(ctx, sb, metav1.CreateOptions{})
+	_, err = kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Create(ctx, sbObj, metav1.CreateOptions{})
 	if err != nil {
 		return "", fmt.Errorf("creating sandbox CR: %w", err)
 	}

--- a/factory/pkg/tasks/address_feedback.sh
+++ b/factory/pkg/tasks/address_feedback.sh
@@ -79,9 +79,10 @@ EOF
 function setupGitRepos {
     echo "Running setupGitRepos..."
     
-    # Check if repo already exists (reuse sandbox case)
-    if [ ! -d "/workspaces/${REPO_NAME}" ]; then
-        echo "cloning repository"
+    # Check if repo already exists and is a valid git repository
+    if [ ! -d "/workspaces/${REPO_NAME}/.git" ]; then
+        echo "repository does not exist or is invalid, cleaning up destination and cloning..."
+        rm -rf "/workspaces/${REPO_NAME}"
         (cd /workspaces/ && git clone ${CLONE_URL})
     else
         echo "repository already exists, cleaning up previous git state..."

--- a/factory/pkg/tasks/fix_issue.sh
+++ b/factory/pkg/tasks/fix_issue.sh
@@ -82,9 +82,10 @@ EOF
 function setupGitRepos {
     echo "Running setupGitRepos..."
     
-    # Check if repo already exists (reuse sandbox case)
-    if [ ! -d "/workspaces/${REPO_NAME}" ]; then
-        echo "cloning repository"
+    # Check if repo already exists and is a valid git repository
+    if [ ! -d "/workspaces/${REPO_NAME}/.git" ]; then
+        echo "repository does not exist or is invalid, cleaning up destination and cloning..."
+        rm -rf "/workspaces/${REPO_NAME}"
         (cd /workspaces/ && git clone ${CLONE_URL})
     else
         echo "repository already exists, cleaning up previous git state..."

--- a/factory/pkg/tasks/investigate_failures.sh
+++ b/factory/pkg/tasks/investigate_failures.sh
@@ -80,9 +80,10 @@ EOF
 function setupGitRepos {
     echo "Running setupGitRepos..."
     
-    # Check if repo already exists (reuse sandbox case)
-    if [ ! -d "/workspaces/${REPO_NAME}" ]; then
-        echo "cloning repository"
+    # Check if repo already exists and is a valid git repository
+    if [ ! -d "/workspaces/${REPO_NAME}/.git" ]; then
+        echo "repository does not exist or is invalid, cleaning up destination and cloning..."
+        rm -rf "/workspaces/${REPO_NAME}"
         (cd /workspaces/ && git clone ${CLONE_URL})
     else
         echo "repository already exists, cleaning up previous git state..."

--- a/factory/pkg/tasks/iterate.sh
+++ b/factory/pkg/tasks/iterate.sh
@@ -88,9 +88,10 @@ EOF
 function setupGitRepos {
     echo "Running setupGitRepos..."
     
-    # only clone if doesn't exist
-    if [ ! -d "/workspaces/${REPO_NAME}" ]; then
-        echo "cloning repository"
+    # only clone if doesn't exist and is a valid git repository
+    if [ ! -d "/workspaces/${REPO_NAME}/.git" ]; then
+        echo "repository does not exist or is invalid, cleaning up destination and cloning..."
+        rm -rf "/workspaces/${REPO_NAME}"
         (cd /workspaces/ && git clone ${CLONE_URL})
     else
         echo "repository already exists, cleaning up previous git state..."

--- a/factory/pkg/tasks/review.sh
+++ b/factory/pkg/tasks/review.sh
@@ -75,9 +75,10 @@ EOF
 function setupGitRepos {
     echo "Running setupGitRepos..."
     
-    # Check if repo already exists (reuse sandbox case)
-    if [ ! -d "/workspaces/${REPO_NAME}" ]; then
-        echo "cloning repository"
+    # Check if repo already exists and is a valid git repository
+    if [ ! -d "/workspaces/${REPO_NAME}/.git" ]; then
+        echo "repository does not exist or is invalid, cleaning up destination and cloning..."
+        rm -rf "/workspaces/${REPO_NAME}"
         (cd /workspaces/ && git clone ${CLONE_URL})
     else
         echo "repository already exists, cleaning up previous git state..."

--- a/factory/pkg/tasks/run_agent.sh
+++ b/factory/pkg/tasks/run_agent.sh
@@ -83,9 +83,10 @@ EOF
 function setupGitRepos {
     echo "Running setupGitRepos..."
     
-    # Check if repo already exists (reuse sandbox case)
-    if [ ! -d "/workspaces/${REPO_NAME}" ]; then
-        echo "cloning repository"
+    # Check if repo already exists and is a valid git repository
+    if [ ! -d "/workspaces/${REPO_NAME}/.git" ]; then
+        echo "repository does not exist or is invalid, cleaning up destination and cloning..."
+        rm -rf "/workspaces/${REPO_NAME}"
         (cd /workspaces/ && git clone ${CLONE_URL})
     else
         echo "repository already exists, cleaning up previous git state..."

--- a/overseer/examples/install-bot-users.sh
+++ b/overseer/examples/install-bot-users.sh
@@ -1,0 +1,74 @@
+#export ARGUS_GITHUB_TOKEN=..
+#export LOVELACE_GITHUB_TOKEN=..
+#export HOPPER_GITHUB_TOKEN=..
+#export ADA_GITHUB_TOKEN=..
+#export REVIEWBOT_GITHUB_TOKEN=..
+#export DAEDALUS_GITHUB_TOKEN=..
+#export FEYNMAN_GITHUB_TOKEN=..
+#export WALLE_GITHUB_TOKEN=..
+
+factory user onboard \
+  --user argus-watcher-bot \
+  --namespace overseer-system \
+  --github-login argus-watcher-bot \
+  --github-token $ARGUS_GITHUB_TOKEN \
+  --github-email argus-watcher-bot@google.com \
+  --gemini-key $GEMINI_API_KEY
+
+
+factory user onboard \
+  --user lovelace-coder-bot \
+  --namespace overseer-system \
+  --github-login lovelace-coder-bot \
+  --github-token $LOVELACE_GITHUB_TOKEN \
+  --github-email lovelace-coder-bot@google.com \
+  --gemini-key $GEMINI_API_KEY
+
+factory user onboard \
+  --user hopper-coder-bot \
+  --namespace overseer-system \
+  --github-login hopper-coder-bot \
+  --github-token $HOPPER_GITHUB_TOKEN \
+  --github-email hopper-coder-bot@google.com \
+  --gemini-key $GEMINI_API_KEY
+
+factory user onboard \
+  --user ada-coder-bot \
+  --namespace overseer-system \
+  --github-login ada-coder-bot \
+  --github-token $ADA_GITHUB_TOKEN \
+  --github-email ada-coder-bot@google.com \
+  --gemini-key $GEMINI_API_KEY
+
+factory user onboard \
+  --user reviewbot-robot \
+  --namespace overseer-system \
+  --github-login reviewbot-robot \
+  --github-token $REVIEWBOT_GITHUB_TOKEN \
+  --github-email reviewbot-robot@google.com \
+  --gemini-key $GEMINI_API_KEY
+
+factory user onboard \
+  --user daedalus-agent-bot \
+  --namespace overseer-system \
+  --github-login daedalus-agent-bot \
+  --github-token $DAEDALUS_GITHUB_TOKEN \
+  --github-email daedalus-agent-bot@google.com \
+  --gemini-key $GEMINI_API_KEY
+
+factory user onboard \
+  --user feynman-agent-bot \
+  --namespace overseer-system \
+  --github-login feynman-agent-bot \
+  --github-token $FEYNMAN_GITHUB_TOKEN \
+  --github-email feynman-agent-bot@google.com \
+  --gemini-key $GEMINI_API_KEY
+
+factory user onboard \
+  --user walle-agent-bot \
+  --namespace overseer-system \
+  --github-login walle-agent-bot \
+  --github-token $WALLE_GITHUB_TOKEN \
+  --github-email walle-agent-bot@google.com \
+  --gemini-key $GEMINI_API_KEY
+

--- a/overseer/examples/install-bot-users.sh
+++ b/overseer/examples/install-bot-users.sh
@@ -7,6 +7,8 @@
 #export FEYNMAN_GITHUB_TOKEN=..
 #export WALLE_GITHUB_TOKEN=..
 
+alias factory=../factory/bin/factory
+
 factory user onboard \
   --user argus-watcher-bot \
   --namespace overseer-system \

--- a/overseer/examples/kcc.yaml
+++ b/overseer/examples/kcc.yaml
@@ -22,3 +22,21 @@ spec:
     issueMode: enabled
     prMode: enabled
     reviewMode: disabled
+  roles:
+    watcher:
+      users:
+        - argus-watcher-bot
+        #- spock-watcher-bot
+    coder:
+      users:
+        - lovelace-coder-bot
+        - hopper-coder-bot
+        - ada-coder-bot
+    reviewer:
+      users:
+        - reviewbot-robot
+    agent:
+      users:
+        - daedalus-agent-bot
+        - feynman-agent-bot
+        - walle-agent-bot

--- a/overseer/examples/kcc.yaml
+++ b/overseer/examples/kcc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kcc
 spec:
   repoURL: https://github.com/GoogleCloudPlatform/k8s-config-connector
-  robotAccount: factorybot-robot
+  robotAccount: argus-watcher-bot
   maxActiveReviews: 20
   maxActiveIssues: 11
   chores:

--- a/overseer/pkg/controllers/overseer_controller.go
+++ b/overseer/pkg/controllers/overseer_controller.go
@@ -347,6 +347,11 @@ func (r *OverseerReconciler) ensureSecrets(ctx context.Context, o *overseerv1alp
 					userSecret, err = r.findSecret(ctx, fmt.Sprintf("user-%s", user), []string{o.Namespace, "overseer-system"})
 				}
 			}
+			if err != nil {
+				if errors.IsNotFound(err) {
+					userSecret, err = r.findSecret(ctx, fmt.Sprintf("factory-user-%s", user), []string{o.Namespace, "overseer-system"})
+				}
+			}
 
 			if err != nil {
 				if errors.IsNotFound(err) {

--- a/overseer/pkg/controllers/overseer_controller.go
+++ b/overseer/pkg/controllers/overseer_controller.go
@@ -341,10 +341,10 @@ func (r *OverseerReconciler) ensureSecrets(ctx context.Context, o *overseerv1alp
 				continue
 			}
 
-			userSecret, err := r.findSecret(ctx, user, []string{o.Namespace, "overseer-system"})
+			userSecret, err := r.findSecret(ctx, fmt.Sprintf("user-%s", user), []string{o.Namespace, "overseer-system"})
 			if err != nil {
 				if errors.IsNotFound(err) {
-					userSecret, err = r.findSecret(ctx, fmt.Sprintf("user-%s", user), []string{o.Namespace, "overseer-system"})
+					userSecret, err = r.findSecret(ctx, user, []string{o.Namespace, "overseer-system"})
 				}
 			}
 			if err != nil {
@@ -366,7 +366,7 @@ func (r *OverseerReconciler) ensureSecrets(ctx context.Context, o *overseerv1alp
 			uEmail := getSecretValue(userSecret, "GITHUB_EMAIL", "email")
 			uToken := getSecretValue(userSecret, "GITHUB_TOKEN", "pat")
 
-			targetSecretName := fmt.Sprintf("factory-user-%s", user)
+			targetSecretName := fmt.Sprintf("user-%s", user)
 			if err := r.reconcileFactorySecret(ctx, targetSecretName, targetNamespace, uLogin, uEmail, uToken, geminiAPIKey); err != nil {
 				return err
 			}

--- a/overseer/pkg/overseer/overseer.go
+++ b/overseer/pkg/overseer/overseer.go
@@ -114,7 +114,7 @@ func newOverseerSandboxFromOverseer(o *overseerv1alpha1.Overseer, name, namespac
 
 	secretName := "factory-user"
 	if roleSpec, ok := o.Spec.Roles["watcher"]; ok && len(roleSpec.Users) > 0 && roleSpec.Users[0] != "" {
-		secretName = fmt.Sprintf("factory-user-%s", roleSpec.Users[0])
+		secretName = fmt.Sprintf("user-%s", roleSpec.Users[0])
 	}
 
 	env := []interface{}{

--- a/repo-agent/pkg/tasks/address_feedback.sh
+++ b/repo-agent/pkg/tasks/address_feedback.sh
@@ -87,9 +87,10 @@ EOF
 function setupGitRepos {
     echo "Running setupGitRepos..."
     
-    # Check if repo already exists (reuse sandbox case)
-    if [ ! -d "/workspaces/${REPO_NAME}" ]; then
-        echo "cloning repository"
+    # Check if repo already exists and is a valid git repository
+    if [ ! -d "/workspaces/${REPO_NAME}/.git" ]; then
+        echo "repository does not exist or is invalid, cleaning up destination and cloning..."
+        rm -rf "/workspaces/${REPO_NAME}"
         (cd /workspaces/ && git clone ${CLONE_URL})
     else
         echo "repository already exists, cleaning up previous git state..."

--- a/repo-agent/pkg/tasks/chore.sh
+++ b/repo-agent/pkg/tasks/chore.sh
@@ -70,7 +70,7 @@ EOF
 
 function setupGitRepos {
     echo "Running setupGitRepos..."
-    if [ -d "/workspaces/${REPO_NAME}" ]; then
+    if [ -d "/workspaces/${REPO_NAME}/.git" ]; then
         echo "Repository already exists at /workspaces/${REPO_NAME}, cleaning up previous git state..."
         (cd "/workspaces/${REPO_NAME}" && git rebase --abort 2>/dev/null || true)
         (cd "/workspaces/${REPO_NAME}" && git merge --abort 2>/dev/null || true)
@@ -82,6 +82,7 @@ function setupGitRepos {
     
     echo "cloning repository"
     # Clone into the specific REPO_NAME directory to ensure consistency
+    rm -rf "/workspaces/${REPO_NAME}"
     git clone "${CLONE_URL}" "/workspaces/${REPO_NAME}"
 
     echo "running gh repo fork"

--- a/repo-agent/pkg/tasks/dev_setup.sh
+++ b/repo-agent/pkg/tasks/dev_setup.sh
@@ -74,9 +74,10 @@ function injectConfigDirData {
 function setupGitRepos {
     echo "Running setupGitRepos..."
     
-    # Check if repo already exists (reuse sandbox case)
-    if [ ! -d "/workspaces/${REPO_NAME}" ]; then
-        echo "cloning repository from ${CLONE_URL}"
+    # Check if repo already exists and is a valid git repository
+    if [ ! -d "/workspaces/${REPO_NAME}/.git" ]; then
+        echo "repository does not exist or is invalid, cleaning up destination and cloning..."
+        rm -rf "/workspaces/${REPO_NAME}"
         (cd /workspaces/ && git clone "${CLONE_URL}" "${REPO_NAME}")
 
         # Ensure we have the fork and remotes set up correctly

--- a/repo-agent/pkg/tasks/fix_issue.sh
+++ b/repo-agent/pkg/tasks/fix_issue.sh
@@ -88,9 +88,10 @@ EOF
 function setupGitRepos {
     echo "Running setupGitRepos..."
     
-    # Check if repo already exists (reuse sandbox case)
-    if [ ! -d "/workspaces/${REPO_NAME}" ]; then
-        echo "cloning repository"
+    # Check if repo already exists and is a valid git repository
+    if [ ! -d "/workspaces/${REPO_NAME}/.git" ]; then
+        echo "repository does not exist or is invalid, cleaning up destination and cloning..."
+        rm -rf "/workspaces/${REPO_NAME}"
         (cd /workspaces/ && git clone ${CLONE_URL})
     else
         echo "repository already exists, cleaning up previous git state..."

--- a/repo-agent/pkg/tasks/investigate_failures.sh
+++ b/repo-agent/pkg/tasks/investigate_failures.sh
@@ -86,9 +86,10 @@ EOF
 function setupGitRepos {
     echo "Running setupGitRepos..."
     
-    # Check if repo already exists (reuse sandbox case)
-    if [ ! -d "/workspaces/${REPO_NAME}" ]; then
-        echo "cloning repository"
+    # Check if repo already exists and is a valid git repository
+    if [ ! -d "/workspaces/${REPO_NAME}/.git" ]; then
+        echo "repository does not exist or is invalid, cleaning up destination and cloning..."
+        rm -rf "/workspaces/${REPO_NAME}"
         (cd /workspaces/ && git clone ${CLONE_URL})
     else
         echo "repository already exists, cleaning up previous git state..."

--- a/repo-agent/pkg/tasks/iterate.sh
+++ b/repo-agent/pkg/tasks/iterate.sh
@@ -89,9 +89,10 @@ EOF
 function setupGitRepos {
     echo "Running setupGitRepos..."
     
-    # only clone if doesn't exist
-    if [ ! -d "/workspaces/${REPO_NAME}" ]; then
-        echo "cloning repository"
+    # only clone if doesn't exist and is a valid git repository
+    if [ ! -d "/workspaces/${REPO_NAME}/.git" ]; then
+        echo "repository does not exist or is invalid, cleaning up destination and cloning..."
+        rm -rf "/workspaces/${REPO_NAME}"
         (cd /workspaces/ && git clone ${CLONE_URL})
     else
         echo "repository already exists, cleaning up previous git state..."

--- a/repo-agent/pkg/tasks/rollback.sh
+++ b/repo-agent/pkg/tasks/rollback.sh
@@ -57,7 +57,7 @@ EOF
 
 function setupGitRepos {
     echo "Running setupGitRepos..."
-    if [ -d "/workspaces/${REPO_NAME}" ]; then
+    if [ -d "/workspaces/${REPO_NAME}/.git" ]; then
         echo "Repository already exists at /workspaces/${REPO_NAME}, cleaning up previous git state..."
         (cd "/workspaces/${REPO_NAME}" && git rebase --abort 2>/dev/null || true)
         (cd "/workspaces/${REPO_NAME}" && git merge --abort 2>/dev/null || true)
@@ -66,7 +66,8 @@ function setupGitRepos {
         (cd "/workspaces/${REPO_NAME}" && git fetch origin)
     else
         echo "cloning repository"
-        git clone "${CLONE_URL}" "/workspaces/${REPO_NAME}"
+        rm -rf "/workspaces/${REPO_NAME}"
+    git clone "${CLONE_URL}" "/workspaces/${REPO_NAME}"
     fi
 
     pushd "/workspaces/${REPO_NAME}" > /dev/null


### PR DESCRIPTION
### 1. Bot Identity & Assignment Stickiness
* **Queue-Time Bot Resolution**: The watch loop now resolves the specific bot user (e.g. `feynman-agent-bot` or `lovelace-coder-bot`) from the role pool at queue-time, saving it directly in the task file. This ensures that the task is sticky to a single bot user even across overseer restarts and prevents the creation of duplicate PRs from multiple bot forks.
* **Redundant API Cleanup**: Removed the redundant flow of unassigning bots at queue-time and then assigning them back. If a specific bot claims a task, the watcher bot is automatically unassigned on execution, ensuring clean assignments.

### 2. Task Serialization & Concurrency Safety
* **Sandbox Serialization**: The watch runner now groups queue tasks by their target sandboxes and runs them sequentially rather than in parallel. This completely eliminates file write and Git index conflicts (`index.lock: File exists`) when multiple tasks (e.g. `investigate` and `address-comments`) are queued for the same PR.
* **Dynamic Sandbox Mapping**: The runner now dynamically maps PR tasks to the parent issue's sandbox (e.g. `fix-k8s-config-connector-10389` instead of guessing `factory-pr-10390`), allowing it to correctly detect if the sandbox is busy.

### 3. Stability & Safety Guardrails
* **PR Author Comment Filter**: Added a filter to ignore comments, reviews, or inline feedback authored by the PR author bot itself. This breaks the infinite loop of the bot responding to its own status reports.
* **Resilient Git Initialization**: Updated all 13 sandbox task scripts to check for a valid `.git` folder on boot. If the repository directory exists but is incomplete or corrupted (e.g. from an aborted clone), it is automatically wiped and cloned cleanly.
* **Orchestration Boundaries**: Added strict safety guardrails in migration workflows (`kcc-example` and `kcc-greenfield`) to forbid checklist agents from writing code or creating PRs directly, ensuring they only orchestrate and delegate code fixes to coders.

The repository is clean, linted, compiled, and all changes have been pushed to the `fix-multibot` branch.turn_ended
**Turn ended.** All requested tasks have been successfully completed, and a clean overall summary of changes was delivered. The workspace and code are fully aligned and updated. Turn complete.
