### PR TITLE
fix: greenfield-wf: keep the agent instructions scoped

### DIFF
--- a/.agents/workflows/kcc-greenfield.txt
+++ b/.agents/workflows/kcc-greenfield.txt
@@ -76,10 +76,7 @@ Only declare the PR as fully passed/verified if no failures are returned across 
 
 ### Step 1: Direct API Types and Identity and Reference Types Pattern
 
-The resource must have a direct KRM type (`_types.go`), identity files (`_identity.go`), and reference files (`_reference.go`) scaffolded and updated via `generate.sh` using the controllerbuilder tool.
-
-1. Open a GitHub issue referencing `.gemini/skills/kcc-direct-greenfield-types-implementer/SKILL.md` for type generation and 
-   `.gemini/skills/kcc-identity-reference/SKILL.md` for identity generation.
+Open a GitHub issue to coordinate the implementation of direct KRM types, identity files, and reference files for a specific Kubernetes resource.
 
 **GitHub Issue Details for Greenfield Resource:**
 *   **Title:** `Greenfield: Implement direct KRM types, identity, and generate.sh for {kind}`
@@ -97,13 +94,9 @@ The resource must have a direct KRM type (`_types.go`), identity files (`_identi
     If you find any shortcomings in the skill (that likely apply to other resources), you may update SKILL.md. Also keep a journal of any less general observations etc. To avoid git merge conflicts, use a file under .gemini/skills/kcc-direct-greenfield-types-implementer/journal/, named after the kind or a similarly unique name. You may grep journal entries to identify learnings from other resources; if you find an important pattern by doing that you may also update the SKILL.md itself.
     ```
 
-### Step 2: Direct Controller, E2E fixtures and Fuzzer 
+### Step 2: Direct Controller, E2E fixtures and Fuzzer
 
-The direct controller must be implemented to manage reconciliation logic (Adapter: Find, Create, Update, Delete) and E2E fixtures must be created and recorded against mockgcp/real GCP to verify functionality.
-
-1. Open a GitHub issue (unassigned or assigned to the current bot) to implement the direct controller and E2E fixtures.
-2. Generate controller Scaffolding & Mappers: Follow .gemini/skills/kcc-direct-controller-implementer/SKILL.md
-3. Implement controller Logic & E2E Fixtures: Follow .gemini/skills/kcc-direct-controller-logic-implementer/SKILL.md
+Open a GitHub issue to coordinate the implementation of the direct controller and E2E fixtures for a specific Kubernetes resource.
 
 **GitHub Issue Details:**
 *   **Title:** `Greenfield: Implement direct controller, E2E fixtures, and fuzzer for {kind}`
@@ -116,14 +109,14 @@ The direct controller must be implemented to manage reconciliation logic (Adapte
     - .gemini/skills/kcc-direct-controller-logic-implementer/SKILL.md
     to implement the direct controller and record/verify E2E fixtures for {kind}.
 
+    The direct controller must be implemented to manage reconciliation logic (Adapter: Find, Create, Update, Delete) and E2E fixtures must be created and recorded against real GCP to verify functionality.
+
     If you find any shortcomings in these skills (that likely apply to other resources), you may update them. Also keep a journal of any less general observations etc. To avoid git merge conflicts, use a file under their respective journal/ folders, named after the kind or a similarly unique name.
     ```
 
 ### Step 3: mockGCP generation
 
-Once the direct controller passes e2e tests against real, use the http log, to create the mockgcp. Your goal is to identify greenfield resources that have completed Phase 2 (Controller & E2E) but are missing high fidelity MockGCP implementations or alignment (Phase 3), and create issues to track this work. Consult the dashboard at [`hack/tools/greenfield/RESOURCE_STATUS.md`](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/master/hack/tools/greenfield/RESOURCE_STATUS.md) and identify resources where `Current Phase` is `2`, the `State` is `MERGED`, and the `Phase 3 PR` column contains `-` (indicating MockGCP alignment is not yet completed).
-
-1. Open a GitHub issue (unassigned or assigned to the current bot) to the mockGCP.
+Open a GitHub issue to coordinate the implementation of the mockGCP for a specific Kubernetes resource.
 
 **GitHub Issue Details for Greenfield Resource:**
 *   **Title:** `Greenfield: Implement MockGCP and Alignment for {kind}`
@@ -136,9 +129,7 @@ Once the direct controller passes e2e tests against real, use the http log, to c
 
 ### Step 4: MockGCP Alignment with RealGCP
 
-Once the initial MockGCP implementation is in place, the HTTP logs must be rigorously aligned with RealGCP output to ensure high fidelity.
-
-1. Open a GitHub issue (unassigned or assigned to the current bot) to align MockGCP logs.
+Open a GitHub issue to coordinate the alignment of MockGCP logs with RealGCP output to ensure high fidelity.
 
 **GitHub Issue Details:**
 *   **Title:** `Greenfield: Align MockGCP logs with RealGCP for {kind}`


### PR DESCRIPTION
 and remove instruction that scans all potential future work and creates Issues for those