### PR TITLE
automated deletion of evicted pods and better surfacing of pod status 

### DIFF
--- a/factory/pkg/commands/sandbox.go
+++ b/factory/pkg/commands/sandbox.go
@@ -180,13 +180,15 @@ func NewSandboxListCommand(ctx context.Context) *cobra.Command {
 				podStatusStr := ""
 				if podList != nil {
 					for _, pod := range podList.Items {
-						if pod.Labels["sandbox"] == name && pod.DeletionTimestamp == nil {
+						if (pod.Labels["sandbox"] == name || pod.Labels["agents.x-k8s.io/sandbox"] == name) && pod.DeletionTimestamp == nil {
 							podStatusStr = string(pod.Status.Phase)
-							if len(pod.Status.ContainerStatuses) > 0 {
+							if pod.Status.Reason != "" {
+								podStatusStr = pod.Status.Reason
+							} else if len(pod.Status.ContainerStatuses) > 0 {
 								state := pod.Status.ContainerStatuses[0].State
 								if state.Waiting != nil && state.Waiting.Reason != "" {
 									podStatusStr = state.Waiting.Reason
-								} else if state.Terminated != nil && state.Terminated.Reason != "" {
+								} else if state.Terminated != nil && state.Terminated.Reason != "" && state.Terminated.Reason != "ContainerStatusUnknown" {
 									podStatusStr = state.Terminated.Reason
 								}
 							}
@@ -204,7 +206,10 @@ func NewSandboxListCommand(ctx context.Context) *cobra.Command {
 				}
 
 				if podStatusStr == "" {
-					if ann := item.GetAnnotations(); ann != nil {
+					replicas, found, _ := unstructured.NestedInt64(item.Object, "spec", "replicas")
+					if found && replicas == 0 {
+						podStatusStr = "Suspended"
+					} else if ann := item.GetAnnotations(); ann != nil {
 						if s, ok := ann["sandbox.gemini.google.com/pod-status"]; ok && s != "" {
 							podStatusStr = s
 						}

--- a/factory/pkg/commands/sandbox.go
+++ b/factory/pkg/commands/sandbox.go
@@ -241,6 +241,11 @@ func NewSandboxListCommand(ctx context.Context) *cobra.Command {
 				if podStatusStr == "" {
 					podStatusStr = "No Pod"
 				}
+				if ann := item.GetAnnotations(); ann != nil {
+					if countStr, ok := ann["sandbox.gemini.google.com/eviction-count"]; ok && countStr != "" && countStr != "0" {
+						podStatusStr = fmt.Sprintf("%s (Evictions: %s)", podStatusStr, countStr)
+					}
+				}
 
 				lastTaskStr := "-"
 				htmlURL := "-"

--- a/factory/pkg/commands/sandbox.go
+++ b/factory/pkg/commands/sandbox.go
@@ -206,9 +206,32 @@ func NewSandboxListCommand(ctx context.Context) *cobra.Command {
 				}
 
 				if podStatusStr == "" {
-					replicas, found, _ := unstructured.NestedInt64(item.Object, "spec", "replicas")
-					if found && replicas == 0 {
-						podStatusStr = "Suspended"
+					isZeroReplicas := false
+					val, found, _ := unstructured.NestedFieldNoCopy(item.Object, "spec", "replicas")
+					if found && val != nil {
+						switch v := val.(type) {
+						case int64:
+							isZeroReplicas = (v == 0)
+						case int:
+							isZeroReplicas = (v == 0)
+						case float64:
+							isZeroReplicas = (v == 0)
+						}
+					}
+					if !isZeroReplicas {
+						conditions, _, _ := unstructured.NestedSlice(item.Object, "status", "conditions")
+						for _, c := range conditions {
+							if condMap, ok := c.(map[string]interface{}); ok {
+								if msg, _ := condMap["message"].(string); strings.Contains(msg, "replicas is 0") {
+									isZeroReplicas = true
+									break
+								}
+							}
+						}
+					}
+
+					if isZeroReplicas {
+						podStatusStr = "Scaled Down"
 					} else if ann := item.GetAnnotations(); ann != nil {
 						if s, ok := ann["sandbox.gemini.google.com/pod-status"]; ok && s != "" {
 							podStatusStr = s

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -205,24 +205,34 @@ func isSandboxTaskRunning(ctx context.Context, kubeClient *clients.KubernetesCli
 		// First check if the sandbox pod has failed or been evicted before calling envd.Connect
 		podList, err := kubeClient.Clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("sandbox=%s", name)})
 		if err == nil && len(podList.Items) > 0 {
-			for _, pod := range podList.Items {
-				if pod.DeletionTimestamp == nil && (pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded || strings.EqualFold(pod.Status.Reason, "Evicted")) {
-					reason := pod.Status.Reason
-					if reason == "" {
-						reason = string(pod.Status.Phase)
+			hasLiveOrPending := false
+			var lastFailedPod *corev1.Pod
+			for i := range podList.Items {
+				pod := &podList.Items[i]
+				if pod.DeletionTimestamp == nil {
+					if pod.Status.Phase == corev1.PodRunning || pod.Status.Phase == corev1.PodPending {
+						hasLiveOrPending = true
+					} else if pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded || strings.EqualFold(pod.Status.Reason, "Evicted") {
+						lastFailedPod = pod
 					}
-					taskState := "Failed"
-					if pod.Status.Phase == corev1.PodSucceeded {
-						taskState = "Completed"
-					}
-					taskType := annotations["sandbox.gemini.google.com/last-task-type"]
-					if taskType == "" {
-						taskType = "task"
-					}
-					klog.Warningf("Sandbox %s pod is in %s state (reason: %s). Updating sandbox annotation from Running to %s.", name, pod.Status.Phase, reason, taskState)
-					_ = factorysandbox.UpdateSandboxTaskAnnotation(ctx, kubeClient, namespace, name, taskType, taskState)
-					return false, nil
 				}
+			}
+			if !hasLiveOrPending && lastFailedPod != nil {
+				reason := lastFailedPod.Status.Reason
+				if reason == "" {
+					reason = string(lastFailedPod.Status.Phase)
+				}
+				taskState := "Failed"
+				if lastFailedPod.Status.Phase == corev1.PodSucceeded {
+					taskState = "Completed"
+				}
+				taskType := annotations["sandbox.gemini.google.com/last-task-type"]
+				if taskType == "" {
+					taskType = "task"
+				}
+				klog.Warningf("Sandbox %s pod is in %s state (reason: %s). Updating sandbox annotation from Running to %s.", name, lastFailedPod.Status.Phase, reason, taskState)
+				_ = factorysandbox.UpdateSandboxTaskAnnotation(ctx, kubeClient, namespace, name, taskType, taskState)
+				return false, nil
 			}
 		}
 

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -24,8 +24,8 @@ import (
 	"github.com/robfig/cron/v3"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 )
 

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -234,6 +234,7 @@ func isSandboxTaskRunning(ctx context.Context, kubeClient *clients.KubernetesCli
 				_ = factorysandbox.UpdateSandboxTaskAnnotation(ctx, kubeClient, namespace, name, taskType, taskState)
 				if strings.EqualFold(reason, "Evicted") || (lastFailedPod.Status.Phase == corev1.PodFailed && strings.EqualFold(lastFailedPod.Status.Reason, "Evicted")) {
 					klog.Infof("Deleting evicted pod %s so controller can recreate it.", lastFailedPod.Name)
+					_ = factorysandbox.IncrementSandboxEvictionCount(ctx, kubeClient, namespace, name)
 					_ = kubeClient.Clientset.CoreV1().Pods(namespace).Delete(ctx, lastFailedPod.Name, metav1.DeleteOptions{})
 				}
 				return false, nil
@@ -1106,6 +1107,13 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 				pod := &podList.Items[i]
 				if pod.DeletionTimestamp == nil && pod.Status.Phase == corev1.PodFailed && strings.EqualFold(pod.Status.Reason, "Evicted") {
 					klog.Infof("Found evicted sandbox pod %s in namespace %s. Deleting pod so controller can recreate or clean up.", pod.Name, rootFlags.Namespace)
+					sbName := pod.Labels["sandbox"]
+					if sbName == "" {
+						sbName = pod.Labels["agents.x-k8s.io/sandbox"]
+					}
+					if sbName != "" {
+						_ = factorysandbox.IncrementSandboxEvictionCount(ctx, kubeClient, rootFlags.Namespace, sbName)
+					}
 					_ = kubeClient.Clientset.CoreV1().Pods(rootFlags.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
 				}
 			}

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -232,6 +232,10 @@ func isSandboxTaskRunning(ctx context.Context, kubeClient *clients.KubernetesCli
 				}
 				klog.Warningf("Sandbox %s pod is in %s state (reason: %s). Updating sandbox annotation from Running to %s.", name, lastFailedPod.Status.Phase, reason, taskState)
 				_ = factorysandbox.UpdateSandboxTaskAnnotation(ctx, kubeClient, namespace, name, taskType, taskState)
+				if strings.EqualFold(reason, "Evicted") || (lastFailedPod.Status.Phase == corev1.PodFailed && strings.EqualFold(lastFailedPod.Status.Reason, "Evicted")) {
+					klog.Infof("Deleting evicted pod %s so controller can recreate it.", lastFailedPod.Name)
+					_ = kubeClient.Clientset.CoreV1().Pods(namespace).Delete(ctx, lastFailedPod.Name, metav1.DeleteOptions{})
+				}
 				return false, nil
 			}
 		}
@@ -1091,6 +1095,21 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 			return
 		}
 		state.mu.Unlock()
+
+		// Proactively delete any evicted sandbox pods in the namespace so the sandbox controller can recreate them or free resources.
+		func() {
+			podList, err := kubeClient.Clientset.CoreV1().Pods(rootFlags.Namespace).List(ctx, metav1.ListOptions{LabelSelector: "sandbox"})
+			if err != nil {
+				return
+			}
+			for i := range podList.Items {
+				pod := &podList.Items[i]
+				if pod.DeletionTimestamp == nil && pod.Status.Phase == corev1.PodFailed && strings.EqualFold(pod.Status.Reason, "Evicted") {
+					klog.Infof("Found evicted sandbox pod %s in namespace %s. Deleting pod so controller can recreate or clean up.", pod.Name, rootFlags.Namespace)
+					_ = kubeClient.Clientset.CoreV1().Pods(rootFlags.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+				}
+			}
+		}()
 
 		if isDoNotProcess(queueDir) {
 			runningCount, err := countRunningSandboxTasks(ctx, kubeClient, rootFlags.Namespace)

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 )
 
@@ -201,6 +202,30 @@ func isSandboxTaskRunning(ctx context.Context, kubeClient *clients.KubernetesCli
 
 	state := annotations["sandbox.gemini.google.com/last-task-state"]
 	if state == "" || strings.EqualFold(state, "Running") {
+		// First check if the sandbox pod has failed or been evicted before calling envd.Connect
+		podList, err := kubeClient.Clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("sandbox=%s", name)})
+		if err == nil && len(podList.Items) > 0 {
+			for _, pod := range podList.Items {
+				if pod.DeletionTimestamp == nil && (pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded || strings.EqualFold(pod.Status.Reason, "Evicted")) {
+					reason := pod.Status.Reason
+					if reason == "" {
+						reason = string(pod.Status.Phase)
+					}
+					taskState := "Failed"
+					if pod.Status.Phase == corev1.PodSucceeded {
+						taskState = "Completed"
+					}
+					taskType := annotations["sandbox.gemini.google.com/last-task-type"]
+					if taskType == "" {
+						taskType = "task"
+					}
+					klog.Warningf("Sandbox %s pod is in %s state (reason: %s). Updating sandbox annotation from Running to %s.", name, pod.Status.Phase, reason, taskState)
+					_ = factorysandbox.UpdateSandboxTaskAnnotation(ctx, kubeClient, namespace, name, taskType, taskState)
+					return false, nil
+				}
+			}
+		}
+
 		// Verify if the task has actually finished by connecting to the sandbox via envd
 		client, err := envd.Connect(ctx, namespace, name)
 		if err == nil {
@@ -233,6 +258,14 @@ func isSandboxTaskRunning(ctx context.Context, kubeClient *clients.KubernetesCli
 					return false, nil
 				}
 			}
+		} else if strings.Contains(err.Error(), "cannot connect to terminated pod") || strings.Contains(err.Error(), "is in Failed state") {
+			taskType := annotations["sandbox.gemini.google.com/last-task-type"]
+			if taskType == "" {
+				taskType = "task"
+			}
+			klog.Warningf("Sandbox %s pod cannot be connected (%v). Updating sandbox annotation to Failed.", name, err)
+			_ = factorysandbox.UpdateSandboxTaskAnnotation(ctx, kubeClient, namespace, name, taskType, "Failed")
+			return false, nil
 		}
 		return true, nil
 	}

--- a/factory/pkg/envd/client.go
+++ b/factory/pkg/envd/client.go
@@ -87,6 +87,7 @@ func GetSandboxPodName(ctx context.Context, namespace, sandboxName string) (stri
 					} `json:"metadata"`
 					Status struct {
 						Phase      string `json:"phase"`
+						Reason     string `json:"reason"`
 						Conditions []struct {
 							Type   string `json:"type"`
 							Status string `json:"status"`
@@ -102,6 +103,13 @@ func GetSandboxPodName(ctx context.Context, namespace, sandboxName string) (stri
 					if pod.Metadata.DeletionTimestamp != nil {
 						hasTerminating = true
 					} else {
+						if pod.Status.Phase == "Failed" || pod.Status.Phase == "Succeeded" || strings.EqualFold(pod.Status.Reason, "Evicted") {
+							reason := pod.Status.Reason
+							if reason == "" {
+								reason = pod.Status.Phase
+							}
+							return "", fmt.Errorf("sandbox pod %s is in %s state (reason: %s): cannot connect to terminated pod", pod.Metadata.Name, pod.Status.Phase, reason)
+						}
 						if pod.Status.Phase == "Running" {
 							for _, cond := range pod.Status.Conditions {
 								if cond.Type == "Ready" && cond.Status == "True" {

--- a/factory/pkg/envd/client.go
+++ b/factory/pkg/envd/client.go
@@ -366,14 +366,7 @@ func (c *Client) Exec(ctx context.Context, cmdStr, cwd string, envs map[string]s
 	return stream.Err()
 }
 
-// SanitizeWorkspace removes stale git lockfiles or corrupted temporary files left over by an evicted or crashed pod.
-func (c *Client) SanitizeWorkspace(ctx context.Context) {
-	sanitizationCmd := `find /workspaces -maxdepth 4 -name "*.lock" -path "*/.git/*" -delete 2>/dev/null || true`
-	_ = c.Exec(ctx, sanitizationCmd, "/workspaces", nil, nil, nil, nil)
-}
-
 func (c *Client) RunTask(ctx context.Context, cmdStr string, envs map[string]string) error {
-	c.SanitizeWorkspace(ctx)
 	return c.Exec(ctx, cmdStr, "/workspaces", envs, nil, os.Stdout, os.Stderr)
 }
 
@@ -408,9 +401,6 @@ func (c *Client) RunTaskResilient(ctx context.Context, cmdStr string, envs map[s
 	} else if isAlreadyRunning {
 		klog.Infof("Task in directory %s is already running. Reattaching...", taskDir)
 	} else {
-		// Pre-task sanitization: clean up any stale git lockfiles across the workspace left by a previously evicted or crashed pod
-		c.SanitizeWorkspace(ctx)
-
 		// Ensure the task directory exists inside the pod before writing to it
 		if err := c.Exec(ctx, fmt.Sprintf("mkdir -p %s", taskDir), "/workspaces", nil, nil, nil, nil); err != nil {
 			return fmt.Errorf("failed to create task directory in pod: %w", err)

--- a/factory/pkg/envd/client.go
+++ b/factory/pkg/envd/client.go
@@ -98,30 +98,41 @@ func GetSandboxPodName(ctx context.Context, namespace, sandboxName string) (stri
 			if err := json.Unmarshal(out, &podList); err == nil {
 				hasTerminating := false
 				activePodName := ""
+				hasLiveOrPending := false
+				var lastFailedReason string
+				var lastFailedPod string
+				var lastFailedPhase string
 
 				for _, pod := range podList.Items {
 					if pod.Metadata.DeletionTimestamp != nil {
 						hasTerminating = true
 					} else {
-						if pod.Status.Phase == "Failed" || pod.Status.Phase == "Succeeded" || strings.EqualFold(pod.Status.Reason, "Evicted") {
-							reason := pod.Status.Reason
-							if reason == "" {
-								reason = pod.Status.Phase
-							}
-							return "", fmt.Errorf("sandbox pod %s is in %s state (reason: %s): cannot connect to terminated pod", pod.Metadata.Name, pod.Status.Phase, reason)
-						}
 						if pod.Status.Phase == "Running" {
+							hasLiveOrPending = true
 							for _, cond := range pod.Status.Conditions {
 								if cond.Type == "Ready" && cond.Status == "True" {
 									activePodName = pod.Metadata.Name
 								}
 							}
+						} else if pod.Status.Phase == "Pending" {
+							hasLiveOrPending = true
+						} else if pod.Status.Phase == "Failed" || pod.Status.Phase == "Succeeded" || strings.EqualFold(pod.Status.Reason, "Evicted") {
+							reason := pod.Status.Reason
+							if reason == "" {
+								reason = pod.Status.Phase
+							}
+							lastFailedReason = reason
+							lastFailedPod = pod.Metadata.Name
+							lastFailedPhase = pod.Status.Phase
 						}
 					}
 				}
 
 				if !hasTerminating && activePodName != "" {
 					return activePodName, nil
+				}
+				if !hasLiveOrPending && lastFailedPod != "" {
+					return "", fmt.Errorf("sandbox pod %s is in %s state (reason: %s): cannot connect to terminated pod", lastFailedPod, lastFailedPhase, lastFailedReason)
 				}
 			}
 		}

--- a/factory/pkg/envd/client.go
+++ b/factory/pkg/envd/client.go
@@ -366,7 +366,14 @@ func (c *Client) Exec(ctx context.Context, cmdStr, cwd string, envs map[string]s
 	return stream.Err()
 }
 
+// SanitizeWorkspace removes stale git lockfiles or corrupted temporary files left over by an evicted or crashed pod.
+func (c *Client) SanitizeWorkspace(ctx context.Context) {
+	sanitizationCmd := `find /workspaces -maxdepth 4 -name "*.lock" -path "*/.git/*" -delete 2>/dev/null || true`
+	_ = c.Exec(ctx, sanitizationCmd, "/workspaces", nil, nil, nil, nil)
+}
+
 func (c *Client) RunTask(ctx context.Context, cmdStr string, envs map[string]string) error {
+	c.SanitizeWorkspace(ctx)
 	return c.Exec(ctx, cmdStr, "/workspaces", envs, nil, os.Stdout, os.Stderr)
 }
 
@@ -401,6 +408,9 @@ func (c *Client) RunTaskResilient(ctx context.Context, cmdStr string, envs map[s
 	} else if isAlreadyRunning {
 		klog.Infof("Task in directory %s is already running. Reattaching...", taskDir)
 	} else {
+		// Pre-task sanitization: clean up any stale git lockfiles across the workspace left by a previously evicted or crashed pod
+		c.SanitizeWorkspace(ctx)
+
 		// Ensure the task directory exists inside the pod before writing to it
 		if err := c.Exec(ctx, fmt.Sprintf("mkdir -p %s", taskDir), "/workspaces", nil, nil, nil, nil); err != nil {
 			return fmt.Errorf("failed to create task directory in pod: %w", err)

--- a/factory/pkg/sandbox/sandbox.go
+++ b/factory/pkg/sandbox/sandbox.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -378,6 +379,36 @@ func UpdateSandboxTaskAnnotation(ctx context.Context, kubeClient *clients.Kubern
 	_, err = kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Update(ctx, unstructObj, metav1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("updating sandbox %s task annotations: %w", sandboxName, err)
+	}
+	return nil
+}
+
+func IncrementSandboxEvictionCount(ctx context.Context, kubeClient *clients.KubernetesClient, namespace, sandboxName string) error {
+	if ctx.Err() != nil {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+	}
+
+	unstructObj, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Get(ctx, sandboxName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("getting sandbox %s: %w", sandboxName, err)
+	}
+
+	annotations := unstructObj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	countStr := annotations["sandbox.gemini.google.com/eviction-count"]
+	count, _ := strconv.Atoi(countStr)
+	count++
+	annotations["sandbox.gemini.google.com/eviction-count"] = strconv.Itoa(count)
+
+	unstructObj.SetAnnotations(annotations)
+	_, err = kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Update(ctx, unstructObj, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("updating sandbox %s eviction count: %w", sandboxName, err)
 	}
 	return nil
 }

--- a/factory/pkg/tasks/address_feedback.sh
+++ b/factory/pkg/tasks/address_feedback.sh
@@ -74,6 +74,9 @@ EOF
 manager
 bin/
 EOF
+
+    echo "Sanitizing workspace (cleaning stale git locks)..."
+    find /workspaces -maxdepth 4 -name "*.lock" -path "*/.git/*" -delete 2>/dev/null || true
 }
 
 function setupGitRepos {

--- a/factory/pkg/tasks/adopt.sh
+++ b/factory/pkg/tasks/adopt.sh
@@ -62,6 +62,9 @@ EOF
 manager
 bin/
 EOF
+
+    echo "Sanitizing workspace (cleaning stale git locks)..."
+    find /workspaces -maxdepth 4 -name "*.lock" -path "*/.git/*" -delete 2>/dev/null || true
 }
 
 setupGit

--- a/factory/pkg/tasks/fix_issue.sh
+++ b/factory/pkg/tasks/fix_issue.sh
@@ -77,6 +77,9 @@ EOF
 manager
 bin/
 EOF
+
+    echo "Sanitizing workspace (cleaning stale git locks)..."
+    find /workspaces -maxdepth 4 -name "*.lock" -path "*/.git/*" -delete 2>/dev/null || true
 }
 
 function setupGitRepos {

--- a/factory/pkg/tasks/investigate_failures.sh
+++ b/factory/pkg/tasks/investigate_failures.sh
@@ -75,6 +75,9 @@ EOF
 manager
 bin/
 EOF
+
+    echo "Sanitizing workspace (cleaning stale git locks)..."
+    find /workspaces -maxdepth 4 -name "*.lock" -path "*/.git/*" -delete 2>/dev/null || true
 }
 
 function setupGitRepos {

--- a/factory/pkg/tasks/iterate.sh
+++ b/factory/pkg/tasks/iterate.sh
@@ -83,6 +83,9 @@ EOF
 manager
 bin/
 EOF
+
+    echo "Sanitizing workspace (cleaning stale git locks)..."
+    find /workspaces -maxdepth 4 -name "*.lock" -path "*/.git/*" -delete 2>/dev/null || true
 }
 
 function setupGitRepos {

--- a/factory/pkg/tasks/review.sh
+++ b/factory/pkg/tasks/review.sh
@@ -70,6 +70,9 @@ EOF
 manager
 bin/
 EOF
+
+    echo "Sanitizing workspace (cleaning stale git locks)..."
+    find /workspaces -maxdepth 4 -name "*.lock" -path "*/.git/*" -delete 2>/dev/null || true
 }
 
 function setupGitRepos {

--- a/factory/pkg/tasks/run_agent.sh
+++ b/factory/pkg/tasks/run_agent.sh
@@ -78,6 +78,9 @@ EOF
 manager
 bin/
 EOF
+
+    echo "Sanitizing workspace (cleaning stale git locks)..."
+    find /workspaces -maxdepth 4 -name "*.lock" -path "*/.git/*" -delete 2>/dev/null || true
 }
 
 function setupGitRepos {

--- a/repo-agent/pkg/api/handlers_overseer.go
+++ b/repo-agent/pkg/api/handlers_overseer.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -350,6 +351,21 @@ func (s *Server) getOverseerSandboxTasks(c *gin.Context) {
 				tState := ann["sandbox.gemini.google.com/last-task-state"]
 				if tState == "" {
 					tState = "Completed"
+				}
+				if strings.EqualFold(tState, "Running") {
+					conditions, _, _ := unstructured.NestedSlice(sb.Object, "status", "conditions")
+					for _, c := range conditions {
+						if condMap, ok := c.(map[string]interface{}); ok {
+							msg, _ := condMap["message"].(string)
+							reason, _ := condMap["reason"].(string)
+							if strings.Contains(strings.ToLower(msg), "evicted") || strings.EqualFold(reason, "evicted") {
+								tState = "Failed (Evicted)"
+								break
+							} else if strings.Contains(strings.ToLower(msg), "phase: failed") || strings.EqualFold(reason, "podfailed") {
+								tState = "Failed (PodFailed)"
+							}
+						}
+					}
 				}
 				synth := []map[string]interface{}{
 					{

--- a/repo-agent/review-ui/ui/src/Overseer.js
+++ b/repo-agent/review-ui/ui/src/Overseer.js
@@ -263,14 +263,62 @@ const Overseer = ({ onBack, namespace: userNamespace }) => {
         return 'var(--status-grey)';
     };
 
+    const getSandboxPodInfo = (sb) => {
+        if (!sb) return { status: 'Unknown', label: 'Unknown', badgeLabel: 'Unknown', color: 'var(--text-secondary)', bgColor: 'var(--bg-secondary)', isSuspended: false, isEvicted: false, isFailed: false };
+        const replicas = sb.spec?.replicas;
+        const conditions = sb.status?.conditions || [];
+        let isSuspended = (replicas === 0 || replicas === '0');
+        if (!isSuspended) {
+            for (const c of conditions) {
+                if (c.message && c.message.toLowerCase().includes('replicas is 0')) {
+                    isSuspended = true;
+                    break;
+                }
+            }
+        }
+        if (isSuspended) {
+            return { status: 'scaled down', label: 'Scaled Down (0)', badgeLabel: 'Scaled Down', color: '#856404', bgColor: '#fff3cd', isSuspended: true, isEvicted: false, isFailed: false };
+        }
+
+        let isEvicted = false;
+        let isFailed = false;
+        let failReason = 'Failed';
+        for (const c of conditions) {
+            const msg = (c.message || '').toLowerCase();
+            const reason = (c.reason || '').toLowerCase();
+            if (msg.includes('evicted') || reason === 'evicted') {
+                isEvicted = true;
+                failReason = 'Evicted';
+                break;
+            }
+            if (msg.includes('phase: failed') || reason === 'podfailed') {
+                isFailed = true;
+            }
+        }
+        if (isEvicted || isFailed) {
+            return {
+                status: isEvicted ? 'evicted' : 'failed',
+                label: isEvicted ? 'Evicted (1)' : 'Failed (1)',
+                badgeLabel: failReason,
+                color: '#d93025',
+                bgColor: '#fce8e6',
+                isSuspended: false,
+                isEvicted: true,
+                isFailed: true
+            };
+        }
+
+        return { status: 'running', label: 'Running (1)', badgeLabel: 'Active', color: 'var(--status-green)', bgColor: 'var(--bg-secondary)', isSuspended: false, isEvicted: false, isFailed: false };
+    };
+
     const filterSandbox = (sb) => {
         if (!searchFilter || !searchFilter.trim()) return true;
         const q = searchFilter.trim().toLowerCase();
         const name = sb.metadata?.name || '';
         const typeBadge = getSandboxBadgeLabel(sb);
         const rawType = sb.metadata?.labels?.['sandbox.gemini.google.com/type'] || sb.metadata?.labels?.['sandbox-type'] || '';
-        const isSuspended = sb.spec?.replicas === 0 || sb.spec?.replicas === '0';
-        const status = isSuspended ? 'suspended' : 'running';
+        const podInfo = getSandboxPodInfo(sb);
+        const status = podInfo.status;
         const issue = sb.metadata?.labels?.['factory.gemini.google.com/issue'] || sb.metadata?.labels?.issue || '';
         const pr = sb.metadata?.labels?.['factory.gemini.google.com/pr'] || sb.metadata?.annotations?.pr || '';
         const user = sb.metadata?.labels?.['factory.gemini.google.com/user'] || '';
@@ -395,19 +443,40 @@ const Overseer = ({ onBack, namespace: userNamespace }) => {
                                         }}>
                                             {getSandboxBadgeLabel(activeSandbox)}
                                         </span>
-                                        {(activeSandbox.spec?.replicas === 0 || activeSandbox.spec?.replicas === '0') && (
-                                            <span style={{ 
-                                                padding: '3px 10px', 
-                                                borderRadius: '12px', 
-                                                fontSize: '0.75rem', 
-                                                fontWeight: 'bold', 
-                                                backgroundColor: '#fff3cd', 
-                                                color: '#856404', 
-                                                border: '1px solid #ffeeba'
-                                            }}>
-                                                ⏸️ Suspended (Replicas: 0)
-                                            </span>
-                                        )}
+                                        {(() => {
+                                            const podInfo = getSandboxPodInfo(activeSandbox);
+                                            if (podInfo.isSuspended) {
+                                                return (
+                                                    <span style={{ 
+                                                        padding: '3px 10px', 
+                                                        borderRadius: '12px', 
+                                                        fontSize: '0.75rem', 
+                                                        fontWeight: 'bold', 
+                                                        backgroundColor: podInfo.bgColor, 
+                                                        color: podInfo.color, 
+                                                        border: '1px solid #ffeeba'
+                                                    }}>
+                                                        ⏸️ Scaled Down (Replicas: 0)
+                                                    </span>
+                                                );
+                                            }
+                                            if (podInfo.isEvicted || podInfo.isFailed) {
+                                                return (
+                                                    <span style={{ 
+                                                        padding: '3px 10px', 
+                                                        borderRadius: '12px', 
+                                                        fontSize: '0.75rem', 
+                                                        fontWeight: 'bold', 
+                                                        backgroundColor: podInfo.bgColor, 
+                                                        color: podInfo.color, 
+                                                        border: '1px solid #f8d7da'
+                                                    }}>
+                                                        ⚠️ {podInfo.label}
+                                                    </span>
+                                                );
+                                            }
+                                            return null;
+                                        })()}
                                     </div>
 
                                     <div style={{ fontSize: '0.85rem', color: 'var(--text-secondary)', display: 'flex', flexWrap: 'wrap', gap: '15px' }}>
@@ -585,16 +654,23 @@ const Overseer = ({ onBack, namespace: userNamespace }) => {
                     </div>
                 ) : activeOverseer ? (() => {
                     const overseerName = `overseer-${activeOverseer.metadata.name}`;
-                    const filtered = sandboxes.filter(sb => {
-                        const name = sb.metadata?.name || '';
-                        const sType = sb.metadata?.labels?.['sandbox.gemini.google.com/type'] || sb.metadata?.labels?.['sandbox-type'] || '';
-                        if (name === overseerName || sType === 'overseer') return false;
-                        return filterSandbox(sb);
+                    const runningSandboxes = filtered.filter(sb => {
+                        const info = getSandboxPodInfo(sb);
+                        return !info.isSuspended && !info.isEvicted && !info.isFailed;
                     });
-                    const activeSandboxes = filtered.filter(sb => !(sb.spec?.replicas === 0 || sb.spec?.replicas === '0'));
-                    const suspendedSandboxes = filtered.filter(sb => sb.spec?.replicas === 0 || sb.spec?.replicas === '0');
+                    const evictedSandboxes = filtered.filter(sb => {
+                        const info = getSandboxPodInfo(sb);
+                        return !info.isSuspended && (info.isEvicted || info.isFailed);
+                    });
+                    const suspendedSandboxes = filtered.filter(sb => {
+                        const info = getSandboxPodInfo(sb);
+                        return info.isSuspended;
+                    });
 
-                    const renderTableRow = (sb, isSuspended) => {
+                    const renderTableRow = (sb) => {
+                        const podInfo = getSandboxPodInfo(sb);
+                        const isSuspended = podInfo.isSuspended;
+                        const isEvicted = podInfo.isEvicted || podInfo.isFailed;
                         const name = sb.metadata?.name || '';
                         const typeBadge = getSandboxBadgeLabel(sb);
                         const icon = getSandboxTypeIcon(sb);
@@ -632,23 +708,23 @@ const Overseer = ({ onBack, namespace: userNamespace }) => {
                                 style={{ 
                                     cursor: 'pointer', 
                                     borderBottom: '1px solid var(--border-color)',
-                                    backgroundColor: isSuspended ? 'rgba(255, 243, 205, 0.04)' : 'transparent',
+                                    backgroundColor: isEvicted ? 'rgba(217, 48, 37, 0.04)' : (isSuspended ? 'rgba(255, 243, 205, 0.04)' : 'transparent'),
                                     opacity: isSuspended ? 0.75 : 1
                                 }}
                                 className="table-row-hover"
                             >
                                 <td style={{ padding: '12px 16px', fontWeight: 'bold', color: 'var(--text-primary)', display: 'flex', alignItems: 'center', gap: '8px' }}>
-                                    <span>{isSuspended ? '⏸️' : icon}</span>
+                                    <span>{isEvicted ? '⚠️' : (isSuspended ? '⏸️' : icon)}</span>
                                     <span style={{ textDecoration: isSuspended ? 'line-through' : 'none' }}>{name}</span>
                                 </td>
                                 <td style={{ padding: '12px 16px' }}>
-                                    <span style={{ fontSize: '0.75rem', padding: '3px 8px', borderRadius: '10px', backgroundColor: isSuspended ? '#fff3cd' : 'var(--bg-secondary)', color: isSuspended ? '#856404' : 'var(--text-secondary)', fontWeight: isSuspended ? 'bold' : 'normal', whiteSpace: 'nowrap' }}>
-                                        {isSuspended ? `Suspended • ${typeBadge}` : typeBadge}
+                                    <span style={{ fontSize: '0.75rem', padding: '3px 8px', borderRadius: '10px', backgroundColor: podInfo.bgColor, color: podInfo.color, fontWeight: (isSuspended || isEvicted) ? 'bold' : 'normal', whiteSpace: 'nowrap' }}>
+                                        {isSuspended ? `Scaled Down • ${typeBadge}` : (isEvicted ? `${podInfo.badgeLabel} • ${typeBadge}` : typeBadge)}
                                     </span>
                                 </td>
                                 <td style={{ padding: '12px 16px', fontSize: '0.85rem' }}>
-                                    <span style={{ color: isSuspended ? '#856404' : 'var(--status-green)', fontWeight: '600' }}>
-                                        {isSuspended ? 'Suspended (0)' : 'Running (1)'}
+                                    <span style={{ color: podInfo.color, fontWeight: '600' }}>
+                                        {podInfo.label}
                                     </span>
                                 </td>
                                 <td style={{ padding: '12px 16px', fontSize: '0.85rem', fontFamily: 'monospace', color: 'var(--text-secondary)' }}>
@@ -751,20 +827,31 @@ const Overseer = ({ onBack, namespace: userNamespace }) => {
                                             </td>
                                         </tr>
 
-                                        {activeSandboxes.map(sb => renderTableRow(sb, false))}
+                                        {runningSandboxes.map(sb => renderTableRow(sb))}
+
+                                        {evictedSandboxes.length > 0 && (
+                                            <>
+                                                <tr style={{ backgroundColor: 'var(--bg-sidebar)', borderTop: '2px solid var(--border-color)' }}>
+                                                    <td colSpan={7} style={{ padding: '10px 16px', fontSize: '0.75rem', fontWeight: 'bold', color: '#d93025', textTransform: 'uppercase' }}>
+                                                        ⚠️ Evicted / Failed Sandboxes ({evictedSandboxes.length})
+                                                    </td>
+                                                </tr>
+                                                {evictedSandboxes.map(sb => renderTableRow(sb))}
+                                            </>
+                                        )}
 
                                         {suspendedSandboxes.length > 0 && (
                                             <>
                                                 <tr style={{ backgroundColor: 'var(--bg-sidebar)', borderTop: '2px solid var(--border-color)' }}>
                                                     <td colSpan={7} style={{ padding: '10px 16px', fontSize: '0.75rem', fontWeight: 'bold', color: '#856404', textTransform: 'uppercase' }}>
-                                                        ⏸️ Suspended Sandboxes ({suspendedSandboxes.length})
+                                                        ⏸️ Scaled Down Sandboxes ({suspendedSandboxes.length})
                                                     </td>
                                                 </tr>
-                                                {suspendedSandboxes.map(sb => renderTableRow(sb, true))}
+                                                {suspendedSandboxes.map(sb => renderTableRow(sb))}
                                             </>
                                         )}
 
-                                        {activeSandboxes.length === 0 && suspendedSandboxes.length === 0 && (
+                                        {runningSandboxes.length === 0 && evictedSandboxes.length === 0 && suspendedSandboxes.length === 0 && (
                                             <tr>
                                                 <td colSpan={7} style={{ padding: '40px', textAlign: 'center', color: 'var(--text-muted)', fontStyle: 'italic' }}>
                                                     No sandboxes match your current filter or repo.

--- a/repo-agent/review-ui/ui/src/Overseer.js
+++ b/repo-agent/review-ui/ui/src/Overseer.js
@@ -264,9 +264,13 @@ const Overseer = ({ onBack, namespace: userNamespace }) => {
     };
 
     const getSandboxPodInfo = (sb) => {
-        if (!sb) return { status: 'Unknown', label: 'Unknown', badgeLabel: 'Unknown', color: 'var(--text-secondary)', bgColor: 'var(--bg-secondary)', isSuspended: false, isEvicted: false, isFailed: false };
+        if (!sb) return { status: 'Unknown', label: 'Unknown', badgeLabel: 'Unknown', color: 'var(--text-secondary)', bgColor: 'var(--bg-secondary)', isSuspended: false, isEvicted: false, isFailed: false, evictionCount: 0 };
         const replicas = sb.spec?.replicas;
         const conditions = sb.status?.conditions || [];
+        const evictionCountStr = sb.metadata?.annotations?.['sandbox.gemini.google.com/eviction-count'] || '0';
+        const evictionCount = parseInt(evictionCountStr, 10) || 0;
+        const evictionSuffix = evictionCount > 0 ? ` (Evictions: ${evictionCount})` : '';
+
         let isSuspended = (replicas === 0 || replicas === '0');
         if (!isSuspended) {
             for (const c of conditions) {
@@ -277,7 +281,7 @@ const Overseer = ({ onBack, namespace: userNamespace }) => {
             }
         }
         if (isSuspended) {
-            return { status: 'scaled down', label: 'Scaled Down (0)', badgeLabel: 'Scaled Down', color: '#856404', bgColor: '#fff3cd', isSuspended: true, isEvicted: false, isFailed: false };
+            return { status: 'scaled down', label: `Scaled Down (0)${evictionSuffix}`, badgeLabel: 'Scaled Down', color: '#856404', bgColor: '#fff3cd', isSuspended: true, isEvicted: false, isFailed: false, evictionCount };
         }
 
         let isEvicted = false;
@@ -298,17 +302,18 @@ const Overseer = ({ onBack, namespace: userNamespace }) => {
         if (isEvicted || isFailed) {
             return {
                 status: isEvicted ? 'evicted' : 'failed',
-                label: isEvicted ? 'Evicted (1)' : 'Failed (1)',
+                label: `${isEvicted ? 'Evicted (1)' : 'Failed (1)'}${evictionSuffix}`,
                 badgeLabel: failReason,
                 color: '#d93025',
                 bgColor: '#fce8e6',
                 isSuspended: false,
                 isEvicted: true,
-                isFailed: true
+                isFailed: true,
+                evictionCount
             };
         }
 
-        return { status: 'running', label: 'Running (1)', badgeLabel: 'Active', color: 'var(--status-green)', bgColor: 'var(--bg-secondary)', isSuspended: false, isEvicted: false, isFailed: false };
+        return { status: 'running', label: `Running (1)${evictionSuffix}`, badgeLabel: 'Active', color: 'var(--status-green)', bgColor: 'var(--bg-secondary)', isSuspended: false, isEvicted: false, isFailed: false, evictionCount };
     };
 
     const filterSandbox = (sb) => {
@@ -445,9 +450,25 @@ const Overseer = ({ onBack, namespace: userNamespace }) => {
                                         </span>
                                         {(() => {
                                             const podInfo = getSandboxPodInfo(activeSandbox);
+                                            const badges = [];
+                                            if (podInfo.evictionCount > 0) {
+                                                badges.push(
+                                                    <span key="eviction-badge" style={{ 
+                                                        padding: '3px 10px', 
+                                                        borderRadius: '12px', 
+                                                        fontSize: '0.75rem', 
+                                                        fontWeight: 'bold', 
+                                                        backgroundColor: '#fff3cd', 
+                                                        color: '#856404', 
+                                                        border: '1px solid #ffeeba'
+                                                    }} title="Total number of times this sandbox's pod has been evicted and automatically cleaned up/recreated.">
+                                                        🔄 Evictions: {podInfo.evictionCount}
+                                                    </span>
+                                                );
+                                            }
                                             if (podInfo.isSuspended) {
-                                                return (
-                                                    <span style={{ 
+                                                badges.push(
+                                                    <span key="status-badge" style={{ 
                                                         padding: '3px 10px', 
                                                         borderRadius: '12px', 
                                                         fontSize: '0.75rem', 
@@ -459,10 +480,9 @@ const Overseer = ({ onBack, namespace: userNamespace }) => {
                                                         ⏸️ Scaled Down (Replicas: 0)
                                                     </span>
                                                 );
-                                            }
-                                            if (podInfo.isEvicted || podInfo.isFailed) {
-                                                return (
-                                                    <span style={{ 
+                                            } else if (podInfo.isEvicted || podInfo.isFailed) {
+                                                badges.push(
+                                                    <span key="status-badge" style={{ 
                                                         padding: '3px 10px', 
                                                         borderRadius: '12px', 
                                                         fontSize: '0.75rem', 
@@ -475,7 +495,7 @@ const Overseer = ({ onBack, namespace: userNamespace }) => {
                                                     </span>
                                                 );
                                             }
-                                            return null;
+                                            return badges;
                                         })()}
                                     </div>
 


### PR DESCRIPTION
### 1. Automated Eviction Handling & Pod Lifecycle Management (`factory watch`)
* **Proactive Eviction Cleanup**: `factory watch` now actively scans the namespace on every watch cycle (`checkRepo()`) and checks pod status during task verification (`isSandboxTaskRunning`). If it encounters a pod in `Evicted` status, it immediately transitions the `Sandbox` CR's `last-task-state` annotation from `Running` to `Failed` and **deletes the evicted pod object**, allowing `agent-sandbox-controller` to immediately spawn a fresh pod or free up cluster resources.
* **Non-Blocking Pod Connection**: When attempting to connect via `envd`, `GetSandboxPodName` immediately fast-fails when a pod is in `Failed` or `Evicted` status rather than hanging in a 6-minute retry loop.
* **Recreated Pod Resilience**: Added intelligent `hasLiveOrPending` verification. If a sandbox pod has been recreated and is starting up while an old evicted pod object is awaiting Kubernetes garbage collection, `factory watch` and `envd` prioritize the active/pending replacement pod and continue smoothly without throwing false failure errors.

### 2. Eviction Metric Tracking & Visibility (`Sandbox` CR, CLI, & Web UI)
* **Persistent Eviction Counter**: Whenever `factory watch` cleans up an evicted pod, it atomically increments a `sandbox.gemini.google.com/eviction-count` annotation on the `Sandbox` Custom Resource.
* **`factory sandbox list` CLI**: The CLI table automatically appends eviction metrics to the `STATUS` column whenever the count is greater than zero (e.g., `Running (Evictions: 1)` or `Scaled Down (Evictions: 2)`).
* **Overseer Web UI & Backend API**: The backend API (`handlers_overseer.go`) accurately reports `Failed (Evicted)` when a pod has failed mid-task. The web interface (`Overseer.js`) groups and highlights evicted sandboxes in the table with distinct warning badges, displays `[Evictions: N]` suffixes on status labels, and renders a dedicated `🔄 Evictions: N` badge inside the right-hand details drawer.

### 3. Decoupled Pre-Task Workspace Sanitization (`factory/pkg/tasks/*.sh`)
* **Stale Lockfile Purging**: To ensure that a pod evicted midway through a Git checkout or commit (`OOM` pressure) does not corrupt the persistent `/workspaces` volume on retry, automatic sanitization (`find /workspaces -maxdepth 4 -name "*.lock" -path "*/.git/*" -delete`) was added to `setupGit` across all embedded task scripts (`fix_issue.sh`, `address_feedback.sh`, `investigate_failures.sh`, `iterate.sh`, `review.sh`, `adopt.sh`, and `run_agent.sh`).
* **Clean Separation of Concerns**: This ensures every task script purges leftover `.git/index.lock` or `HEAD.lock` files right before initializing its repository, while keeping `envd.Client` strictly decoupled as a general-purpose remote command executor.




Shows `Evicted` and `Scaled Down` in sandbox list:

```
barni@barni.c ~/workspace/src/github.com/barney-s/gemini-for-kubernetes-development/factory% ./bin/factory sandbox list  -n overseer-kcc  
NAME                TYPE     STATUS         ASSIGNED BOT          LAST TASK                  PR/ISSUE URL                                                                AGE
factory-pr-10977    pr       Scaled Down    lovelace-coder-bot    investigate (Completed)    https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/10977      9h52m40s
factory-pr-11264    pr       Running        hopper-coder-bot      investigate (Running)      https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/11264      9h52m41s
factory-pr-11386    pr       Running        ada-coder-bot         investigate (Completed)    https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/11386      1h28m56s
factory-pr-11415    pr       Running        ada-coder-bot         iterate (Completed)        https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/11415      9h52m49s
factory-pr-11483    pr       Running        lovelace-coder-bot    iterate (Completed)        https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/11483      9h52m43s
factory-pr-11530    pr       Scaled Down    ada-coder-bot         investigate (Completed)    https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/11530      9h52m44s
factory-pr-11546    pr       Scaled Down    hopper-coder-bot      investigate (Completed)    https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/11546      9h52m45s
factory-pr-11563    pr       Evicted        lovelace-coder-bot    investigate (Running)      https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/11563      9h52m47s
overseer-kcc        agent    Running        -                     -                          -                                                                           10h1m29s
wf-issue-10588      agent    Scaled Down    daedalus-agent-bot    agent (Completed)          https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/10588    9h52m37s
wf-issue-10612      agent    Running        walle-agent-bot       agent (Completed)          https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/10612    9h52m39s
wf-issue-10735      agent    Running        feynman-agent-bot     agent (Completed)          https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/10735    9h52m49s
wf-issue-10886      agent    Running        feynman-agent-bot     agent (Completed)          https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/10886    9h52m41s
wf-issue-10938      agent    Running        daedalus-agent-bot    agent (Completed)          https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/10938    9h52m42s
wf-issue-10939      agent    Running        daedalus-agent-bot    agent (Completed)          https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/10939    9h52m43s
wf-issue-11525      agent    Running        walle-agent-bot       agent (Completed)          https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/11525    9h52m42s
wf-issue-11543      agent    Running        walle-agent-bot       agent (Completed)          https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/11543    9h52m43s
```