### PR TITLE
fix(factory): prevent self-suspension using IsCurrentSandbox via standard k8s pod inspection

### DIFF
--- a/factory/pkg/commands/sandbox.go
+++ b/factory/pkg/commands/sandbox.go
@@ -513,6 +513,12 @@ func NewSandboxSuspendCommand(ctx context.Context) *cobra.Command {
 				if !targets[name] {
 					continue
 				}
+				if factorysandbox.IsCurrentSandbox(ctx, kubeClient, &item, rootFlags.Namespace) {
+					if !all && len(args) > 0 {
+						fmt.Printf("Skipping active watch daemon sandbox '%s' (cannot self-suspend via factory suspend).\n", name)
+					}
+					continue
+				}
 				replicas, found, _ := unstructured.NestedInt64(item.Object, "spec", "replicas")
 				if found && replicas == 0 {
 					fmt.Printf("Sandbox '%s' is already suspended (replicas=0).\n", name)

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -278,11 +278,7 @@ func countRunningSandboxTasks(ctx context.Context, kubeClient *clients.Kubernete
 
 	count := 0
 	for _, item := range list.Items {
-		if strings.HasPrefix(item.GetName(), "overseer-") {
-			continue
-		}
-		labels := item.GetLabels()
-		if labels != nil && labels["overseer.gemini.google.com/overseer"] != "" {
+		if factorysandbox.IsCurrentSandbox(ctx, kubeClient, &item, namespace) {
 			continue
 		}
 
@@ -2683,6 +2679,9 @@ func cleanupStaleIdleSandboxes(ctx context.Context, kubeClient *clients.Kubernet
 	now := time.Now()
 	for _, item := range list.Items {
 		name := item.GetName()
+		if factorysandbox.IsCurrentSandbox(ctx, kubeClient, &item, namespace) {
+			continue
+		}
 		creationTime := item.GetCreationTimestamp().Time
 		if creationTime.IsZero() {
 			continue

--- a/factory/pkg/sandbox/sandbox.go
+++ b/factory/pkg/sandbox/sandbox.go
@@ -393,6 +393,14 @@ func IsCurrentSandbox(ctx context.Context, kubeClient *clients.KubernetesClient,
 		return false
 	}
 
+	// If not running inside a Kubernetes pod (or sandbox container), we are running on an external workstation.
+	// Therefore, no cluster sandbox corresponds to "this current process".
+	if os.Getenv("KUBERNETES_SERVICE_HOST") == "" && os.Getenv("SANDBOX_NAME") == "" {
+		if _, err := os.Stat("/var/run/secrets/kubernetes.io/serviceaccount/token"); os.IsNotExist(err) {
+			return false
+		}
+	}
+
 	// 1. Fast path from explicit environment variables
 	if envSB := os.Getenv("SANDBOX_NAME"); envSB != "" && envSB == sbName {
 		return true

--- a/factory/pkg/sandbox/sandbox.go
+++ b/factory/pkg/sandbox/sandbox.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -381,6 +382,54 @@ func UpdateSandboxTaskAnnotation(ctx context.Context, kubeClient *clients.Kubern
 	return nil
 }
 
+// IsCurrentSandbox checks if the given Sandbox resource corresponds to the pod currently running this process,
+// preventing self-suspension or self-eviction of the active watch/controller daemon.
+func IsCurrentSandbox(ctx context.Context, kubeClient *clients.KubernetesClient, item *unstructured.Unstructured, namespace string) bool {
+	if item == nil {
+		return false
+	}
+	sbName := item.GetName()
+	if sbName == "" {
+		return false
+	}
+
+	// 1. Fast path from explicit environment variables
+	if envSB := os.Getenv("SANDBOX_NAME"); envSB != "" && envSB == sbName {
+		return true
+	}
+	podName := os.Getenv("POD_NAME")
+	if podName == "" {
+		podName = os.Getenv("HOSTNAME")
+	}
+	if podName != "" {
+		// If the pod name exactly equals the sandbox name (e.g. overseer-kcc == overseer-kcc)
+		if podName == sbName {
+			return true
+		}
+		// If the pod name starts with the sandbox name followed by a hyphen (e.g. overseer-kcc-6c66b9cb6d-7gprl)
+		if strings.HasPrefix(podName, sbName+"-") {
+			return true
+		}
+		// 2. Query k8s API for the current pod's labels and owner references
+		if kubeClient != nil && kubeClient.Clientset != nil {
+			pod, err := kubeClient.Clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+			if err == nil && pod != nil {
+				// Check standard sandbox label on the pod
+				if pod.Labels["sandbox"] == sbName || pod.Labels["agents.x-k8s.io/sandbox"] == sbName {
+					return true
+				}
+				// Check owner references pointing to this Sandbox resource
+				for _, owner := range pod.OwnerReferences {
+					if owner.Name == sbName {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
 func SuspendIdleSandboxes(ctx context.Context, kubeClient *clients.KubernetesClient, namespace string, idleTimeout time.Duration, dryRun bool) (int, error) {
 	if kubeClient == nil || idleTimeout <= 0 {
 		return 0, nil
@@ -396,6 +445,9 @@ func SuspendIdleSandboxes(ctx context.Context, kubeClient *clients.KubernetesCli
 
 	for _, item := range list.Items {
 		name := item.GetName()
+		if IsCurrentSandbox(ctx, kubeClient, &item, namespace) {
+			continue
+		}
 		replicas, found, err := unstructured.NestedInt64(item.Object, "spec", "replicas")
 		if err == nil && found && replicas == 0 {
 			continue // Already suspended

--- a/factory/pkg/sandbox/sandbox_test.go
+++ b/factory/pkg/sandbox/sandbox_test.go
@@ -2,6 +2,7 @@ package sandbox_test
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -119,6 +120,7 @@ func TestIsCurrentSandbox_And_SuspendSkip(t *testing.T) {
 	ns := "test-namespace"
 	sbName := "my-active-daemon"
 
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
 	t.Setenv("HOSTNAME", sbName)
 
 	oldTime := time.Now().Add(-24 * time.Hour).UTC().Format(time.RFC3339)
@@ -138,8 +140,18 @@ func TestIsCurrentSandbox_And_SuspendSkip(t *testing.T) {
 	}
 
 	if !sandbox.IsCurrentSandbox(ctx, kubeClient, controllerSandbox, ns) {
-		t.Errorf("Expected IsCurrentSandbox=true when HOSTNAME matches sandbox name")
+		t.Errorf("Expected IsCurrentSandbox=true when HOSTNAME matches sandbox name inside cluster")
 	}
+
+	// Verify that outside the cluster (workstation without k8s env/tokens), IsCurrentSandbox returns false
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("SANDBOX_NAME", "")
+	if sandbox.IsCurrentSandbox(ctx, kubeClient, controllerSandbox, ns) {
+		if _, err := os.Stat("/var/run/secrets/kubernetes.io/serviceaccount/token"); os.IsNotExist(err) {
+			t.Errorf("Expected IsCurrentSandbox=false when running outside cluster on workstation")
+		}
+	}
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
 
 	_, err := fakeDynamic.Resource(k8s.SandboxGVR).Namespace(ns).Create(ctx, controllerSandbox, metav1.CreateOptions{})
 	if err != nil {

--- a/factory/pkg/sandbox/sandbox_test.go
+++ b/factory/pkg/sandbox/sandbox_test.go
@@ -106,6 +106,61 @@ func TestSuspendIdleSandboxes(t *testing.T) {
 	}
 }
 
+func TestIsCurrentSandbox_And_SuspendSkip(t *testing.T) {
+	scheme := runtime.NewScheme()
+	fakeDynamic := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{
+		k8s.SandboxGVR: "SandboxList",
+	})
+	kubeClient := &clients.KubernetesClient{
+		DynamicClient: fakeDynamic,
+	}
+
+	ctx := context.Background()
+	ns := "test-namespace"
+	sbName := "my-active-daemon"
+
+	t.Setenv("HOSTNAME", sbName)
+
+	oldTime := time.Now().Add(-24 * time.Hour).UTC().Format(time.RFC3339)
+	controllerSandbox := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "agents.x-k8s.io/v1alpha1",
+			"kind":       "Sandbox",
+			"metadata": map[string]interface{}{
+				"name":              sbName,
+				"namespace":         ns,
+				"creationTimestamp": oldTime,
+			},
+			"spec": map[string]interface{}{
+				"replicas": int64(1),
+			},
+		},
+	}
+
+	if !sandbox.IsCurrentSandbox(ctx, kubeClient, controllerSandbox, ns) {
+		t.Errorf("Expected IsCurrentSandbox=true when HOSTNAME matches sandbox name")
+	}
+
+	_, err := fakeDynamic.Resource(k8s.SandboxGVR).Namespace(ns).Create(ctx, controllerSandbox, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create controller sandbox: %v", err)
+	}
+
+	count, err := sandbox.SuspendIdleSandboxes(ctx, kubeClient, ns, 30*time.Minute, false)
+	if err != nil {
+		t.Fatalf("SuspendIdleSandboxes failed: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("Expected 0 sandboxes suspended when checking current sandbox, got %d", count)
+	}
+
+	updated, _ := fakeDynamic.Resource(k8s.SandboxGVR).Namespace(ns).Get(ctx, sbName, metav1.GetOptions{})
+	rep, _, _ := unstructured.NestedInt64(updated.Object, "spec", "replicas")
+	if rep != 1 {
+		t.Errorf("Expected current sandbox replicas=1 (skipped), got %d", rep)
+	}
+}
+
 func TestUpdateSandboxTaskAnnotation_Resume(t *testing.T) {
 	scheme := runtime.NewScheme()
 	fakeDynamic := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{


### PR DESCRIPTION

- Add IsCurrentSandbox helper using standard k8s mechanisms (HOSTNAME/POD_NAME/SANDBOX_NAME env vars, pod labels, and owner references) to identify the active running pod
- Skip IsCurrentSandbox in SuspendIdleSandboxes so watch daemons and controller pods never auto-suspend themselves when idle-timeout triggers
- Skip IsCurrentSandbox in factory suspend (--all) to prevent self-suspension of the active watch pod
- Update watch cleanup loops and countRunningSandboxTasks to use IsCurrentSandbox rather than hardcoded prefixes
- Add unit test TestIsCurrentSandbox_And_SuspendSkip verifying self-suspension prevention