### PR TITLE
Fix nil pointer dereference panic in isWorkflowDefinition

### DIFF
--- a/factory/pkg/commands/agent.go
+++ b/factory/pkg/commands/agent.go
@@ -435,6 +435,9 @@ func fetchWorkflowContent(ctx context.Context, ghClient *githubv39.Client, urlSt
 		if err != nil {
 			return nil, fmt.Errorf("fetching content from GitHub repo: %w", err)
 		}
+		if fileContent == nil {
+			return nil, fmt.Errorf("content is nil (possibly a directory or submodule)")
+		}
 		contentStr, err := fileContent.GetContent()
 		if err != nil {
 			return nil, fmt.Errorf("decoding GitHub content: %w", err)

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -467,6 +467,10 @@ func isWorkflowDefinition(ctx context.Context, ghClient *githubv39.Client, owner
 		klog.V(4).Infof("Failed to get content for %s: %v", cleanPath, err)
 		return false
 	}
+	if fileContent == nil {
+		klog.V(4).Infof("Content is nil for %s (possibly a directory or submodule)", cleanPath)
+		return false
+	}
 	content, err := fileContent.GetContent()
 	if err != nil {
 		return false


### PR DESCRIPTION
Prevent overseer-kcc from crashing in a panic loop when check/resolving issues referencing skill directories.