### PR TITLE
feat: track and accumulate gemini-cli token usage across task scripts and workflows

### DIFF
--- a/factory/pkg/tasks/address_feedback.sh
+++ b/factory/pkg/tasks/address_feedback.sh
@@ -123,7 +123,8 @@ function configureGemini {
 {
   "general": {
     "enableAutoUpdate": false,
-    "retryFetchErrors": true
+    "retryFetchErrors": true,
+    "previewFeatures": true
   }
 }
 EOF
@@ -135,6 +136,84 @@ function installExtensions {
         for ext in $EXTENSIONS; do
             gemini extensions install "$ext" --consent
         done
+    fi
+}
+
+function record_gemini_usage {
+    local output_file="$1"
+    local task_dir="$(dirname "${PROMPT_FILE}")"
+    if [ -f "$output_file" ]; then
+        python3 -c '
+import json, os, sys
+
+output_file = sys.argv[1]
+task_dir = sys.argv[2]
+
+try:
+    with open(output_file, "r") as f:
+        data = json.load(f)
+except Exception:
+    sys.exit(0)
+
+stats = data.get("stats", {})
+models = stats.get("models", {})
+if not models and ("total_tokens" in stats or "total" in stats or "totalRequests" in stats):
+    models = {data.get("model", "gemini-cli"): {
+        "api": {"totalRequests": stats.get("totalRequests", stats.get("tool_calls", 0) + 1), "totalErrors": stats.get("totalErrors", 0), "totalLatencyMs": stats.get("totalLatencyMs", stats.get("duration_ms", 0))},
+        "tokens": {"input": stats.get("input", stats.get("input_tokens", 0)), "output": stats.get("candidates", stats.get("output", stats.get("output_tokens", 0))), "total": stats.get("total", stats.get("total_tokens", 0)), "cached": stats.get("cached", 0), "thoughts": stats.get("thoughts", 0)}
+    }}
+
+if not models:
+    sys.exit(0)
+
+usage_path = os.path.join(task_dir, "llm-usage.json")
+token_path = os.path.join(task_dir, "token-usage.json")
+
+existing = {"models": {}}
+if os.path.exists(usage_path):
+    try:
+        with open(usage_path, "r") as f:
+            existing = json.load(f)
+    except Exception:
+        pass
+elif os.path.exists(token_path):
+    try:
+        with open(token_path, "r") as f:
+            existing = json.load(f)
+    except Exception:
+        pass
+
+for model_name, model_data in models.items():
+    api = model_data.get("api", {})
+    tokens = model_data.get("tokens", {})
+    
+    cur_model = existing.get("models", {}).get(model_name, {
+        "api": {"totalRequests": 0, "totalErrors": 0, "totalLatencyMs": 0},
+        "tokens": {"input": 0, "output": 0, "total": 0, "cached": 0, "thoughts": 0}
+    })
+    
+    cur_model["api"]["totalRequests"] += api.get("totalRequests", api.get("total_requests", 1))
+    cur_model["api"]["totalErrors"] += api.get("totalErrors", api.get("total_errors", 0))
+    cur_model["api"]["totalLatencyMs"] += api.get("totalLatencyMs", api.get("total_latency_ms", 0))
+    
+    cur_model["tokens"]["input"] += tokens.get("input", 0)
+    cur_model["tokens"]["output"] += tokens.get("candidates", tokens.get("output", 0))
+    cur_model["tokens"]["total"] += tokens.get("total", 0)
+    cur_model["tokens"]["cached"] += tokens.get("cached", 0)
+    cur_model["tokens"]["thoughts"] += tokens.get("thoughts", 0)
+    
+    if "models" not in existing:
+        existing["models"] = {}
+    existing["models"][model_name] = cur_model
+
+try:
+    with open(usage_path, "w") as f:
+        json.dump(existing, f, indent=2)
+    with open(token_path, "w") as f:
+        json.dump(existing, f, indent=2)
+except Exception:
+    pass
+' "$output_file" "$task_dir"
     fi
 }
 
@@ -160,6 +239,7 @@ function runGemini {
         fi
         if (cd "/workspaces/${REPO_NAME}" && export GEMINI_API_KEY="${GEMINI_API_KEY}" && gemini "${GEMINI_ARGS[@]}" < ${PROMPT_FILE} > "$(dirname "${PROMPT_FILE}")/gemini-output.json"); then
              echo "Gemini execution successful with model: $MODEL"
+             record_gemini_usage "$(dirname "${PROMPT_FILE}")/gemini-output.json"
              SUCCESS=true
              break
         else

--- a/factory/pkg/tasks/adopt.sh
+++ b/factory/pkg/tasks/adopt.sh
@@ -69,6 +69,102 @@ EOF
 
 setupGit
 
+function configureGemini {
+    echo "Running configureGemini..."
+    echo "creating ${USER_HOME}/.gemini directory"
+    mkdir -p "${USER_HOME}/.gemini"
+
+    echo "writing gemini config"
+    cat <<EOF > "${USER_HOME}/.gemini/settings.json"
+{
+  "general": {
+    "enableAutoUpdate": false,
+    "retryFetchErrors": true,
+    "previewFeatures": true
+  }
+}
+EOF
+}
+configureGemini
+
+function record_gemini_usage {
+    local output_file="$1"
+    local task_dir="$(dirname "${PROMPT_FILE}")"
+    if [ -f "$output_file" ]; then
+        python3 -c '
+import json, os, sys
+
+output_file = sys.argv[1]
+task_dir = sys.argv[2]
+
+try:
+    with open(output_file, "r") as f:
+        data = json.load(f)
+except Exception:
+    sys.exit(0)
+
+stats = data.get("stats", {})
+models = stats.get("models", {})
+if not models and ("total_tokens" in stats or "total" in stats or "totalRequests" in stats):
+    models = {data.get("model", "gemini-cli"): {
+        "api": {"totalRequests": stats.get("totalRequests", stats.get("tool_calls", 0) + 1), "totalErrors": stats.get("totalErrors", 0), "totalLatencyMs": stats.get("totalLatencyMs", stats.get("duration_ms", 0))},
+        "tokens": {"input": stats.get("input", stats.get("input_tokens", 0)), "output": stats.get("candidates", stats.get("output", stats.get("output_tokens", 0))), "total": stats.get("total", stats.get("total_tokens", 0)), "cached": stats.get("cached", 0), "thoughts": stats.get("thoughts", 0)}
+    }}
+
+if not models:
+    sys.exit(0)
+
+usage_path = os.path.join(task_dir, "llm-usage.json")
+token_path = os.path.join(task_dir, "token-usage.json")
+
+existing = {"models": {}}
+if os.path.exists(usage_path):
+    try:
+        with open(usage_path, "r") as f:
+            existing = json.load(f)
+    except Exception:
+        pass
+elif os.path.exists(token_path):
+    try:
+        with open(token_path, "r") as f:
+            existing = json.load(f)
+    except Exception:
+        pass
+
+for model_name, model_data in models.items():
+    api = model_data.get("api", {})
+    tokens = model_data.get("tokens", {})
+    
+    cur_model = existing.get("models", {}).get(model_name, {
+        "api": {"totalRequests": 0, "totalErrors": 0, "totalLatencyMs": 0},
+        "tokens": {"input": 0, "output": 0, "total": 0, "cached": 0, "thoughts": 0}
+    })
+    
+    cur_model["api"]["totalRequests"] += api.get("totalRequests", api.get("total_requests", 1))
+    cur_model["api"]["totalErrors"] += api.get("totalErrors", api.get("total_errors", 0))
+    cur_model["api"]["totalLatencyMs"] += api.get("totalLatencyMs", api.get("total_latency_ms", 0))
+    
+    cur_model["tokens"]["input"] += tokens.get("input", 0)
+    cur_model["tokens"]["output"] += tokens.get("candidates", tokens.get("output", 0))
+    cur_model["tokens"]["total"] += tokens.get("total", 0)
+    cur_model["tokens"]["cached"] += tokens.get("cached", 0)
+    cur_model["tokens"]["thoughts"] += tokens.get("thoughts", 0)
+    
+    if "models" not in existing:
+        existing["models"] = {}
+    existing["models"][model_name] = cur_model
+
+try:
+    with open(usage_path, "w") as f:
+        json.dump(existing, f, indent=2)
+    with open(token_path, "w") as f:
+        json.dump(existing, f, indent=2)
+except Exception:
+    pass
+' "$output_file" "$task_dir"
+    fi
+}
+
 # Fork the repository if it doesn't already exist under the bot user account
 GH_USER="${GITHUB_USER_ID}"
 if [ -n "${GITHUB_BOT_LOGIN}" ]; then
@@ -125,6 +221,7 @@ elif [ "$STRATEGY" = "reimplement" ]; then
         echo "Trying model: $MODEL"
         if gemini --yolo --model "$MODEL" --output-format json < "${PROMPT_FILE}" > "$(dirname "${PROMPT_FILE}")/gemini-output.json"; then
             echo "Gemini execution successful with model: $MODEL"
+            record_gemini_usage "$(dirname "${PROMPT_FILE}")/gemini-output.json"
             SUCCESS=true
             break
         else

--- a/factory/pkg/tasks/fix_issue.sh
+++ b/factory/pkg/tasks/fix_issue.sh
@@ -181,7 +181,8 @@ function configureGemini {
 {
   "general": {
     "enableAutoUpdate": false,
-    "retryFetchErrors": true
+    "retryFetchErrors": true,
+    "previewFeatures": true
   }
 }
 EOF
@@ -193,6 +194,84 @@ function installExtensions {
         for ext in $EXTENSIONS; do
             gemini extensions install "$ext" --consent
         done
+    fi
+}
+
+function record_gemini_usage {
+    local output_file="$1"
+    local task_dir="$(dirname "${PROMPT_FILE}")"
+    if [ -f "$output_file" ]; then
+        python3 -c '
+import json, os, sys
+
+output_file = sys.argv[1]
+task_dir = sys.argv[2]
+
+try:
+    with open(output_file, "r") as f:
+        data = json.load(f)
+except Exception:
+    sys.exit(0)
+
+stats = data.get("stats", {})
+models = stats.get("models", {})
+if not models and ("total_tokens" in stats or "total" in stats or "totalRequests" in stats):
+    models = {data.get("model", "gemini-cli"): {
+        "api": {"totalRequests": stats.get("totalRequests", stats.get("tool_calls", 0) + 1), "totalErrors": stats.get("totalErrors", 0), "totalLatencyMs": stats.get("totalLatencyMs", stats.get("duration_ms", 0))},
+        "tokens": {"input": stats.get("input", stats.get("input_tokens", 0)), "output": stats.get("candidates", stats.get("output", stats.get("output_tokens", 0))), "total": stats.get("total", stats.get("total_tokens", 0)), "cached": stats.get("cached", 0), "thoughts": stats.get("thoughts", 0)}
+    }}
+
+if not models:
+    sys.exit(0)
+
+usage_path = os.path.join(task_dir, "llm-usage.json")
+token_path = os.path.join(task_dir, "token-usage.json")
+
+existing = {"models": {}}
+if os.path.exists(usage_path):
+    try:
+        with open(usage_path, "r") as f:
+            existing = json.load(f)
+    except Exception:
+        pass
+elif os.path.exists(token_path):
+    try:
+        with open(token_path, "r") as f:
+            existing = json.load(f)
+    except Exception:
+        pass
+
+for model_name, model_data in models.items():
+    api = model_data.get("api", {})
+    tokens = model_data.get("tokens", {})
+    
+    cur_model = existing.get("models", {}).get(model_name, {
+        "api": {"totalRequests": 0, "totalErrors": 0, "totalLatencyMs": 0},
+        "tokens": {"input": 0, "output": 0, "total": 0, "cached": 0, "thoughts": 0}
+    })
+    
+    cur_model["api"]["totalRequests"] += api.get("totalRequests", api.get("total_requests", 1))
+    cur_model["api"]["totalErrors"] += api.get("totalErrors", api.get("total_errors", 0))
+    cur_model["api"]["totalLatencyMs"] += api.get("totalLatencyMs", api.get("total_latency_ms", 0))
+    
+    cur_model["tokens"]["input"] += tokens.get("input", 0)
+    cur_model["tokens"]["output"] += tokens.get("candidates", tokens.get("output", 0))
+    cur_model["tokens"]["total"] += tokens.get("total", 0)
+    cur_model["tokens"]["cached"] += tokens.get("cached", 0)
+    cur_model["tokens"]["thoughts"] += tokens.get("thoughts", 0)
+    
+    if "models" not in existing:
+        existing["models"] = {}
+    existing["models"][model_name] = cur_model
+
+try:
+    with open(usage_path, "w") as f:
+        json.dump(existing, f, indent=2)
+    with open(token_path, "w") as f:
+        json.dump(existing, f, indent=2)
+except Exception:
+    pass
+' "$output_file" "$task_dir"
     fi
 }
 
@@ -216,6 +295,7 @@ function runGemini {
         echo "Trying model: $MODEL"
         if gemini --yolo --model "$MODEL" --output-format json < ${PROMPT_FILE} > "$(dirname "${PROMPT_FILE}")/gemini-output.json"; then
             echo "Gemini execution successful with model: $MODEL"
+            record_gemini_usage "$(dirname "${PROMPT_FILE}")/gemini-output.json"
             SUCCESS=true
             break
         else

--- a/factory/pkg/tasks/investigate_failures.sh
+++ b/factory/pkg/tasks/investigate_failures.sh
@@ -147,7 +147,8 @@ function configureGemini {
 {
   "general": {
     "enableAutoUpdate": false,
-    "retryFetchErrors": true
+    "retryFetchErrors": true,
+    "previewFeatures": true
   }
 }
 EOF
@@ -159,6 +160,84 @@ function installExtensions {
         for ext in $EXTENSIONS; do
             gemini extensions install "$ext" --consent
         done
+    fi
+}
+
+function record_gemini_usage {
+    local output_file="$1"
+    local task_dir="$(dirname "${PROMPT_FILE}")"
+    if [ -f "$output_file" ]; then
+        python3 -c '
+import json, os, sys
+
+output_file = sys.argv[1]
+task_dir = sys.argv[2]
+
+try:
+    with open(output_file, "r") as f:
+        data = json.load(f)
+except Exception:
+    sys.exit(0)
+
+stats = data.get("stats", {})
+models = stats.get("models", {})
+if not models and ("total_tokens" in stats or "total" in stats or "totalRequests" in stats):
+    models = {data.get("model", "gemini-cli"): {
+        "api": {"totalRequests": stats.get("totalRequests", stats.get("tool_calls", 0) + 1), "totalErrors": stats.get("totalErrors", 0), "totalLatencyMs": stats.get("totalLatencyMs", stats.get("duration_ms", 0))},
+        "tokens": {"input": stats.get("input", stats.get("input_tokens", 0)), "output": stats.get("candidates", stats.get("output", stats.get("output_tokens", 0))), "total": stats.get("total", stats.get("total_tokens", 0)), "cached": stats.get("cached", 0), "thoughts": stats.get("thoughts", 0)}
+    }}
+
+if not models:
+    sys.exit(0)
+
+usage_path = os.path.join(task_dir, "llm-usage.json")
+token_path = os.path.join(task_dir, "token-usage.json")
+
+existing = {"models": {}}
+if os.path.exists(usage_path):
+    try:
+        with open(usage_path, "r") as f:
+            existing = json.load(f)
+    except Exception:
+        pass
+elif os.path.exists(token_path):
+    try:
+        with open(token_path, "r") as f:
+            existing = json.load(f)
+    except Exception:
+        pass
+
+for model_name, model_data in models.items():
+    api = model_data.get("api", {})
+    tokens = model_data.get("tokens", {})
+    
+    cur_model = existing.get("models", {}).get(model_name, {
+        "api": {"totalRequests": 0, "totalErrors": 0, "totalLatencyMs": 0},
+        "tokens": {"input": 0, "output": 0, "total": 0, "cached": 0, "thoughts": 0}
+    })
+    
+    cur_model["api"]["totalRequests"] += api.get("totalRequests", api.get("total_requests", 1))
+    cur_model["api"]["totalErrors"] += api.get("totalErrors", api.get("total_errors", 0))
+    cur_model["api"]["totalLatencyMs"] += api.get("totalLatencyMs", api.get("total_latency_ms", 0))
+    
+    cur_model["tokens"]["input"] += tokens.get("input", 0)
+    cur_model["tokens"]["output"] += tokens.get("candidates", tokens.get("output", 0))
+    cur_model["tokens"]["total"] += tokens.get("total", 0)
+    cur_model["tokens"]["cached"] += tokens.get("cached", 0)
+    cur_model["tokens"]["thoughts"] += tokens.get("thoughts", 0)
+    
+    if "models" not in existing:
+        existing["models"] = {}
+    existing["models"][model_name] = cur_model
+
+try:
+    with open(usage_path, "w") as f:
+        json.dump(existing, f, indent=2)
+    with open(token_path, "w") as f:
+        json.dump(existing, f, indent=2)
+except Exception:
+    pass
+' "$output_file" "$task_dir"
     fi
 }
 
@@ -184,6 +263,7 @@ function runGemini {
         fi
         if (cd "/workspaces/${REPO_NAME}" && export GEMINI_API_KEY="${GEMINI_API_KEY}" && gemini "${GEMINI_ARGS[@]}" < ${PROMPT_FILE} > "$(dirname "${PROMPT_FILE}")/gemini-output.json"); then
              echo "Gemini execution successful with model: $MODEL"
+             record_gemini_usage "$(dirname "${PROMPT_FILE}")/gemini-output.json"
              SUCCESS=true
              break
         else

--- a/factory/pkg/tasks/iterate.sh
+++ b/factory/pkg/tasks/iterate.sh
@@ -149,7 +149,8 @@ function configureGemini {
 {
   "general": {
     "enableAutoUpdate": false,
-    "retryFetchErrors": true
+    "retryFetchErrors": true,
+    "previewFeatures": true
   }
 }
 EOF
@@ -161,6 +162,84 @@ function installExtensions {
         for ext in $EXTENSIONS; do
             gemini extensions install "$ext" --consent
         done
+    fi
+}
+
+function record_gemini_usage {
+    local output_file="$1"
+    local task_dir="$(dirname "${PROMPT_FILE}")"
+    if [ -f "$output_file" ]; then
+        python3 -c '
+import json, os, sys
+
+output_file = sys.argv[1]
+task_dir = sys.argv[2]
+
+try:
+    with open(output_file, "r") as f:
+        data = json.load(f)
+except Exception:
+    sys.exit(0)
+
+stats = data.get("stats", {})
+models = stats.get("models", {})
+if not models and ("total_tokens" in stats or "total" in stats or "totalRequests" in stats):
+    models = {data.get("model", "gemini-cli"): {
+        "api": {"totalRequests": stats.get("totalRequests", stats.get("tool_calls", 0) + 1), "totalErrors": stats.get("totalErrors", 0), "totalLatencyMs": stats.get("totalLatencyMs", stats.get("duration_ms", 0))},
+        "tokens": {"input": stats.get("input", stats.get("input_tokens", 0)), "output": stats.get("candidates", stats.get("output", stats.get("output_tokens", 0))), "total": stats.get("total", stats.get("total_tokens", 0)), "cached": stats.get("cached", 0), "thoughts": stats.get("thoughts", 0)}
+    }}
+
+if not models:
+    sys.exit(0)
+
+usage_path = os.path.join(task_dir, "llm-usage.json")
+token_path = os.path.join(task_dir, "token-usage.json")
+
+existing = {"models": {}}
+if os.path.exists(usage_path):
+    try:
+        with open(usage_path, "r") as f:
+            existing = json.load(f)
+    except Exception:
+        pass
+elif os.path.exists(token_path):
+    try:
+        with open(token_path, "r") as f:
+            existing = json.load(f)
+    except Exception:
+        pass
+
+for model_name, model_data in models.items():
+    api = model_data.get("api", {})
+    tokens = model_data.get("tokens", {})
+    
+    cur_model = existing.get("models", {}).get(model_name, {
+        "api": {"totalRequests": 0, "totalErrors": 0, "totalLatencyMs": 0},
+        "tokens": {"input": 0, "output": 0, "total": 0, "cached": 0, "thoughts": 0}
+    })
+    
+    cur_model["api"]["totalRequests"] += api.get("totalRequests", api.get("total_requests", 1))
+    cur_model["api"]["totalErrors"] += api.get("totalErrors", api.get("total_errors", 0))
+    cur_model["api"]["totalLatencyMs"] += api.get("totalLatencyMs", api.get("total_latency_ms", 0))
+    
+    cur_model["tokens"]["input"] += tokens.get("input", 0)
+    cur_model["tokens"]["output"] += tokens.get("candidates", tokens.get("output", 0))
+    cur_model["tokens"]["total"] += tokens.get("total", 0)
+    cur_model["tokens"]["cached"] += tokens.get("cached", 0)
+    cur_model["tokens"]["thoughts"] += tokens.get("thoughts", 0)
+    
+    if "models" not in existing:
+        existing["models"] = {}
+    existing["models"][model_name] = cur_model
+
+try:
+    with open(usage_path, "w") as f:
+        json.dump(existing, f, indent=2)
+    with open(token_path, "w") as f:
+        json.dump(existing, f, indent=2)
+except Exception:
+    pass
+' "$output_file" "$task_dir"
     fi
 }
 
@@ -188,6 +267,7 @@ function runGemini {
             fi
             if (cd "/workspaces/${REPO_NAME}" && export GEMINI_API_KEY="${GEMINI_API_KEY}" && gemini "${GEMINI_ARGS[@]}" < ${PROMPT_FILE} > "$(dirname "${PROMPT_FILE}")/gemini-output.json"); then
                 echo "Gemini execution successful with model: $MODEL"
+                record_gemini_usage "$(dirname "${PROMPT_FILE}")/gemini-output.json"
                 SUCCESS=true
                 break
             else

--- a/factory/pkg/tasks/review.sh
+++ b/factory/pkg/tasks/review.sh
@@ -119,10 +119,89 @@ function configureGemini {
 {
   "general": {
     "enableAutoUpdate": false,
-    "retryFetchErrors": true
+    "retryFetchErrors": true,
+    "previewFeatures": true
   }
 }
 EOF
+}
+
+function record_gemini_usage {
+    local output_file="$1"
+    local task_dir="$(dirname "${PROMPT_FILE}")"
+    if [ -f "$output_file" ]; then
+        python3 -c '
+import json, os, sys
+
+output_file = sys.argv[1]
+task_dir = sys.argv[2]
+
+try:
+    with open(output_file, "r") as f:
+        data = json.load(f)
+except Exception:
+    sys.exit(0)
+
+stats = data.get("stats", {})
+models = stats.get("models", {})
+if not models and ("total_tokens" in stats or "total" in stats or "totalRequests" in stats):
+    models = {data.get("model", "gemini-cli"): {
+        "api": {"totalRequests": stats.get("totalRequests", stats.get("tool_calls", 0) + 1), "totalErrors": stats.get("totalErrors", 0), "totalLatencyMs": stats.get("totalLatencyMs", stats.get("duration_ms", 0))},
+        "tokens": {"input": stats.get("input", stats.get("input_tokens", 0)), "output": stats.get("candidates", stats.get("output", stats.get("output_tokens", 0))), "total": stats.get("total", stats.get("total_tokens", 0)), "cached": stats.get("cached", 0), "thoughts": stats.get("thoughts", 0)}
+    }}
+
+if not models:
+    sys.exit(0)
+
+usage_path = os.path.join(task_dir, "llm-usage.json")
+token_path = os.path.join(task_dir, "token-usage.json")
+
+existing = {"models": {}}
+if os.path.exists(usage_path):
+    try:
+        with open(usage_path, "r") as f:
+            existing = json.load(f)
+    except Exception:
+        pass
+elif os.path.exists(token_path):
+    try:
+        with open(token_path, "r") as f:
+            existing = json.load(f)
+    except Exception:
+        pass
+
+for model_name, model_data in models.items():
+    api = model_data.get("api", {})
+    tokens = model_data.get("tokens", {})
+    
+    cur_model = existing.get("models", {}).get(model_name, {
+        "api": {"totalRequests": 0, "totalErrors": 0, "totalLatencyMs": 0},
+        "tokens": {"input": 0, "output": 0, "total": 0, "cached": 0, "thoughts": 0}
+    })
+    
+    cur_model["api"]["totalRequests"] += api.get("totalRequests", api.get("total_requests", 1))
+    cur_model["api"]["totalErrors"] += api.get("totalErrors", api.get("total_errors", 0))
+    cur_model["api"]["totalLatencyMs"] += api.get("totalLatencyMs", api.get("total_latency_ms", 0))
+    
+    cur_model["tokens"]["input"] += tokens.get("input", 0)
+    cur_model["tokens"]["output"] += tokens.get("candidates", tokens.get("output", 0))
+    cur_model["tokens"]["total"] += tokens.get("total", 0)
+    cur_model["tokens"]["cached"] += tokens.get("cached", 0)
+    cur_model["tokens"]["thoughts"] += tokens.get("thoughts", 0)
+    
+    if "models" not in existing:
+        existing["models"] = {}
+    existing["models"][model_name] = cur_model
+
+try:
+    with open(usage_path, "w") as f:
+        json.dump(existing, f, indent=2)
+    with open(token_path, "w") as f:
+        json.dump(existing, f, indent=2)
+except Exception:
+    pass
+' "$output_file" "$task_dir"
+    fi
 }
 
 function runGemini {
@@ -141,9 +220,24 @@ function runGemini {
     SUCCESS=false
     for MODEL in $MODELS_LIST; do
         echo "Trying model: $MODEL"
-        GEMINI_ARGS=("--yolo" "--model" "$MODEL")
-        if (cd "/workspaces/${REPO_NAME}" && export GEMINI_API_KEY="${GEMINI_API_KEY}" && gemini "${GEMINI_ARGS[@]}" < ${PROMPT_FILE} > "$(dirname "${PROMPT_FILE}")/review-output.txt"); then
+        GEMINI_ARGS=("--yolo" "--model" "$MODEL" "--output-format" "json")
+        if (cd "/workspaces/${REPO_NAME}" && export GEMINI_API_KEY="${GEMINI_API_KEY}" && gemini "${GEMINI_ARGS[@]}" < ${PROMPT_FILE} > "$(dirname "${PROMPT_FILE}")/gemini-output.json"); then
              echo "Gemini execution successful with model: $MODEL"
+             record_gemini_usage "$(dirname "${PROMPT_FILE}")/gemini-output.json"
+             python3 -c '
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        data = json.load(f)
+        resp = data.get("response", "")
+        if resp:
+            print(resp)
+        else:
+            print(data)
+except Exception:
+    with open(sys.argv[1]) as f:
+        print(f.read())
+' "$(dirname "${PROMPT_FILE}")/gemini-output.json" > "$(dirname "${PROMPT_FILE}")/review-output.txt"
              SUCCESS=true
              break
         else

--- a/factory/pkg/tasks/run_agent.sh
+++ b/factory/pkg/tasks/run_agent.sh
@@ -124,7 +124,8 @@ function configureGemini {
 {
   "general": {
     "enableAutoUpdate": false,
-    "retryFetchErrors": true
+    "retryFetchErrors": true,
+    "previewFeatures": true
   }
 }
 EOF
@@ -165,14 +166,18 @@ function commitChanges {
                 echo "Committing uncommitted changes..."
                 git diff > /tmp/agent_diff.txt
                 
-                COMMIT_MSG=$(gemini "Generate a concise, meaningful commit message for the following changes.
+                gemini --yolo --output-format json -p "Generate a concise, meaningful commit message for the following changes.
     The changes are part of an agent named '${AGENT_NAME}' (defined in ${AGENT_FILE}).
     
     DIFF:
     $(cat /tmp/agent_diff.txt | head -c 2000)
     
     The commit message should be prefixed with 'chore: ' and should explicitly mention it was automatically generated.
-    Only output the commit message itself.")
+    Only output the commit message itself." > /tmp/gemini-commit-msg.json || true
+                if [ -f /tmp/gemini-commit-msg.json ]; then
+                    record_gemini_usage /tmp/gemini-commit-msg.json
+                    COMMIT_MSG=$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1])).get("response", "").strip())' /tmp/gemini-commit-msg.json 2>/dev/null)
+                fi
                 
                 if [ -z "$COMMIT_MSG" ]; then
                     COMMIT_MSG="chore: automatic updates from agent ${AGENT_NAME}"
@@ -227,6 +232,84 @@ function commitChanges {
             echo "No changes detected."
             echo "No changes detected." > "$(dirname "${PROMPT_FILE}")/agent-output.txt"
         fi
+    fi
+}
+
+function record_gemini_usage {
+    local output_file="$1"
+    local task_dir="$(dirname "${PROMPT_FILE}")"
+    if [ -f "$output_file" ]; then
+        python3 -c '
+import json, os, sys
+
+output_file = sys.argv[1]
+task_dir = sys.argv[2]
+
+try:
+    with open(output_file, "r") as f:
+        data = json.load(f)
+except Exception:
+    sys.exit(0)
+
+stats = data.get("stats", {})
+models = stats.get("models", {})
+if not models and ("total_tokens" in stats or "total" in stats or "totalRequests" in stats):
+    models = {data.get("model", "gemini-cli"): {
+        "api": {"totalRequests": stats.get("totalRequests", stats.get("tool_calls", 0) + 1), "totalErrors": stats.get("totalErrors", 0), "totalLatencyMs": stats.get("totalLatencyMs", stats.get("duration_ms", 0))},
+        "tokens": {"input": stats.get("input", stats.get("input_tokens", 0)), "output": stats.get("candidates", stats.get("output", stats.get("output_tokens", 0))), "total": stats.get("total", stats.get("total_tokens", 0)), "cached": stats.get("cached", 0), "thoughts": stats.get("thoughts", 0)}
+    }}
+
+if not models:
+    sys.exit(0)
+
+usage_path = os.path.join(task_dir, "llm-usage.json")
+token_path = os.path.join(task_dir, "token-usage.json")
+
+existing = {"models": {}}
+if os.path.exists(usage_path):
+    try:
+        with open(usage_path, "r") as f:
+            existing = json.load(f)
+    except Exception:
+        pass
+elif os.path.exists(token_path):
+    try:
+        with open(token_path, "r") as f:
+            existing = json.load(f)
+    except Exception:
+        pass
+
+for model_name, model_data in models.items():
+    api = model_data.get("api", {})
+    tokens = model_data.get("tokens", {})
+    
+    cur_model = existing.get("models", {}).get(model_name, {
+        "api": {"totalRequests": 0, "totalErrors": 0, "totalLatencyMs": 0},
+        "tokens": {"input": 0, "output": 0, "total": 0, "cached": 0, "thoughts": 0}
+    })
+    
+    cur_model["api"]["totalRequests"] += api.get("totalRequests", api.get("total_requests", 1))
+    cur_model["api"]["totalErrors"] += api.get("totalErrors", api.get("total_errors", 0))
+    cur_model["api"]["totalLatencyMs"] += api.get("totalLatencyMs", api.get("total_latency_ms", 0))
+    
+    cur_model["tokens"]["input"] += tokens.get("input", 0)
+    cur_model["tokens"]["output"] += tokens.get("candidates", tokens.get("output", 0))
+    cur_model["tokens"]["total"] += tokens.get("total", 0)
+    cur_model["tokens"]["cached"] += tokens.get("cached", 0)
+    cur_model["tokens"]["thoughts"] += tokens.get("thoughts", 0)
+    
+    if "models" not in existing:
+        existing["models"] = {}
+    existing["models"][model_name] = cur_model
+
+try:
+    with open(usage_path, "w") as f:
+        json.dump(existing, f, indent=2)
+    with open(token_path, "w") as f:
+        json.dump(existing, f, indent=2)
+except Exception:
+    pass
+' "$output_file" "$task_dir"
     fi
 }
 
@@ -353,6 +436,7 @@ function runAgent {
         fi
         if gemini --yolo --model "$MODEL" ${RESUME_FLAG} --include-directories "$(dirname "${PROMPT_FILE}")" --output-format json < "${PROMPT_FILE}" > "$(dirname "${PROMPT_FILE}")/gemini-output.json"; then
             echo "Gemini execution successful with model: $MODEL"
+            record_gemini_usage "$(dirname "${PROMPT_FILE}")/gemini-output.json"
             SUCCESS=true
             break
         else

--- a/repo-agent/pkg/tasks/address_feedback.sh
+++ b/repo-agent/pkg/tasks/address_feedback.sh
@@ -128,7 +128,8 @@ function configureGemini {
 {
   "general": {
     "enableAutoUpdate": false,
-    "retryFetchErrors": true
+    "retryFetchErrors": true,
+    "previewFeatures": true
   }
 }
 EOF

--- a/repo-agent/pkg/tasks/dev_setup.sh
+++ b/repo-agent/pkg/tasks/dev_setup.sh
@@ -157,7 +157,8 @@ function configureGemini {
 {
   "general": {
     "enableAutoUpdate": false,
-    "retryFetchErrors": true
+    "retryFetchErrors": true,
+    "previewFeatures": true
   }
 }
 EOF

--- a/repo-agent/pkg/tasks/fix_issue.sh
+++ b/repo-agent/pkg/tasks/fix_issue.sh
@@ -179,7 +179,8 @@ function configureGemini {
 {
   "general": {
     "enableAutoUpdate": false,
-    "retryFetchErrors": true
+    "retryFetchErrors": true,
+    "previewFeatures": true
   }
 }
 EOF

--- a/repo-agent/pkg/tasks/investigate_failures.sh
+++ b/repo-agent/pkg/tasks/investigate_failures.sh
@@ -137,7 +137,8 @@ function configureGemini {
 {
   "general": {
     "enableAutoUpdate": false,
-    "retryFetchErrors": true
+    "retryFetchErrors": true,
+    "previewFeatures": true
   }
 }
 EOF

--- a/repo-agent/pkg/tasks/iterate.sh
+++ b/repo-agent/pkg/tasks/iterate.sh
@@ -148,7 +148,8 @@ function configureGemini {
 {
   "general": {
     "enableAutoUpdate": false,
-    "retryFetchErrors": true
+    "retryFetchErrors": true,
+    "previewFeatures": true
   }
 }
 EOF

--- a/repo-agent/pkg/tasks/tasks.go
+++ b/repo-agent/pkg/tasks/tasks.go
@@ -171,8 +171,18 @@ func processGeminiOutput(ctx context.Context, sb *sandbox.IssueSandbox, taskDir 
 	}
 	usagePath := taskPath(taskDir, "llm-usage.json")
 	if err := os.WriteFile(usagePath, statsJSON, 0644); err != nil {
-		log.Error(err, "Failed to write llm-usage.json", "path", usagePath)
+		log.Error(err, "Failed to write llm-usage.json on host", "path", usagePath)
 	} else {
-		log.Info("Wrote LLM usage stats", "path", usagePath)
+		log.Info("Wrote LLM usage stats on host", "path", usagePath)
+	}
+	tokenUsagePath := taskPath(taskDir, "token-usage.json")
+	if err := os.WriteFile(tokenUsagePath, statsJSON, 0644); err != nil {
+		log.Error(err, "Failed to write token-usage.json on host", "path", tokenUsagePath)
+	} else {
+		log.Info("Wrote token usage stats on host", "path", tokenUsagePath)
+	}
+	if sb != nil {
+		_ = sb.WriteFile(usagePath, statsJSON)
+		_ = sb.WriteFile(tokenUsagePath, statsJSON)
 	}
 }

--- a/repo-agent/pkg/tasks/triage_issue.sh
+++ b/repo-agent/pkg/tasks/triage_issue.sh
@@ -29,7 +29,8 @@ function configureGemini {
 {
   "general": {
     "enableAutoUpdate": false,
-    "retryFetchErrors": true
+    "retryFetchErrors": true,
+    "previewFeatures": true
   }
 }
 EOF


### PR DESCRIPTION
* **Enabled `previewFeatures`**: Added `"previewFeatures": true` inside `.gemini/settings.json` across all 13 task scripts (`factory/pkg/tasks/*.sh` and `repo-agent/pkg/tasks/*.sh`) so `gemini-cli` outputs structured usage statistics.
* **Embedded Usage Recorder**: Added a `record_gemini_usage` helper function to all `factory/pkg/tasks/*.sh` scripts (`fix_issue`, `review`, `run_agent`, `adopt`, `investigate_failures`, `iterate`, `address_feedback`). It automatically extracts token and API request counts from `gemini --output-format json` and saves/accumulates them in `/workspaces/tasks/<taskID>/llm-usage.json` and `token-usage.json`.
* **Multi-Run Accumulation**: Automatically merges and sums token spend (`input`, `output`, `cached`, `thoughts`, `total`) across multiple `gemini` calls within the same workflow task (e.g. prompt runs + commit message generation).
* **Standardized JSON Output**: Updated `review.sh` and `run_agent.sh` to use `--output-format json` to capture token spend while extracting raw text for existing downstream parsers.
* **Synchronized `repo-agent` Output**: Updated `processGeminiOutput` in `repo-agent/pkg/tasks/tasks.go` to output both `llm-usage.json` and `token-usage.json` across both host and sandbox filesystems.