### PR TITLE
chore(overseer): enable chores mode and update max active issues in kcc manifest

### DIFF
--- a/overseer/examples/kcc.yaml
+++ b/overseer/examples/kcc.yaml
@@ -7,9 +7,9 @@ spec:
   minNumber: 9000
   robotAccount: argus-watcher-bot
   maxActiveReviews: 20
-  maxActiveIssues: 11
+  maxActiveIssues: 50
   chores:
-    mode: disabled
+    mode: enabled
     #include:
     #  - KCC Release Scheduler
   geminiAPIKeySecretName: gemini-vscode-tokens

--- a/overseer/examples/kcc.yaml
+++ b/overseer/examples/kcc.yaml
@@ -7,7 +7,7 @@ spec:
   minNumber: 9000
   robotAccount: argus-watcher-bot
   maxActiveReviews: 20
-  maxActiveIssues: 50
+  maxActiveIssues: 25
   chores:
     mode: enabled
     #include:


### PR DESCRIPTION
This PR enables chores mode and sets maxActiveIssues to 25 in the KCC overseer manifest.