### PR TITLE
fix(watch): only update state.lastSHA after queueing investigate and reduce cooldown to 2h

### DIFF
--- a/.agents/workflows/kcc-example.txt
+++ b/.agents/workflows/kcc-example.txt
@@ -3,6 +3,7 @@ description: A meta-skill for KCC kinds that describes the steps we need to take
 name: checklist-for-kind
 schedule: never
 mode: workflow
+cooldown: 2h
 ---
 
 # Checklist for KCC Resource Kind Migration

--- a/.agents/workflows/kcc-greenfield.txt
+++ b/.agents/workflows/kcc-greenfield.txt
@@ -3,6 +3,7 @@ description: A meta-skill for KCC Greenfield resources that describes the steps 
 name: checklist-for-kind
 schedule: never
 mode: workflow
+cooldown: 2h
 ---
 
 # Checklist for KCC Greenfield Resource Migration

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -1309,8 +1309,6 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 					}
 				}
 
-
-
 				if hasFailure {
 					filename := fmt.Sprintf("task-pr-%d-investigate.yaml", num)
 					if !taskExists(incomingDir, processingDir, filename) {

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -1309,10 +1309,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 					}
 				}
 
-				if state.lastSHA != headSHA {
-					state.lastSHA = headSHA
-					processedPRs[num] = state
-				}
+
 
 				if hasFailure {
 					filename := fmt.Sprintf("task-pr-%d-investigate.yaml", num)
@@ -1373,7 +1370,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 								}
 							}
 
-							if state.lastSHA != headSHA || prevFailed || isExplicitlyAssigned || time.Since(state.lastInvestigatedTime) > 6*time.Hour {
+							if state.lastSHA != headSHA || prevFailed || isExplicitlyAssigned || time.Since(state.lastInvestigatedTime) > 2*time.Hour {
 								sandboxName := resolveSandboxName(ctx, kubeClient, ghClient, "pr-investigate", num, owner, repo)
 								running, err := isSandboxTaskRunning(ctx, kubeClient, rootFlags.Namespace, sandboxName)
 								if err != nil {
@@ -1418,6 +1415,9 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 							}
 						}
 					}
+				} else if state.lastSHA != headSHA {
+					state.lastSHA = headSHA
+					processedPRs[num] = state
 				}
 
 				// Check review comments and approvals


### PR DESCRIPTION
minor bug which was causing longer delay in responding to failures in an automated way. 
User can still assign the coder bot to get faster response.