### PR TITLE
envd: write exit code on quota error termination and task abort

### DIFF
--- a/factory/pkg/envd/client.go
+++ b/factory/pkg/envd/client.go
@@ -457,7 +457,7 @@ func (c *Client) RunTaskResilient(ctx context.Context, cmdStr string, envs map[s
 				defer killCancel()
 
 				fmt.Printf("Terminating process in pod...\n")
-				killCmd := fmt.Sprintf("if [ -f %s ]; then pids=\"$(cat %s) $(pgrep -P $(cat %s) 2>/dev/null)\"; kill $pids 2>/dev/null || true; fi", pidFile, pidFile, pidFile)
+				killCmd := fmt.Sprintf("if [ -f %s ]; then pids=\"$(cat %s) $(pgrep -P $(cat %s) 2>/dev/null)\"; kill $pids 2>/dev/null || true; if [ ! -f %s ]; then echo 143 > %s; fi; fi", pidFile, pidFile, pidFile, exitCodeFile, exitCodeFile)
 				_ = c.Exec(killCtx, killCmd, "/workspaces", nil, nil, nil, nil)
 			}
 			return loopCtx.Err()
@@ -483,7 +483,7 @@ func (c *Client) RunTaskResilient(ctx context.Context, cmdStr string, envs map[s
 						klog.Warningf("Quota exceeded detected in task output. Terminating task process in sandbox pod immediately...")
 						killCtx, killCancel := context.WithTimeout(context.Background(), 15*time.Second)
 						defer killCancel()
-						killCmd := fmt.Sprintf("if [ -f %s ]; then pids=\"$(cat %s) $(pgrep -P $(cat %s) 2>/dev/null)\"; kill -9 $pids 2>/dev/null || true; fi", pidFile, pidFile, pidFile)
+						killCmd := fmt.Sprintf("if [ -f %s ]; then pids=\"$(cat %s) $(pgrep -P $(cat %s) 2>/dev/null)\"; kill -9 $pids 2>/dev/null || true; echo 137 > %s; fi", pidFile, pidFile, pidFile, exitCodeFile)
 						_ = c.Exec(killCtx, killCmd, "/workspaces", nil, nil, nil, nil)
 						return fmt.Errorf("task failed due to quota exceeded (RESOURCE_EXHAUSTED / 429)")
 					}
@@ -537,6 +537,9 @@ func (c *Client) RunTaskResilient(ctx context.Context, cmdStr string, envs map[s
 									klog.Errorf("Failed to mark key as quota exceeded: %v", err)
 								}
 							}
+							killCtx, killCancel := context.WithTimeout(context.Background(), 15*time.Second)
+							defer killCancel()
+							_ = c.Exec(killCtx, fmt.Sprintf("echo 137 > %s", exitCodeFile), "/workspaces", nil, nil, nil, nil)
 							return fmt.Errorf("task failed due to quota exceeded (RESOURCE_EXHAUSTED / 429)")
 						}
 					}
@@ -572,6 +575,9 @@ func (c *Client) RunTaskResilient(ctx context.Context, cmdStr string, envs map[s
 											klog.Errorf("Failed to mark key as quota exceeded: %v", err)
 										}
 									}
+									killCtx, killCancel := context.WithTimeout(context.Background(), 15*time.Second)
+									defer killCancel()
+									_ = c.Exec(killCtx, fmt.Sprintf("echo 137 > %s", exitCodeFile), "/workspaces", nil, nil, nil, nil)
 									return fmt.Errorf("task failed due to quota exceeded (RESOURCE_EXHAUSTED / 429)")
 								}
 							}
@@ -586,6 +592,9 @@ func (c *Client) RunTaskResilient(ctx context.Context, cmdStr string, envs map[s
 						return nil
 					}
 				}
+				killCtx, killCancel := context.WithTimeout(context.Background(), 15*time.Second)
+				defer killCancel()
+				_ = c.Exec(killCtx, fmt.Sprintf("if [ ! -f %s ]; then echo 1 > %s; fi", exitCodeFile, exitCodeFile), "/workspaces", nil, nil, nil, nil)
 				return fmt.Errorf("task process terminated abruptly (PID file missing or process not found)")
 			}
 


### PR DESCRIPTION
### What Was Fixed
1. **Quota Exceeded (`429`) Termination:** When `envd` terminates a task process inside the pod due to `429 Quota Exceeded`, it now immediately writes exit code `137` (`SIGKILL`) to `/workspaces/tasks/<id>/exit_code`.
2. **Task Cancellation / Abort:** When a task is canceled or aborted via context cancellation (`Ctrl+C` or timeout), `envd` now writes exit code `143` (`SIGTERM`) to `/workspaces/tasks/<id>/exit_code` if an exit code has not already been recorded.
3. **Abrupt Crash Fallback:** If a process terminates abruptly and no `exit_code` file exists after a 5-second grace period, `1` is written to `exit_code` before `RunTaskResilient` returns an error.