### PR TITLE
fix(factory): use max() instead of sum when calculating active sandboxes

### DIFF
--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -1886,7 +1886,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 				if err != nil {
 					klog.Errorf("Failed to count running sandbox tasks: %v", err)
 				}
-				activeCount := runningCount + filesInProcessing
+				activeCount := max(runningCount, filesInProcessing)
 
 				if activeCount >= maxPending {
 					fmt.Printf("Reached maximum pending sandboxes limit (%d). Skipping remaining queue items.\n", maxPending)


### PR DESCRIPTION

Prevent double-counting tasks that are currently executing in processing/ and already have active pods running in Kubernetes.