### PR TITLE
overseer: fix circuit-breaker to use overseer/stop label and reset on comment

### DIFF
--- a/factory/design/watch-design-note.md
+++ b/factory/design/watch-design-note.md
@@ -101,14 +101,9 @@ When processing a PR, the scan evaluates conditions and queues tasks in three ph
 ### Phase 3: CI Check Failures (`pr-investigate`)
 * **Trigger**: Check runs or status checks for the head commit have failed.
 * **Check Run Deduplication**: Check runs are deduplicated by name, keeping only the latest run (highest ID), ensuring older cancelled/failed runs do not block the PR if a newer run succeeded.
-* **Retry Count**: If `investigationCount >= 3` since the last commit, it posts a "giving up" message and halts retries.
-* **Giving Up State & Reset Behavior**:
-  * Once a bot posts a "giving up" comment (`"giving up. Human assistance is required"`), the PR enters a given-up state (`hasPostedGivingUp = true`).
-  * **Reset Condition**: The given-up state and the 3-attempt investigation counter (`investigationCount`) are reset **only** when a new git commit is pushed to the pull request advancing the commit timestamp (`lastCommitTime`) past the giving up comment timestamp.
-  * **Human Feedback / Comments**: Posting new instructions or comments on the PR does *not* reset the giving up state directly. However, when a PR has failing CI checks while in the given-up state, Overseer skips further CI investigation retries (`pr-investigate`) and jumps directly to review comment evaluation (`pr-comments`). This ensures the bot can respond to human guidance and push code fixes (which advances the commit SHA and resets the giving up state).
-  * **Deleting vs. Hiding Comments**: Deleting the bot's giving up comment (and excess investigation comments) removes them from the GitHub API payload, immediately clearing the given-up state on the next scan cycle. However, hiding or minimizing comments on GitHub does not clear the state because the GitHub REST API still returns minimized comment bodies.
-* **Retry on Recovery**: If the previous investigation task is in `processed/` but has status `"Failed"`, the watcher ignores the SHA check and allows retrying the task.
-* **Assignment**: The bot user remains assigned to the PR while the task is executing. If it reaches the retry limit and gives up, it explicitly unassigns itself to request human review.
+* **Halting Processing (`overseer/stop`)**: To halt automatic CI investigation or bot processing on any pull request or issue, attach the `overseer/stop` label (or `<triggerLabel>/stop`). Overseer immediately skips processing any PR with this label.
+* **Retry on Recovery**: If the previous investigation task is in `processed/` but has status `"Failed"` or if 6 hours have passed since the last investigation (`time.Since(lastInvestigatedTime) > 6*time.Hour`), the watcher queues a retry for `pr-investigate`.
+* **Assignment**: The bot user remains assigned to the PR while tasks are executing or pending.
 
 ---
 

--- a/factory/design/watch-design-note.md
+++ b/factory/design/watch-design-note.md
@@ -101,7 +101,10 @@ When processing a PR, the scan evaluates conditions and queues tasks in three ph
 ### Phase 3: CI Check Failures (`pr-investigate`)
 * **Trigger**: Check runs or status checks for the head commit have failed.
 * **Check Run Deduplication**: Check runs are deduplicated by name, keeping only the latest run (highest ID), ensuring older cancelled/failed runs do not block the PR if a newer run succeeded.
-* **Halting Processing (`overseer/stop`)**: To halt automatic CI investigation or bot processing on any pull request or issue, attach the `overseer/stop` label (or `<triggerLabel>/stop`). Overseer immediately skips processing any PR with this label.
+* **Automated Circuit Breaker (`overseer/stop`)**: If the bot attempts to investigate/fix CI failures (`started investigating CI check failures`) 3 times since the latest git commit OR latest human comment (`max(lastCommitTime, lastHumanCommentTime)`) without success, it triggers an automated circuit breaker:
+  * It attaches the `overseer/stop` label (`or <triggerLabel>/stop`) to the pull request and posts an informative comment explaining that automated investigation is paused.
+  * To retry or resume automated investigation, a human maintainer simply removes the `overseer/stop` label (and/or pushes a new commit or leaves a comment).
+* **Halting Processing (`overseer/stop`)**: To manually halt bot processing on any pull request or issue at any time, attach the `overseer/stop` label. Overseer immediately skips processing any PR with this label.
 * **Retry on Recovery**: If the previous investigation task is in `processed/` but has status `"Failed"` or if 6 hours have passed since the last investigation (`time.Since(lastInvestigatedTime) > 6*time.Hour`), the watcher queues a retry for `pr-investigate`.
 * **Assignment**: The bot user remains assigned to the PR while tasks are executing or pending.
 

--- a/factory/design/watch-design-note.md
+++ b/factory/design/watch-design-note.md
@@ -101,9 +101,9 @@ When processing a PR, the scan evaluates conditions and queues tasks in three ph
 ### Phase 3: CI Check Failures (`pr-investigate`)
 * **Trigger**: Check runs or status checks for the head commit have failed.
 * **Check Run Deduplication**: Check runs are deduplicated by name, keeping only the latest run (highest ID), ensuring older cancelled/failed runs do not block the PR if a newer run succeeded.
-* **Automated Circuit Breaker (`overseer/stop`)**: If the bot attempts to investigate/fix CI failures (`started investigating CI check failures`) 3 times since the latest git commit OR latest human comment (`max(lastCommitTime, lastHumanCommentTime)`) without success, it triggers an automated circuit breaker:
+* **Automated Circuit Breaker (`overseer/stop`)**: If the bot attempts to investigate/fix CI failures (`started investigating CI check failures`) 3 times since the latest git commit OR latest human comment without success, it triggers an automated circuit breaker:
   * It attaches the `overseer/stop` label (`or <triggerLabel>/stop`) to the pull request and posts an informative comment explaining that automated investigation is paused.
-  * To retry or resume automated investigation, a human maintainer simply removes the `overseer/stop` label (and/or pushes a new commit or leaves a comment).
+  * **Effortless Retries (Unlabeling)**: To retry or resume automated investigation, a human maintainer simply removes the `overseer/stop` label (no comment or commit required). When un-labeled, the bot's pause comment (`pausing automated investigation`) acts as a new reset boundary, clearing the retry count (`investigationCount = 0`) and queueing a fresh investigation.
 * **Halting Processing (`overseer/stop`)**: To manually halt bot processing on any pull request or issue at any time, attach the `overseer/stop` label. Overseer immediately skips processing any PR with this label.
 * **Retry on Recovery**: If the previous investigation task is in `processed/` but has status `"Failed"` or if 6 hours have passed since the last investigation (`time.Since(lastInvestigatedTime) > 6*time.Hour`), the watcher queues a retry for `pr-investigate`.
 * **Assignment**: The bot user remains assigned to the PR while tasks are executing or pending.

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -1247,114 +1247,56 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 				if hasFailure {
 					filename := fmt.Sprintf("task-pr-%d-investigate.yaml", num)
 					if !taskExists(incomingDir, processingDir, filename) {
-						// Count investigations since last commit
-						investigationCount := 0
-						if listCommentsErr == nil {
-							for _, c := range comments {
-								isPoolBot := false
-								for _, bot := range allBotUsers {
-									if strings.EqualFold(c.GetUser().GetLogin(), bot) {
-										isPoolBot = true
-										break
-									}
-								}
-								if isPoolBot &&
-									strings.Contains(c.GetBody(), "started investigating CI check failures") &&
-									c.GetCreatedAt().After(lastCommitTime) {
-									investigationCount++
+						prevFailed := false
+						processedPath := filepath.Join(processedDir, filename)
+						if data, err := os.ReadFile(processedPath); err == nil {
+							var t QueueTask
+							if err := yaml.Unmarshal(data, &t); err == nil {
+								if t.Status == "Failed" {
+									prevFailed = true
 								}
 							}
 						}
 
-						// Post giving up comment if we haven't already posted it since the last commit
-						hasPostedGivingUp := false
-						if listCommentsErr == nil {
-							for _, c := range comments {
-								isPoolBot := false
-								for _, bot := range allBotUsers {
-									if strings.EqualFold(c.GetUser().GetLogin(), bot) {
-										isPoolBot = true
-										break
-									}
-								}
-								if isPoolBot &&
-									strings.Contains(c.GetBody(), "giving up. Human assistance is required") &&
-									c.GetCreatedAt().After(lastCommitTime) {
-									hasPostedGivingUp = true
-									break
-								}
-							}
-						}
+						if state.lastSHA != headSHA || prevFailed || isExplicitlyAssigned || time.Since(state.lastInvestigatedTime) > 6*time.Hour {
+							sandboxName := resolveSandboxName(ctx, kubeClient, ghClient, "pr-investigate", num, owner, repo)
+							running, err := isSandboxTaskRunning(ctx, kubeClient, rootFlags.Namespace, sandboxName)
+							if err != nil {
+								klog.Errorf("Failed to check if sandbox %s is running: %v", sandboxName, err)
+							} else if running {
+								klog.Infof("Skipping PR #%d investigate because there is an in-flight sandbox %s.", num, sandboxName)
+							} else {
+								assignedBot := assignedBotUser(prIssue, allBotUsers)
 
-						if hasPostedGivingUp {
-							klog.Infof("Skipping PR #%d investigate because the bot has already given up on the current commit.", num)
-						} else if investigationCount >= 3 {
-							if !dryRun {
-								addGitHubComment(ctx, ghClient, owner, repo, num, "🤖 AI Factory has attempted to fix CI failures for this PR 3 times since the last commit and is giving up. Human assistance is required.")
-								if assignedBot != "" && !unassignedPRs[num] {
-									fmt.Printf("Unassigning bot %s from PR #%d because it has given up...\n", assignedBot, num)
-									if _, _, err := ghClient.Issues.RemoveAssignees(ctx, owner, repo, num, []string{assignedBot}); err != nil {
-										klog.Errorf("Failed to unassign bot %s from PR #%d: %v", assignedBot, num, err)
-									}
-									unassignedPRs[num] = true
+								taskAssignee := assignedBot
+								if taskAssignee == "" {
+									taskAssignee = author
 								}
-								if _, _, err := ghClient.Issues.AddLabelsToIssue(ctx, owner, repo, num, []string{"overseer/giving-up"}); err != nil {
-									klog.Errorf("Failed to add giving up label to PR #%d: %v", num, err)
-								}
-							}
-							klog.Infof("Skipping PR #%d investigate because it has reached the maximum retry limit (3).", num)
-						} else {
-							prevFailed := false
-							processedPath := filepath.Join(processedDir, filename)
-							if data, err := os.ReadFile(processedPath); err == nil {
-								var t QueueTask
-								if err := yaml.Unmarshal(data, &t); err == nil {
-									if t.Status == "Failed" {
-										prevFailed = true
-									}
-								}
-							}
 
-							if state.lastSHA != headSHA || prevFailed || isExplicitlyAssigned || time.Since(state.lastInvestigatedTime) > 6*time.Hour {
-								sandboxName := resolveSandboxName(ctx, kubeClient, ghClient, "pr-investigate", num, owner, repo)
-								running, err := isSandboxTaskRunning(ctx, kubeClient, rootFlags.Namespace, sandboxName)
-								if err != nil {
-									klog.Errorf("Failed to check if sandbox %s is running: %v", sandboxName, err)
-								} else if running {
-									klog.Infof("Skipping PR #%d investigate because there is an in-flight sandbox %s.", num, sandboxName)
+								prURL := fmt.Sprintf("https://github.com/%s/%s/pull/%d", owner, repo, num)
+								task := &QueueTask{
+									Type:      "pr-investigate",
+									URL:       prURL,
+									Number:    num,
+									Priority:  getPRPriority(prIssue),
+									Phase:     3,
+									CreatedAt: pr.GetCreatedAt(),
+									Assignee:  taskAssignee,
+									Status:    "Pending",
+									CommitSHA: headSHA,
+								}
+
+								if dryRun {
+									fmt.Printf("[DRYRUN] Would queue investigate task for PR #%d: %s\n", num, prURL)
 								} else {
-									assignedBot := assignedBotUser(prIssue, allBotUsers)
-
-									taskAssignee := assignedBot
-									if taskAssignee == "" {
-										taskAssignee = author
-									}
-
-									prURL := fmt.Sprintf("https://github.com/%s/%s/pull/%d", owner, repo, num)
-									task := &QueueTask{
-										Type:      "pr-investigate",
-										URL:       prURL,
-										Number:    num,
-										Priority:  getPRPriority(prIssue),
-										Phase:     3,
-										CreatedAt: pr.GetCreatedAt(),
-										Assignee:  taskAssignee,
-										Status:    "Pending",
-										CommitSHA: headSHA,
-									}
-
-									if dryRun {
-										fmt.Printf("[DRYRUN] Would queue investigate task for PR #%d: %s\n", num, prURL)
+									fmt.Printf("Queueing investigate task for PR #%d...\n", num)
+									state.lastSHA = headSHA
+									state.lastInvestigatedTime = time.Now()
+									processedPRs[num] = state
+									if err := writeTaskAtomically(incomingDir, filename, task); err != nil {
+										klog.Errorf("Failed to queue investigate task for PR #%d: %v", num, err)
 									} else {
-										fmt.Printf("Queueing investigate task for PR #%d...\n", num)
-										state.lastSHA = headSHA
-										state.lastInvestigatedTime = time.Now()
-										processedPRs[num] = state
-										if err := writeTaskAtomically(incomingDir, filename, task); err != nil {
-											klog.Errorf("Failed to queue investigate task for PR #%d: %v", num, err)
-										} else {
-											writeTaskJournalEvent(queueDir, filename, task, "Created", 0)
-										}
+										writeTaskJournalEvent(queueDir, filename, task, "Created", 0)
 									}
 								}
 							}

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -1257,7 +1257,8 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 										break
 									}
 								}
-								if !isPoolBot && c.GetCreatedAt().After(lastResetTime) {
+								// Advance reset timestamp when any human comments OR when the bot previously paused automated investigation
+								if (!isPoolBot || strings.Contains(c.GetBody(), "pausing automated investigation")) && c.GetCreatedAt().After(lastResetTime) {
 									lastResetTime = c.GetCreatedAt()
 								}
 							}

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -1247,56 +1247,101 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 				if hasFailure {
 					filename := fmt.Sprintf("task-pr-%d-investigate.yaml", num)
 					if !taskExists(incomingDir, processingDir, filename) {
-						prevFailed := false
-						processedPath := filepath.Join(processedDir, filename)
-						if data, err := os.ReadFile(processedPath); err == nil {
-							var t QueueTask
-							if err := yaml.Unmarshal(data, &t); err == nil {
-								if t.Status == "Failed" {
-									prevFailed = true
+						lastResetTime := lastCommitTime
+						if listCommentsErr == nil {
+							for _, c := range comments {
+								isPoolBot := false
+								for _, bot := range allBotUsers {
+									if strings.EqualFold(c.GetUser().GetLogin(), bot) {
+										isPoolBot = true
+										break
+									}
+								}
+								if !isPoolBot && c.GetCreatedAt().After(lastResetTime) {
+									lastResetTime = c.GetCreatedAt()
 								}
 							}
 						}
 
-						if state.lastSHA != headSHA || prevFailed || isExplicitlyAssigned || time.Since(state.lastInvestigatedTime) > 6*time.Hour {
-							sandboxName := resolveSandboxName(ctx, kubeClient, ghClient, "pr-investigate", num, owner, repo)
-							running, err := isSandboxTaskRunning(ctx, kubeClient, rootFlags.Namespace, sandboxName)
-							if err != nil {
-								klog.Errorf("Failed to check if sandbox %s is running: %v", sandboxName, err)
-							} else if running {
-								klog.Infof("Skipping PR #%d investigate because there is an in-flight sandbox %s.", num, sandboxName)
-							} else {
-								assignedBot := assignedBotUser(prIssue, allBotUsers)
-
-								taskAssignee := assignedBot
-								if taskAssignee == "" {
-									taskAssignee = author
+						investigationCount := 0
+						if listCommentsErr == nil {
+							for _, c := range comments {
+								isPoolBot := false
+								for _, bot := range allBotUsers {
+									if strings.EqualFold(c.GetUser().GetLogin(), bot) {
+										isPoolBot = true
+										break
+									}
 								}
-
-								prURL := fmt.Sprintf("https://github.com/%s/%s/pull/%d", owner, repo, num)
-								task := &QueueTask{
-									Type:      "pr-investigate",
-									URL:       prURL,
-									Number:    num,
-									Priority:  getPRPriority(prIssue),
-									Phase:     3,
-									CreatedAt: pr.GetCreatedAt(),
-									Assignee:  taskAssignee,
-									Status:    "Pending",
-									CommitSHA: headSHA,
+								if isPoolBot &&
+									strings.Contains(c.GetBody(), "started investigating CI check failures") &&
+									c.GetCreatedAt().After(lastResetTime) {
+									investigationCount++
 								}
+							}
+						}
 
-								if dryRun {
-									fmt.Printf("[DRYRUN] Would queue investigate task for PR #%d: %s\n", num, prURL)
+						if investigationCount >= 3 {
+							stopLabel := getStopLabel(triggerLabel)
+							if !dryRun {
+								addGitHubComment(ctx, ghClient, owner, repo, num, fmt.Sprintf("🤖 AI Factory has attempted to investigate/fix CI check failures for this pull request 3 times since the last commit or update without success. To prevent infinite loops, I am pausing automated investigation and attaching the `%s` label.\n\nTo request another attempt or resume automated processing, please remove the `%s` label from this pull request (and/or push a new commit or leave a comment).", stopLabel, stopLabel))
+								if _, _, err := ghClient.Issues.AddLabelsToIssue(ctx, owner, repo, num, []string{stopLabel}); err != nil {
+									klog.Errorf("Failed to add stop label '%s' to PR #%d: %v", stopLabel, num, err)
+								}
+							}
+							klog.Infof("Skipping PR #%d investigate because it has reached the maximum retry limit (3 attempts since last update) and applying stop label '%s'.", num, stopLabel)
+						} else {
+							prevFailed := false
+							processedPath := filepath.Join(processedDir, filename)
+							if data, err := os.ReadFile(processedPath); err == nil {
+								var t QueueTask
+								if err := yaml.Unmarshal(data, &t); err == nil {
+									if t.Status == "Failed" {
+										prevFailed = true
+									}
+								}
+							}
+
+							if state.lastSHA != headSHA || prevFailed || isExplicitlyAssigned || time.Since(state.lastInvestigatedTime) > 6*time.Hour {
+								sandboxName := resolveSandboxName(ctx, kubeClient, ghClient, "pr-investigate", num, owner, repo)
+								running, err := isSandboxTaskRunning(ctx, kubeClient, rootFlags.Namespace, sandboxName)
+								if err != nil {
+									klog.Errorf("Failed to check if sandbox %s is running: %v", sandboxName, err)
+								} else if running {
+									klog.Infof("Skipping PR #%d investigate because there is an in-flight sandbox %s.", num, sandboxName)
 								} else {
-									fmt.Printf("Queueing investigate task for PR #%d...\n", num)
-									state.lastSHA = headSHA
-									state.lastInvestigatedTime = time.Now()
-									processedPRs[num] = state
-									if err := writeTaskAtomically(incomingDir, filename, task); err != nil {
-										klog.Errorf("Failed to queue investigate task for PR #%d: %v", num, err)
+									assignedBot := assignedBotUser(prIssue, allBotUsers)
+
+									taskAssignee := assignedBot
+									if taskAssignee == "" {
+										taskAssignee = author
+									}
+
+									prURL := fmt.Sprintf("https://github.com/%s/%s/pull/%d", owner, repo, num)
+									task := &QueueTask{
+										Type:      "pr-investigate",
+										URL:       prURL,
+										Number:    num,
+										Priority:  getPRPriority(prIssue),
+										Phase:     3,
+										CreatedAt: pr.GetCreatedAt(),
+										Assignee:  taskAssignee,
+										Status:    "Pending",
+										CommitSHA: headSHA,
+									}
+
+									if dryRun {
+										fmt.Printf("[DRYRUN] Would queue investigate task for PR #%d: %s\n", num, prURL)
 									} else {
-										writeTaskJournalEvent(queueDir, filename, task, "Created", 0)
+										fmt.Printf("Queueing investigate task for PR #%d...\n", num)
+										state.lastSHA = headSHA
+										state.lastInvestigatedTime = time.Now()
+										processedPRs[num] = state
+										if err := writeTaskAtomically(incomingDir, filename, task); err != nil {
+											klog.Errorf("Failed to queue investigate task for PR #%d: %v", num, err)
+										} else {
+											writeTaskJournalEvent(queueDir, filename, task, "Created", 0)
+										}
 									}
 								}
 							}
@@ -2318,6 +2363,13 @@ func hasStopLabel(labels []*githubv39.Label, triggerLabel string) bool {
 		}
 	}
 	return false
+}
+
+func getStopLabel(triggerLabel string) string {
+	if triggerLabel != "" && !strings.EqualFold(triggerLabel, "overseer") {
+		return triggerLabel + "/stop"
+	}
+	return "overseer/stop"
 }
 
 func removePendingTasksForNumber(incomingDir string, number int) {


### PR DESCRIPTION
Seeing lots of 
```
I0710 06:59:56.217031     193 watch.go:1290] Skipping PR #11488 investigate because the bot has already given up on the current commit.
```

We need a better way of identifying such PRs. so auto label it.

#### 1. Removed Legacy "Giving Up" Circuit Breaker
* **Eliminated Redundant State**: Removed the old mechanism that counted investigation attempts, unassigned bot users (`RemoveAssignees`), added the `overseer/giving-up` label, and permanently blocked CI retry investigations once a bot posted `"giving up. Human assistance is required"`.

#### 2. Implemented Automated Label-Based Circuit Breaker (`overseer/stop`)
* **Dynamic Reset Check (`lastResetTime`)**: When evaluating a pull request for CI check failures, the watcher now calculates `lastResetTime` as the latest timestamp between the most recent git commit (`lastCommitTime`) **OR** the most recent comment posted by any human maintainer (`lastHumanCommentTime`).
* **Automated Stop Trigger**: The watcher counts how many times the bot has started investigating CI check failures (`started investigating CI check failures`) after `lastResetTime`. If the bot reaches **3 retry attempts** on the same commit without success or human intervention:
  * It directly attaches the **`overseer/stop` label** (or `<triggerLabel>/stop`).
  * It posts a single transparent comment explaining that automated CI investigation is paused to prevent infinite retry loops.
  * All subsequent watcher scan cycles skip the pull request because of the `overseer/stop` label.

#### 3. Simplified Human Recovery & Retries
* **Unlabel to Resume**: To resume automated investigation, a developer or maintainer simply **removes the `overseer/stop` label** from the pull request (and optionally leaves a comment e.g. `/retest` or pushes a code fix). As soon as the label is removed, the watcher sees the updated human activity/commit, resets the retry counter, and queues a fresh investigation right away.

#### 4. Architecture Documentation Updated (`watch-design-note.md`)
* Updated the Phase 3 (`pr-investigate`) design specifications to document the new automated `overseer/stop` circuit breaker and label-based recovery workflow.