### PR TITLE
 feat: Support Stop Labels & Enable Iteration on Approved PRs

### DIFF
--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -535,6 +535,11 @@ func queueIssueTasks(ctx context.Context, ghClient *githubv39.Client, kubeClient
 		if cfg != nil && cfg.MinNumber > 0 && num < cfg.MinNumber {
 			continue
 		}
+		if hasStopLabel(issue.Labels, triggerLabel) {
+			klog.Infof("Skipping issue #%d because it has the stop label ('overseer/stop' or '%s/stop')", num, triggerLabel)
+			removePendingTasksForNumber(incomingDir, num)
+			continue
+		}
 		if refIssues[num] {
 			klog.Infof("Skipping issue #%d because there is already a PR referencing it.", num)
 			continue
@@ -1073,6 +1078,11 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 				if cfg != nil && cfg.MinNumber > 0 && num < cfg.MinNumber {
 					continue
 				}
+				if hasStopLabel(prIssue.Labels, triggerLabel) {
+					klog.Infof("Skipping PR #%d because it has the stop label ('overseer/stop' or '%s/stop')", num, triggerLabel)
+					removePendingTasksForNumber(incomingDir, num)
+					continue
+				}
 				pr, _, err := ghClient.PullRequests.Get(ctx, owner, repo, num)
 				if err != nil {
 					klog.Errorf("Failed to fetch full PR #%d: %v", num, err)
@@ -1095,6 +1105,11 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 
 				// Sync labels from referenced parent issues to the PR
 				syncReferencedIssueLabels(ctx, ghClient, owner, repo, pr, prIssue)
+				if hasStopLabel(prIssue.Labels, triggerLabel) {
+					klog.Infof("Skipping PR #%d after label sync because it has the stop label ('overseer/stop' or '%s/stop')", num, triggerLabel)
+					removePendingTasksForNumber(incomingDir, num)
+					continue
+				}
 
 				headSHA := pr.GetHead().GetSHA()
 
@@ -1706,6 +1721,10 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 						if issue.PullRequestLinks != nil {
 							continue
 						}
+						if hasStopLabel(issue.Labels, triggerLabel) {
+							klog.Infof("Skipping auto labeling/assigning issue #%d because it has the stop label ('overseer/stop' or '%s/stop')", issue.GetNumber(), triggerLabel)
+							continue
+						}
 
 						hasTriggerLabel := false
 						for _, l := range issue.Labels {
@@ -1910,6 +1929,16 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 				if running {
 					klog.Infof("Skipping task %s because sandbox %s is currently busy running another task.", filename, sandboxName)
 					continue
+				}
+
+				if task.Number > 0 && !dryRun {
+					if issueOrPR, _, err := ghClient.Issues.Get(ctx, owner, repo, task.Number); err == nil && issueOrPR != nil {
+						if hasStopLabel(issueOrPR.Labels, triggerLabel) {
+							klog.Infof("Skipping task %s and removing from incoming because target #%d has the stop label ('overseer/stop' or '%s/stop')", filename, task.Number, triggerLabel)
+							_ = os.Remove(filepath.Join(incomingDir, filename))
+							continue
+						}
+					}
 				}
 
 				if task.Type != "agent-chore" && task.Recovered {
@@ -2351,6 +2380,35 @@ func shouldIgnoreUser(user *githubv39.User, githubLogin string, allowlistedBots 
 	}
 
 	return false
+}
+
+func hasStopLabel(labels []*githubv39.Label, triggerLabel string) bool {
+	stopLabels := []string{"overseer/stop"}
+	if triggerLabel != "" && !strings.EqualFold(triggerLabel, "overseer") {
+		stopLabels = append(stopLabels, triggerLabel+"/stop")
+	}
+	for _, label := range labels {
+		for _, stop := range stopLabels {
+			if strings.EqualFold(label.GetName(), stop) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func removePendingTasksForNumber(incomingDir string, number int) {
+	files, err := os.ReadDir(incomingDir)
+	if err != nil {
+		return
+	}
+	pattern1 := fmt.Sprintf("-issue-%d.yaml", number)
+	pattern2 := fmt.Sprintf("-pr-%d-", number)
+	for _, f := range files {
+		if !f.IsDir() && (strings.Contains(f.Name(), pattern1) || strings.Contains(f.Name(), pattern2)) {
+			_ = os.Remove(filepath.Join(incomingDir, f.Name()))
+		}
+	}
 }
 
 func cleanupClosedPRSandboxes(ctx context.Context, ghClient *githubv39.Client, kubeClient *clients.KubernetesClient, owner, repo, namespace string, dryRun bool) error {

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -1427,37 +1427,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 					}
 
 					if isApproved {
-						if hasNewComments {
-							klog.Infof("PR #%d is approved / LGTM'd. Ignoring new comments/feedback.", num)
-
-							// Post ignore comment if we haven't already posted it since the last commit
-							hasPostedIgnore := false
-							ignorePrefix := "🤖 AI Factory is ignoring new comments/feedback because this PR is already approved"
-							for _, c := range comments {
-								isPoolBot := false
-								for _, bot := range allBotUsers {
-									if strings.EqualFold(c.GetUser().GetLogin(), bot) {
-										isPoolBot = true
-										break
-									}
-								}
-								if isPoolBot &&
-									strings.HasPrefix(c.GetBody(), ignorePrefix) &&
-									c.GetCreatedAt().After(lastCommitTime) {
-									hasPostedIgnore = true
-									break
-								}
-							}
-
-							if !hasPostedIgnore && !dryRun {
-								addGitHubComment(ctx, ghClient, owner, repo, num, ignorePrefix+" / LGTM'd.")
-							}
-
-							state.lastCommentAddressedTime = time.Now()
-							processedPRs[num] = state
-						}
-						// Skip queueing comment task since it's approved
-						continue
+						klog.V(2).Infof("PR #%d is approved / LGTM'd", num)
 					}
 
 					if hasNewComments {


### PR DESCRIPTION
This pull request introduces two core behavioral adjustments to `factory watch` (and Overseer) to give engineers better granular control over bot mutations while keeping bots responsive to review feedback throughout the entire PR lifecycle.


### 1. Added Support for `overseer/stop` (and `<triggerLabel>/stop`) Labels
To allow maintainers to freeze bot mutations on a specific Issue or Pull Request instantly without shutting down the entire watcher service, Overseer now recognizes stop labels across all phases of the reconciliation loop:

* **New Helper Functions (`watch.go`)**:
  * **`hasStopLabel(labels, triggerLabel)`**: Checks whether the target contains `overseer/stop` (or `<triggerLabel>/stop` if a custom `--trigger-label` is configured).
  * **`removePendingTasksForNumber(incomingDir, number)`**: Automatically finds and deletes any unstarted queue files (`*-issue-<num>.yaml` and `*-pr-<num>-*.yaml`) residing in the `incoming/` directory.

* **Multi-stage Stop Enforcement**:
  * **Queueing Issues (`queueIssueTasks`)**: Skips scanning and task creation if the issue has the stop label, instantly purging any pending `task-issue-<num>.yaml` files from the queue.
  * **Processing PRs (`processPRsFunc`)**: Skips scanning and task creation for PRs labeled with the stop label right when the PR is inspected, as well as immediately after syncing inherited labels from referenced parent issues.
  * **Auto-Discovery (`issuesCreator`)**: Prevents Overseer from automatically adding the trigger label or assigning watcher bots to open issues created by bot accounts if the issue has the stop label.
  * **Task Execution (`runRunner`)**: right before a task file transitions from `incoming/` to `processing/` to spin up a container sandbox, Overseer queries the GitHub API (`ghClient.Issues.Get`) for a live label check. If the stop label was attached after the task was queued, the task is dropped and deleted from `incoming/` before launching the sandbox container.


### 2. Removed Iteration Freeze on Approved / LGTM'd PRs
Previously, Overseer would check whether a PR had the `lgtm` or `approved` label attached and halt further automated iterations (`PR #%d is approved / LGTM'd. Ignoring new comments/feedback.`). This feature caused the bot to ignore legitimate follow-up review feedback or requests for rebasing after an approval was granted.

* **Retained Detection Code**: Kept `isApproved := isPRApprovedOrLGTM(pr, prIssue, reviews)` and added `klog.V(2).Infof(...)` debugging output so metrics and internal logging still track approved states accurately.
* **Removed Freeze Logic**: Removed the check that blocked `pr-comments` task creation (`continue`) and posted the notice (`🤖 AI Factory is ignoring new comments/feedback because this PR is already approved`).
* **Outcome**: Watcher bots now remain active and responsive to new review comments (`hasNewComments == true`) even after a PR has received an `lgtm` or `approved` label.
