### PR TITLE
fix(watch): ignore epoch timestamps when extracting referenced issue numbers

### DIFF
--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -2202,22 +2202,22 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 func getReferencedIssues(pr *githubv39.PullRequest) map[int]bool {
 	referenced := make(map[int]bool)
 
-	// Check branch name
+	// Check branch name, ignoring epoch timestamps (num >= 10000000)
 	if pr.GetHead().GetRef() != "" {
 		re := regexp.MustCompile(`\d+`)
 		for _, match := range re.FindAllString(pr.GetHead().GetRef(), -1) {
-			if num, err := strconv.Atoi(match); err == nil {
+			if num, err := strconv.Atoi(match); err == nil && num < 10000000 {
 				referenced[num] = true
 			}
 		}
 	}
 
-	// Check title and body
-	re := regexp.MustCompile(`#(\d+)\b`)
+	// Check title and body for #1234 or "Fixes/Closes/Resolves/Issue 1234"
+	re := regexp.MustCompile(`(?:#|(?i:\b(?:fixes|closes|resolves|issue)\s+))(\d+)\b`)
 	for _, text := range []string{pr.GetTitle(), pr.GetBody()} {
 		for _, match := range re.FindAllStringSubmatch(text, -1) {
 			if len(match) > 1 {
-				if num, err := strconv.Atoi(match[1]); err == nil {
+				if num, err := strconv.Atoi(match[1]); err == nil && num < 10000000 {
 					referenced[num] = true
 				}
 			}

--- a/factory/pkg/commands/watch_test.go
+++ b/factory/pkg/commands/watch_test.go
@@ -119,6 +119,15 @@ func TestGetReferencedIssues(t *testing.T) {
 			body:     "Just refactoring some code",
 			expected: map[int]bool{},
 		},
+		{
+			name:    "Branch with timestamp and keyword issue link without #",
+			headRef: "ada-coder-bot:issue-11414-1783386792",
+			title:   "Fixes 11414",
+			body:    "Resolves 11414 without hash",
+			expected: map[int]bool{
+				11414: true,
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
we were seeing incorrect issue extraction in logs:

```
I0710 04:54:31.916095     181 watch.go:1294] Skipping PR #11488 investigate because the bot has already given up on the current commit.
W0710 04:54:33.497916     181 watch.go:2235] Failed to fetch referenced parent issue #1783379065 for PR #11407: GET https://api.github.com/repos/GoogleCloudPlatform/k8s-config-connector/issues/1783379065: 404 Not Found []
W0710 04:54:36.787797     181 watch.go:2235] Failed to fetch referenced parent issue #1783091101 for PR #11299: GET https://api.github.com/repos/GoogleCloudPlatform/k8s-config-connector/issues/1783091101: 404 Not Found []
W0710 04:54:40.199923     181 watch.go:2235] Failed to fetch referenced parent issue #1783386792 for PR 
```