### PR TITLE
feat(factory): support workflow cooldowns, self-healing sandbox resolution, and PR author task assignment

### DIFF
--- a/.agents/workflows/kcc-direct-migration-tracker.txt
+++ b/.agents/workflows/kcc-direct-migration-tracker.txt
@@ -3,6 +3,7 @@ description: Tracks the overall status of KCC resource migration from TF/DCL to 
 name: kcc-direct-migration-tracker
 schedule: never
 mode: workflow
+cooldown: 6h
 ---
 
 # Role

--- a/.agents/workflows/kcc-example.txt
+++ b/.agents/workflows/kcc-example.txt
@@ -18,7 +18,7 @@ Instead of doing the coding yourself under this skill, you will coordinate and o
 > [!IMPORTANT]
 > **Safety Guardrails (Strict Enforcement)**:
 > - **Do NOT write code or create PRs directly**: You must **never** checkout code, write code, run builds/tests, commit changes, or run `gh pr create` to send/push PRs. Your role under this skill is strictly limited to planning, progress tracking, and orchestration. All code implementation, CI fixing, and triage work must be delegated to coder and reviewer bots by creating child issues or assigning PRs back to their author bots.
-> - **Do NOT comment on child Pull Requests**: You must **never** comment directly on the child Pull Requests. The watch daemon will automatically monitor and handle PR review feedback and CI check failures. If you need to request action or re-trigger a run, do so only by assigning the PR to the PR author bot (using `gh pr edit <pr> --add-assignee <author>` or assigning via `gh` CLI).
+> - **Do NOT comment on child Pull Requests**: You must **never** comment directly on the child Pull Requests. The watch daemon will automatically monitor and handle PR review feedback and CI check failures. If you need to request action or re-trigger a run, do so only by assigning the PR to the PR author bot (using `gh pr edit <pr> --add-assignee <author>` or assigning via `gh` CLI). However, if the PR has the `overseer/giving-up` label, you MUST NOT assign the PR back to the bot, as this indicates the retry limit was reached and human OWNER intervention is required.
 > - **Do NOT approve, LGTM, or label PRs**: You must **never** approve, LGTM, or add approval/merging labels (such as `lgtm`, `approved`, or `automerge`) to any Pull Requests. These actions require human OWNER review and approval.
 
 

--- a/.agents/workflows/kcc-greenfield.txt
+++ b/.agents/workflows/kcc-greenfield.txt
@@ -20,7 +20,7 @@ Instead of doing the coding yourself under this skill, you will coordinate and o
 > [!IMPORTANT]
 > **Safety Guardrails (Strict Enforcement)**:
 > - **Do NOT write code or create PRs directly**: You must **never** checkout code, write code, run builds/tests, commit changes, or run `gh pr create` to send/push PRs. Your role under this skill is strictly limited to planning, progress tracking, and orchestration. All code implementation, CI fixing, and triage work must be delegated to coder and reviewer bots by creating child issues or assigning PRs back to their author bots.
-> - **Do NOT comment on child Pull Requests**: You must **never** comment directly on the child Pull Requests. The watch daemon will automatically monitor and handle PR review feedback and CI check failures. If you need to request action or re-trigger a run, do so only by assigning the PR to the PR author bot (using `gh pr edit <pr> --add-assignee <author>` or assigning via `gh` CLI).
+> - **Do NOT comment on child Pull Requests**: You must **never** comment directly on the child Pull Requests. The watch daemon will automatically monitor and handle PR review feedback and CI check failures. If you need to request action or re-trigger a run, do so only by assigning the PR to the PR author bot (using `gh pr edit <pr> --add-assignee <author>` or assigning via `gh` CLI). However, if the PR has the `overseer/giving-up` label, you MUST NOT assign the PR back to the bot, as this indicates the retry limit was reached and human OWNER intervention is required.
 > - **Do NOT approve, LGTM, or label PRs**: You must **never** approve, LGTM, or add approval/merging labels (such as `lgtm`, `approved`, or `automerge`) to any Pull Requests. These actions require human OWNER review and approval.
 
 

--- a/factory/pkg/commands/agent.go
+++ b/factory/pkg/commands/agent.go
@@ -38,8 +38,10 @@ type AgentDefinition struct {
 	Schedule    string `yaml:"schedule"`
 	SkipPR      bool   `yaml:"skipPR,omitempty"`
 	Mode        string `yaml:"mode,omitempty"`
+	Cooldown    string `yaml:"cooldown,omitempty"`
 	Prompt      string `yaml:"-"`
 }
+
 
 func NewAgentCommand(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{

--- a/factory/pkg/commands/agent.go
+++ b/factory/pkg/commands/agent.go
@@ -42,7 +42,6 @@ type AgentDefinition struct {
 	Prompt      string `yaml:"-"`
 }
 
-
 func NewAgentCommand(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "agent",

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -1068,7 +1068,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 
 							taskAssignee := assignedBot
 							if taskAssignee == "" {
-								taskAssignee = targetAssignee
+								taskAssignee = author
 							}
 
 							prURL := fmt.Sprintf("https://github.com/%s/%s/pull/%d", owner, repo, num)
@@ -1142,6 +1142,24 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 							assignedBot = ""
 						}
 					}
+					// Remove the giving up label if present
+					hasGivingUpLabel := false
+					for _, l := range prIssue.Labels {
+						if l.GetName() == "overseer/giving-up" {
+							hasGivingUpLabel = true
+							break
+						}
+					}
+					if hasGivingUpLabel {
+						if dryRun {
+							fmt.Printf("[DRYRUN] Would remove giving up label from PR #%d due to new commit %s\n", num, headSHA)
+						} else {
+							fmt.Printf("Removing giving up label from PR #%d due to new commit %s...\n", num, headSHA)
+							if _, err := ghClient.Issues.RemoveLabelForIssue(ctx, owner, repo, num, "overseer/giving-up"); err != nil {
+								klog.Errorf("Failed to remove giving up label from PR #%d: %v", num, err)
+							}
+						}
+					}
 				}
 
 				if hasFailure {
@@ -1166,30 +1184,34 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 							}
 						}
 
-						if investigationCount >= 3 && !isExplicitlyAssigned {
-							// Post giving up comment if we haven't already posted it since the last commit
-							hasPostedGivingUp := false
-							if listCommentsErr == nil {
-								for _, c := range comments {
-									isPoolBot := false
-									for _, bot := range allBotUsers {
-										if strings.EqualFold(c.GetUser().GetLogin(), bot) {
-											isPoolBot = true
-											break
-										}
-									}
-									if isPoolBot &&
-										strings.Contains(c.GetBody(), "giving up. Human assistance is required") &&
-										c.GetCreatedAt().After(lastCommitTime) {
-										hasPostedGivingUp = true
+						// Post giving up comment if we haven't already posted it since the last commit
+						hasPostedGivingUp := false
+						if listCommentsErr == nil {
+							for _, c := range comments {
+								isPoolBot := false
+								for _, bot := range allBotUsers {
+									if strings.EqualFold(c.GetUser().GetLogin(), bot) {
+										isPoolBot = true
 										break
 									}
 								}
-							}
-							if !dryRun {
-								if !hasPostedGivingUp {
-									addGitHubComment(ctx, ghClient, owner, repo, num, "🤖 AI Factory has attempted to fix CI failures for this PR 3 times since the last commit and is giving up. Human assistance is required.")
+								if isPoolBot &&
+									strings.Contains(c.GetBody(), "giving up. Human assistance is required") &&
+									c.GetCreatedAt().After(lastCommitTime) {
+									hasPostedGivingUp = true
+									break
 								}
+							}
+						}
+
+						if hasPostedGivingUp {
+							klog.Infof("Skipping PR #%d investigate because the bot has already given up on the current commit.", num)
+							continue
+						}
+
+						if investigationCount >= 3 && !isExplicitlyAssigned {
+							if !dryRun {
+								addGitHubComment(ctx, ghClient, owner, repo, num, "🤖 AI Factory has attempted to fix CI failures for this PR 3 times since the last commit and is giving up. Human assistance is required.")
 								if assignedBot != "" && !unassignedPRs[num] {
 									fmt.Printf("Unassigning bot %s from PR #%d because it has given up...\n", assignedBot, num)
 									if _, _, err := ghClient.Issues.RemoveAssignees(ctx, owner, repo, num, []string{assignedBot}); err != nil {
@@ -1197,61 +1219,65 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 									}
 									unassignedPRs[num] = true
 								}
-							}
-							klog.Infof("Skipping PR #%d investigate because it has reached the maximum retry limit (3).", num)
-						} else {
-							prevFailed := false
-							processedPath := filepath.Join(processedDir, filename)
-							if data, err := os.ReadFile(processedPath); err == nil {
-								var t QueueTask
-								if err := yaml.Unmarshal(data, &t); err == nil {
-									if t.Status == "Failed" {
-										prevFailed = true
-									}
+								if _, _, err := ghClient.Issues.AddLabelsToIssue(ctx, owner, repo, num, []string{"overseer/giving-up"}); err != nil {
+									klog.Errorf("Failed to add giving up label to PR #%d: %v", num, err)
 								}
 							}
+							klog.Infof("Skipping PR #%d investigate because it has reached the maximum retry limit (3).", num)
+							continue
+						}
 
-							if state.lastSHA != headSHA || prevFailed || isExplicitlyAssigned || time.Since(state.lastInvestigatedTime) > 6*time.Hour {
-								sandboxName := resolveSandboxName(ctx, kubeClient, ghClient, "pr-investigate", num, owner, repo)
-								running, err := isSandboxTaskRunning(ctx, kubeClient, rootFlags.Namespace, sandboxName)
-								if err != nil {
-									klog.Errorf("Failed to check if sandbox %s is running: %v", sandboxName, err)
-									continue
-								} else if running {
-									klog.Infof("Skipping PR #%d investigate because there is an in-flight sandbox %s.", num, sandboxName)
+						prevFailed := false
+						processedPath := filepath.Join(processedDir, filename)
+						if data, err := os.ReadFile(processedPath); err == nil {
+							var t QueueTask
+							if err := yaml.Unmarshal(data, &t); err == nil {
+								if t.Status == "Failed" {
+									prevFailed = true
+								}
+							}
+						}
+
+						if state.lastSHA != headSHA || prevFailed || isExplicitlyAssigned || time.Since(state.lastInvestigatedTime) > 6*time.Hour {
+							sandboxName := resolveSandboxName(ctx, kubeClient, ghClient, "pr-investigate", num, owner, repo)
+							running, err := isSandboxTaskRunning(ctx, kubeClient, rootFlags.Namespace, sandboxName)
+							if err != nil {
+								klog.Errorf("Failed to check if sandbox %s is running: %v", sandboxName, err)
+								continue
+							} else if running {
+								klog.Infof("Skipping PR #%d investigate because there is an in-flight sandbox %s.", num, sandboxName)
+							} else {
+								assignedBot := assignedBotUser(prIssue, allBotUsers)
+
+								taskAssignee := assignedBot
+								if taskAssignee == "" {
+									taskAssignee = author
+								}
+
+								prURL := fmt.Sprintf("https://github.com/%s/%s/pull/%d", owner, repo, num)
+								task := &QueueTask{
+									Type:      "pr-investigate",
+									URL:       prURL,
+									Number:    num,
+									Priority:  getPRPriority(prIssue),
+									Phase:     3,
+									CreatedAt: pr.GetCreatedAt(),
+									Assignee:  taskAssignee,
+									Status:    "Pending",
+									CommitSHA: headSHA,
+								}
+
+								if dryRun {
+									fmt.Printf("[DRYRUN] Would queue investigate task for PR #%d: %s\n", num, prURL)
 								} else {
-									assignedBot := assignedBotUser(prIssue, allBotUsers)
-
-									taskAssignee := assignedBot
-									if taskAssignee == "" {
-										taskAssignee = targetAssignee
-									}
-
-									prURL := fmt.Sprintf("https://github.com/%s/%s/pull/%d", owner, repo, num)
-									task := &QueueTask{
-										Type:      "pr-investigate",
-										URL:       prURL,
-										Number:    num,
-										Priority:  getPRPriority(prIssue),
-										Phase:     3,
-										CreatedAt: pr.GetCreatedAt(),
-										Assignee:  taskAssignee,
-										Status:    "Pending",
-										CommitSHA: headSHA,
-									}
-
-									if dryRun {
-										fmt.Printf("[DRYRUN] Would queue investigate task for PR #%d: %s\n", num, prURL)
+									fmt.Printf("Queueing investigate task for PR #%d...\n", num)
+									state.lastSHA = headSHA
+									state.lastInvestigatedTime = time.Now()
+									processedPRs[num] = state
+									if err := writeTaskAtomically(incomingDir, filename, task); err != nil {
+										klog.Errorf("Failed to queue investigate task for PR #%d: %v", num, err)
 									} else {
-										fmt.Printf("Queueing investigate task for PR #%d...\n", num)
-										state.lastSHA = headSHA
-										state.lastInvestigatedTime = time.Now()
-										processedPRs[num] = state
-										if err := writeTaskAtomically(incomingDir, filename, task); err != nil {
-											klog.Errorf("Failed to queue investigate task for PR #%d: %v", num, err)
-										} else {
-											writeTaskJournalEvent(queueDir, filename, task, "Created", 0)
-										}
+										writeTaskJournalEvent(queueDir, filename, task, "Created", 0)
 									}
 								}
 							}
@@ -1373,7 +1399,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 							} else {
 								taskAssignee := assignedBot
 								if taskAssignee == "" {
-									taskAssignee = targetAssignee
+									taskAssignee = author
 								}
 
 								prURL := fmt.Sprintf("https://github.com/%s/%s/pull/%d", owner, repo, num)

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -134,7 +134,7 @@ func assignedBotUser(issue *githubv39.Issue, botUsers []string) string {
 	return ""
 }
 
-func resolveSandboxName(ctx context.Context, kubeClient *clients.KubernetesClient, taskType string, num int, repo string) string {
+func resolveSandboxName(ctx context.Context, kubeClient *clients.KubernetesClient, ghClient *githubv39.Client, taskType string, num int, owner, repo string) string {
 	if taskType == "issue-fix" || taskType == "agent-chore" {
 		wfName := fmt.Sprintf("wf-issue-%d", num)
 		if kubeClient != nil {
@@ -153,6 +153,27 @@ func resolveSandboxName(ctx context.Context, kubeClient *clients.KubernetesClien
 		sbs, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(rootFlags.Namespace).List(ctx, listOpts)
 		if err == nil && len(sbs.Items) > 0 {
 			return sbs.Items[0].GetName()
+		}
+	}
+
+	// If no sandbox is labeled with this PR, try to find a matching issue sandbox by checking referenced issues
+	if kubeClient != nil && ghClient != nil && owner != "" {
+		pr, _, err := ghClient.PullRequests.Get(ctx, owner, repo, num)
+		if err == nil {
+			// Find referenced issue numbers
+			referencedIssues := getReferencedIssues(pr)
+			for issueNum := range referencedIssues {
+				// Check if there is an active/existing sandbox for this issue
+				issueSandboxName := fmt.Sprintf("fix-%s-%d", repo, issueNum)
+				if _, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(rootFlags.Namespace).Get(ctx, issueSandboxName, metav1.GetOptions{}); err == nil {
+					// We found a matching issue sandbox! Alias it to the PR now for future lookups.
+					klog.Infof("Self-healing: Found matching issue sandbox '%s' for PR #%d. Aliasing sandbox to PR...", issueSandboxName, num)
+					if aliasErr := factorysandbox.AliasSandboxToPR(ctx, kubeClient, rootFlags.Namespace, issueSandboxName, num, pr.GetHTMLURL()); aliasErr != nil {
+						klog.Warningf("Failed to dynamically alias sandbox '%s' to PR #%d: %v", issueSandboxName, num, aliasErr)
+					}
+					return issueSandboxName
+				}
+			}
 		}
 	}
 
@@ -1035,7 +1056,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 				if isConflicting {
 					filename := fmt.Sprintf("task-pr-%d-iterate.yaml", num)
 					if !taskExists(incomingDir, processingDir, filename) {
-						sandboxName := resolveSandboxName(ctx, kubeClient, "pr-iterate", num, repo)
+						sandboxName := resolveSandboxName(ctx, kubeClient, ghClient, "pr-iterate", num, owner, repo)
 						running, err := isSandboxTaskRunning(ctx, kubeClient, rootFlags.Namespace, sandboxName)
 						if err != nil {
 							klog.Errorf("Failed to check if sandbox %s is running: %v", sandboxName, err)
@@ -1191,7 +1212,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 							}
 
 							if state.lastSHA != headSHA || prevFailed || isExplicitlyAssigned || time.Since(state.lastInvestigatedTime) > 6*time.Hour {
-								sandboxName := resolveSandboxName(ctx, kubeClient, "pr-investigate", num, repo)
+								sandboxName := resolveSandboxName(ctx, kubeClient, ghClient, "pr-investigate", num, owner, repo)
 								running, err := isSandboxTaskRunning(ctx, kubeClient, rootFlags.Namespace, sandboxName)
 								if err != nil {
 									klog.Errorf("Failed to check if sandbox %s is running: %v", sandboxName, err)
@@ -1342,7 +1363,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 						}
 						filename := fmt.Sprintf("task-pr-%d-comments.yaml", num)
 						if !taskExists(incomingDir, processingDir, filename) {
-							sandboxName := resolveSandboxName(ctx, kubeClient, "pr-comments", num, repo)
+							sandboxName := resolveSandboxName(ctx, kubeClient, ghClient, "pr-comments", num, owner, repo)
 							running, err := isSandboxTaskRunning(ctx, kubeClient, rootFlags.Namespace, sandboxName)
 							if err != nil {
 								klog.Errorf("Failed to check if sandbox %s is running: %v", sandboxName, err)
@@ -1787,7 +1808,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 				filename := item.filename
 				task := item.task
 
-				sandboxName := resolveSandboxName(ctx, kubeClient, task.Type, task.Number, repo)
+				sandboxName := resolveSandboxName(ctx, kubeClient, ghClient, task.Type, task.Number, owner, repo)
 				if activeSandboxesInCycle[sandboxName] {
 					klog.Infof("Skipping task %s because sandbox %s is already scheduled to run a task in this cycle.", filename, sandboxName)
 					continue
@@ -2000,7 +2021,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 									sandboxName = fmt.Sprintf("agent-%s-%d", repo, t.Number)
 								}
 							case "pr-investigate", "pr-comments", "pr-iterate", "pr-review":
-								sandboxName = resolveSandboxName(ctx, kubeClient, t.Type, t.Number, repo)
+								sandboxName = resolveSandboxName(ctx, kubeClient, ghClient, t.Type, t.Number, owner, repo)
 							}
 
 							if sandboxName != "" {

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -426,6 +426,44 @@ func isWorkflowDefinition(ctx context.Context, ghClient *githubv39.Client, owner
 	return false
 }
 
+func getWorkflowCooldown(ctx context.Context, ghClient *githubv39.Client, owner, repo, path string) time.Duration {
+	defaultCooldown := 10 * time.Minute
+	if path == "" {
+		return defaultCooldown
+	}
+
+	var content []byte
+	var err error
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		content, err = fetchWorkflowContent(ctx, ghClient, path)
+	} else {
+		cleanPath := strings.TrimPrefix(path, "./")
+		cleanPath = strings.TrimPrefix(cleanPath, "/")
+		var fileContent *githubv39.RepositoryContent
+		fileContent, _, _, err = ghClient.Repositories.GetContents(ctx, owner, repo, cleanPath, &githubv39.RepositoryContentGetOptions{})
+		if err == nil {
+			var contentStr string
+			contentStr, err = fileContent.GetContent()
+			content = []byte(contentStr)
+		}
+	}
+	if err != nil {
+		return defaultCooldown
+	}
+
+	agentDef, err := ParseAgent(content)
+	if err != nil || agentDef.Cooldown == "" {
+		return defaultCooldown
+	}
+
+	d, err := time.ParseDuration(agentDef.Cooldown)
+	if err != nil {
+		klog.Warningf("Failed to parse workflow cooldown duration %q: %v", agentDef.Cooldown, err)
+		return defaultCooldown
+	}
+	return d
+}
+
 func queueIssueTasks(ctx context.Context, ghClient *githubv39.Client, kubeClient *clients.KubernetesClient, cfg *config.FactoryConfig, owner, repo string, issues []*githubv39.Issue, processedIssues map[int]time.Time, refIssues map[int]bool, targetAssignee string, allBotUsers []string, incomingDir, processingDir, processedDir, queueDir string, dryRun bool, triggerLabel string) {
 	klog.Infof("queueIssueTasks called with %d issues", len(issues))
 	for _, issue := range issues {
@@ -465,8 +503,8 @@ func queueIssueTasks(ctx context.Context, ghClient *githubv39.Client, kubeClient
 		// Check if the workflow session already completed recently
 		processedPath := filepath.Join(processedDir, filename)
 		if info, err := os.Stat(processedPath); err == nil {
-			// Rate limit: only run once every 10 minutes
-			if time.Since(info.ModTime()) < 10*time.Minute {
+			cooldown := getWorkflowCooldown(ctx, ghClient, owner, repo, workflowPath)
+			if time.Since(info.ModTime()) < cooldown {
 				continue
 			}
 		}


### PR DESCRIPTION
### 1. Workflow Frontmatter Cooldown Configuration
* **Description**: Added support for an optional `cooldown` parameter in workflow frontmatter files (e.g., `cooldown: 6h`).
* **Implementation**: The Watcher Daemon parses this parameter and uses it to throttle how frequently a workflow can run on a specific issue. It defaults to a `10-minute` cooldown if the parameter is omitted. 
* **Example**: Used in `kcc-direct-migration-tracker.txt` to enforce a `6h` delay between runs.

---

### 2. Self-Healing Linked Issue Sandbox Resolution
* **Description**: Allows Pull Request tasks to discover and reuse existing environments created for their parent issues.
* **Implementation**: When running a PR task, if KCC cannot find a sandbox directly associated with the PR, it queries GitHub to find any referenced/linked issues. If it finds an active sandbox for a linked issue, it automatically links/aliases that sandbox to the PR rather than starting a new sandbox from scratch, saving significant time and resources.

---

### 3. PR Task Ownership & Safety Handlers
* **Author Bot Defaulting**: When a PR task (`pr-comments`, `pr-investigate`, `pr-iterate`) is queued while unassigned, KCC now assigns it directly to the **original PR author bot** instead of defaulting to the watcher bot running the daemon. This ensures that the bot performing code changes has permission to execute `git push` on the target repository fork.
* **`overseer/giving-up` Labels**:
  * The Watcher daemon now labels a PR with `overseer/giving-up` when it reaches the 3-strike retry limit.
  * The label is automatically cleaned up/removed when a new commit resets the PR's branch state.
* **Orchestrator Safety Guidelines**: Safety rules inside migration workflows (`kcc-example.txt` and `kcc-greenfield.txt`) were updated to prevent orchestrator bots from automatically re-assigning PRs marked with `overseer/giving-up` back to the bots, resolving the split-brain assignment loop.