### PR TITLE
feat: categorize token-usage rollups by sandbox type with per-task drill-down

### DIFF
--- a/factory/design/token-usage-collection.md
+++ b/factory/design/token-usage-collection.md
@@ -63,9 +63,13 @@ The `key` is the idempotency key: re-posting upserts (append to the log; last li
 
 ## 5. Rollups
 
-* **Per PR**: group by `pr`.
-* **Per issue**: a record counts toward issue N if `issue == N` or N is in `issues` (PR tasks roll back up to their parent issue).
-* **Per workflow**: group by `workflow` session; a session `issue-N` also absorbs untagged records that reference issue N, so PR tasks spawned by a workflow count toward it.
+The three rollups are **mutually exclusive** — every record is counted in exactly one, matching the sandbox categories shown in the dashboard:
+
+* **Per workflow** ("Workflow Issues"): group by `workflow` session; a session `issue-N` also absorbs untagged records that reference issue N, so PR tasks spawned by a workflow count toward it.
+* **Per issue** ("Issue / PR sandboxes"): remaining records count toward issue N if `issue == N` or N is in `issues` — the issue sandbox plus any PR work it led to. Rows with linked PRs are labeled `#N / PR #M`. Issues owned by a workflow session are excluded.
+* **Per PR** ("PR sandboxes"): what is left — standalone PR work (reviews, investigations, adoptions) with no issue or workflow linkage.
+
+All rollup list responses include the per-task `records` (with `taskType` and `sandbox`) for drill-down in the dashboard.
 
 Endpoints: `GET /v1/usage/rollups/{issues,prs,workflows}[?repo=]` and `GET /v1/usage/rollups/workflows/{session}` (detail with per-task records).
 

--- a/factory/pkg/tokenusage/store.go
+++ b/factory/pkg/tokenusage/store.go
@@ -190,11 +190,25 @@ func (s *Store) List(f ListFilter) []UsageRecord {
 	return out
 }
 
-// RollupByIssue groups records by issue number: a record counts toward issue
-// N if rec.Issue == N or N appears in rec.Issues (PR tasks linked back to
-// the issue).
+// The three rollup views are mutually exclusive so each record is counted in
+// exactly one of them:
+//   - workflow rollups take every record tagged with a workflow session or
+//     referencing a workflow issue;
+//   - issue rollups take the remaining records linked to an issue (the issue
+//     sandbox and any PR work it led to — an "issue/PR sandbox");
+//   - PR rollups take what is left: standalone PR work (reviews,
+//     investigations, adoptions) not tied to any issue.
+
+// RollupByIssue groups non-workflow records by issue number: a record counts
+// toward issue N if rec.Issue == N or N appears in rec.Issues (PR tasks
+// linked back to the issue). Issues owned by a workflow session are excluded
+// (they appear in the workflow rollups instead).
 func (s *Store) RollupByIssue(repo string) []Rollup {
+	wfIssues := s.workflowIssueSet(repo)
 	return s.rollup(repo, func(rec UsageRecord) []string {
+		if recordInWorkflow(rec, wfIssues) {
+			return nil
+		}
 		seen := map[int]bool{}
 		var keys []string
 		if rec.Issue != 0 {
@@ -211,14 +225,61 @@ func (s *Store) RollupByIssue(repo string) []Rollup {
 	})
 }
 
-// RollupByPR groups records by PR number.
+// RollupByPR groups standalone PR records by PR number. Records linked to a
+// workflow or to an issue are excluded (they appear in the workflow/issue
+// rollups instead).
 func (s *Store) RollupByPR(repo string) []Rollup {
+	wfIssues := s.workflowIssueSet(repo)
 	return s.rollup(repo, func(rec UsageRecord) []string {
-		if rec.PR == 0 {
+		if rec.PR == 0 || recordInWorkflow(rec, wfIssues) || recordTouchesAnyIssue(rec) {
 			return nil
 		}
 		return []string{strconv.Itoa(rec.PR)}
 	})
+}
+
+// workflowIssueSet returns the issue numbers owned by a workflow session
+// (i.e. any record tagged workflow "issue-N").
+func (s *Store) workflowIssueSet(repo string) map[int]bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	set := map[int]bool{}
+	for _, rec := range s.records {
+		if repo != "" && rec.Repo != repo {
+			continue
+		}
+		if n := workflowSessionIssue(rec.Workflow); n != 0 {
+			set[n] = true
+		}
+	}
+	return set
+}
+
+func recordInWorkflow(rec UsageRecord, wfIssues map[int]bool) bool {
+	if rec.Workflow != "" {
+		return true
+	}
+	if wfIssues[rec.Issue] {
+		return true
+	}
+	for _, n := range rec.Issues {
+		if wfIssues[n] {
+			return true
+		}
+	}
+	return false
+}
+
+func recordTouchesAnyIssue(rec UsageRecord) bool {
+	if rec.Issue != 0 {
+		return true
+	}
+	for _, n := range rec.Issues {
+		if n != 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // RollupByWorkflow groups records by workflow session. A session "issue-N"
@@ -237,7 +298,7 @@ func (s *Store) RollupByWorkflow(repo string) []Rollup {
 
 	var out []Rollup
 	for session := range sessions {
-		r := s.WorkflowRollup(repo, session, false)
+		r := s.WorkflowRollup(repo, session, true)
 		if r != nil {
 			out = append(out, *r)
 		}
@@ -307,6 +368,7 @@ func (s *Store) rollup(repo string, keysFor func(UsageRecord) []string) []Rollup
 				groups[key] = g
 			}
 			accumulate(g, rec)
+			g.Records = append(g.Records, rec)
 		}
 	}
 	out := make([]Rollup, 0, len(groups))

--- a/factory/pkg/tokenusage/store_test.go
+++ b/factory/pkg/tokenusage/store_test.go
@@ -109,35 +109,49 @@ func TestRollups(t *testing.T) {
 		Workflow: "issue-42", WorkflowName: "greenfield",
 		Stats: statsFor("gemini-2.5-pro", 100, 50, 150),
 	})
-	// PR task referencing issue 42 but without a workflow tag: must be
-	// absorbed into workflow issue-42.
+	// PR task referencing workflow issue 42 but without a workflow tag: must
+	// be absorbed into workflow issue-42 (and appear nowhere else).
 	mustPut(t, s, UsageRecord{
 		Key: "fix-repo-42:t2", Repo: "org/repo", PR: 101, Issues: []int{42},
 		Stats: statsFor("gemini-2.5-pro", 10, 5, 15),
 	})
-	// Unrelated PR.
+	// Standalone PR (no issue, no workflow).
 	mustPut(t, s, UsageRecord{
 		Key: "pr-7:t3", Repo: "org/repo", PR: 7,
 		Stats: statsFor("gemini-2.5-flash", 1, 1, 2),
 	})
+	// Non-workflow issue sandbox that produced a PR ("issue/PR sandbox").
+	mustPut(t, s, UsageRecord{
+		Key: "fix-repo-55:t4", Repo: "org/repo", Issue: 55, PR: 200,
+		Stats: statsFor("gemini-2.5-pro", 20, 10, 30),
+	})
+	// Review of that PR, linked back to issue 55: counts toward the issue.
+	mustPut(t, s, UsageRecord{
+		Key: "factory-pr-200:t5", Repo: "org/repo", PR: 200, Issues: []int{55},
+		Stats: statsFor("gemini-2.5-pro", 5, 2, 7),
+	})
 
+	// The three rollups are mutually exclusive.
 	issues := s.RollupByIssue("org/repo")
-	if len(issues) != 1 || issues[0].Key != "42" {
-		t.Fatalf("issue rollup: expected single issue 42, got %+v", issues)
+	if len(issues) != 1 || issues[0].Key != "55" {
+		t.Fatalf("issue rollup: expected only non-workflow issue 55, got %+v", issues)
 	}
-	if issues[0].TaskCount != 2 {
-		t.Errorf("issue 42 rollup: expected 2 tasks, got %d", issues[0].TaskCount)
+	if issues[0].TaskCount != 2 || len(issues[0].Records) != 2 {
+		t.Errorf("issue 55 rollup: expected 2 tasks with records, got %+v", issues[0])
 	}
-	if got := issues[0].Stats.Models["gemini-2.5-pro"].Tokens.Total; got != 165 {
-		t.Errorf("issue 42 rollup: expected total 165, got %d", got)
+	if got := issues[0].Stats.Models["gemini-2.5-pro"].Tokens.Total; got != 37 {
+		t.Errorf("issue 55 rollup: expected total 37, got %d", got)
+	}
+	if len(issues[0].PRs) != 1 || issues[0].PRs[0] != 200 {
+		t.Errorf("issue 55 rollup PRs: expected [200], got %v", issues[0].PRs)
 	}
 
 	prs := s.RollupByPR("org/repo")
-	if len(prs) != 2 {
-		t.Fatalf("pr rollup: expected 2 PRs, got %+v", prs)
+	if len(prs) != 1 || prs[0].Key != "7" {
+		t.Fatalf("pr rollup: expected only standalone PR 7, got %+v", prs)
 	}
-	if prs[0].Key != "7" || prs[1].Key != "101" {
-		t.Errorf("pr rollup keys should sort numerically: got %s, %s", prs[0].Key, prs[1].Key)
+	if len(prs[0].Records) != 1 {
+		t.Errorf("pr 7 rollup: expected records included, got %+v", prs[0])
 	}
 
 	wfs := s.RollupByWorkflow("org/repo")
@@ -148,8 +162,8 @@ func TestRollups(t *testing.T) {
 	if wf.Key != "issue-42" || wf.WorkflowName != "greenfield" {
 		t.Errorf("workflow rollup identity: got %+v", wf)
 	}
-	if wf.TaskCount != 2 {
-		t.Errorf("workflow absorption: expected 2 tasks, got %d", wf.TaskCount)
+	if wf.TaskCount != 2 || len(wf.Records) != 2 {
+		t.Errorf("workflow absorption: expected 2 tasks with records, got taskCount=%d records=%d", wf.TaskCount, len(wf.Records))
 	}
 	if got := wf.Stats.Models["gemini-2.5-pro"].Tokens.Total; got != 165 {
 		t.Errorf("workflow rollup: expected total 165, got %d", got)

--- a/repo-agent/review-ui/ui/src/TokenUsage.js
+++ b/repo-agent/review-ui/ui/src/TokenUsage.js
@@ -46,61 +46,65 @@ const TokenHeaderCells = () => (
     </>
 );
 
-const RollupTable = ({ title, rollups, keyLabel, renderKey, expanded, onToggle, records }) => (
-    <div style={{ backgroundColor: 'var(--bg-card)', borderRadius: '8px', boxShadow: 'var(--shadow-card)', padding: '16px', marginBottom: '24px' }}>
-        <h3 style={{ margin: '0 0 12px 4px', color: 'var(--text-primary)' }}>{title}</h3>
-        {(!rollups || rollups.length === 0) ? (
-            <p style={{ color: 'var(--text-secondary)', margin: '4px' }}>No usage recorded yet.</p>
-        ) : (
-            <table style={{ width: '100%', borderCollapse: 'collapse', textAlign: 'left' }}>
-                <thead>
-                    <tr>
-                        <th style={thStyle}>{keyLabel}</th>
-                        <th style={{ ...thStyle, textAlign: 'right' }}>Tasks</th>
-                        <TokenHeaderCells />
-                    </tr>
-                </thead>
-                <tbody>
-                    {rollups.map(r => {
-                        const s = sumStats(r.stats);
-                        const isOpen = expanded === r.key;
-                        return (
-                            <React.Fragment key={r.key}>
-                                <tr className="table-row-hover" style={{ cursor: onToggle ? 'pointer' : 'default' }}
-                                    onClick={onToggle ? () => onToggle(isOpen ? null : r.key) : undefined}>
-                                    <td style={{ ...tdStyle, fontWeight: 'bold' }}>
-                                        {onToggle && <span style={{ marginRight: '6px' }}>{isOpen ? '▾' : '▸'}</span>}
-                                        {renderKey ? renderKey(r) : r.key}
-                                    </td>
-                                    <td style={numStyle}>{fmt(r.taskCount)}</td>
-                                    <TokenCells s={s} />
-                                </tr>
-                                {isOpen && (records || r.records || []).map(rec => (
-                                    <tr key={rec.key} style={{ backgroundColor: 'var(--bg-comment-card)' }}>
-                                        <td style={{ ...tdStyle, paddingLeft: '36px', fontSize: '13px' }}>
-                                            {rec.taskType || '-'} · {rec.sandbox || '-'}
-                                            {rec.pr ? ` · PR #${rec.pr}` : ''}{rec.issue ? ` · issue #${rec.issue}` : ''}
+const RollupTable = ({ title, subtitle, rollups, keyLabel, renderKey }) => {
+    const [expanded, setExpanded] = useState(null);
+    return (
+        <div style={{ backgroundColor: 'var(--bg-card)', borderRadius: '8px', boxShadow: 'var(--shadow-card)', padding: '16px', marginBottom: '24px' }}>
+            <h3 style={{ margin: '0 0 2px 4px', color: 'var(--text-primary)' }}>{title}</h3>
+            {subtitle && <p style={{ margin: '0 0 12px 4px', color: 'var(--text-secondary)', fontSize: '13px' }}>{subtitle}</p>}
+            {(!rollups || rollups.length === 0) ? (
+                <p style={{ color: 'var(--text-secondary)', margin: '4px' }}>No usage recorded yet.</p>
+            ) : (
+                <table style={{ width: '100%', borderCollapse: 'collapse', textAlign: 'left' }}>
+                    <thead>
+                        <tr>
+                            <th style={thStyle}>{keyLabel}</th>
+                            <th style={{ ...thStyle, textAlign: 'right' }}>Tasks</th>
+                            <TokenHeaderCells />
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {rollups.map(r => {
+                            const s = sumStats(r.stats);
+                            const isOpen = expanded === r.key;
+                            return (
+                                <React.Fragment key={r.key}>
+                                    <tr className="table-row-hover" style={{ cursor: 'pointer' }}
+                                        onClick={() => setExpanded(isOpen ? null : r.key)}>
+                                        <td style={{ ...tdStyle, fontWeight: 'bold' }}>
+                                            <span style={{ marginRight: '6px' }}>{isOpen ? '▾' : '▸'}</span>
+                                            {renderKey ? renderKey(r) : r.key}
                                         </td>
-                                        <td style={numStyle}>-</td>
-                                        <TokenCells s={sumStats(rec.stats)} />
+                                        <td style={numStyle}>{fmt(r.taskCount)}</td>
+                                        <TokenCells s={s} />
                                     </tr>
-                                ))}
-                            </React.Fragment>
-                        );
-                    })}
-                </tbody>
-            </table>
-        )}
-    </div>
-);
+                                    {isOpen && (r.records || []).map(rec => (
+                                        <tr key={rec.key} style={{ backgroundColor: 'var(--bg-comment-card)' }}>
+                                            <td style={{ ...tdStyle, paddingLeft: '36px', fontSize: '13px' }}>
+                                                {rec.taskType || '-'} · {rec.sandbox || '-'}
+                                                {rec.pr ? ` · PR #${rec.pr}` : ''}{rec.issue ? ` · issue #${rec.issue}` : ''}
+                                            </td>
+                                            <td style={numStyle}>-</td>
+                                            <TokenCells s={sumStats(rec.stats)} />
+                                        </tr>
+                                    ))}
+                                </React.Fragment>
+                            );
+                        })}
+                    </tbody>
+                </table>
+            )}
+        </div>
+    );
+};
+
+const prList = (prs) => (prs || []).map(n => `#${n}`).join(', ');
 
 const TokenUsage = ({ onBack }) => {
     const [workflows, setWorkflows] = useState([]);
     const [issues, setIssues] = useState([]);
     const [prs, setPRs] = useState([]);
     const [error, setError] = useState(null);
-    const [expandedWorkflow, setExpandedWorkflow] = useState(null);
-    const [workflowRecords, setWorkflowRecords] = useState([]);
 
     const fetchRollups = useCallback(() => {
         const get = (path, setter) =>
@@ -137,23 +141,6 @@ const TokenUsage = ({ onBack }) => {
         return () => clearInterval(interval);
     }, [fetchRollups]);
 
-    useEffect(() => {
-        if (!expandedWorkflow) {
-            setWorkflowRecords([]);
-            return;
-        }
-        fetch(`/api/usage/v1/usage/rollups/workflows/${encodeURIComponent(expandedWorkflow)}`)
-            .then(res => {
-                if (!res.ok) throw new Error(`HTTP error ${res.status}`);
-                return res.json();
-            })
-            .then(data => setWorkflowRecords(data.records || []))
-            .catch(err => {
-                console.error('Failed to fetch workflow detail:', err);
-                setWorkflowRecords([]);
-            });
-    }, [expandedWorkflow]);
-
     return (
         <div style={{ padding: '24px', maxWidth: '1400px', margin: '0 auto' }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px' }}>
@@ -168,16 +155,26 @@ const TokenUsage = ({ onBack }) => {
             )}
 
             <RollupTable
-                title="Per Workflow"
+                title="Workflow Issues"
+                subtitle="Workflow sandboxes (wf-issue-*), including all tasks and PRs spawned by the workflow."
                 rollups={workflows}
                 keyLabel="Workflow"
-                renderKey={r => `${r.workflowName ? `${r.workflowName} · ` : ''}${r.key}${r.prs?.length ? ` (PRs: ${r.prs.map(n => `#${n}`).join(', ')})` : ''}`}
-                expanded={expandedWorkflow}
-                onToggle={setExpandedWorkflow}
-                records={workflowRecords}
+                renderKey={r => `${r.workflowName ? `${r.workflowName} · ` : ''}${r.key}${r.prs?.length ? ` (PRs: ${prList(r.prs)})` : ''}`}
             />
-            <RollupTable title="Per Issue" rollups={issues} keyLabel="Issue" renderKey={r => `#${r.key}`} />
-            <RollupTable title="Per Pull Request" rollups={prs} keyLabel="Pull Request" renderKey={r => `#${r.key}`} />
+            <RollupTable
+                title="Issue / PR Sandboxes"
+                subtitle="Issue sandboxes and the PR work they led to; issues owned by a workflow are counted above instead."
+                rollups={issues}
+                keyLabel="Issue"
+                renderKey={r => `#${r.key}${r.prs?.length ? ` / PR ${prList(r.prs)}` : ''}`}
+            />
+            <RollupTable
+                title="PR Sandboxes"
+                subtitle="Standalone PR work (reviews, investigations, adoptions) not linked to any issue or workflow."
+                rollups={prs}
+                keyLabel="Pull Request"
+                renderKey={r => `#${r.key}`}
+            />
         </div>
     );
 };


### PR DESCRIPTION
Make the three collector rollups mutually exclusive so each record is counted exactly once: workflow rollups absorb everything linked to a workflow session, issue rollups take the remaining issue-linked records (the issue sandbox plus PR work it led to), and PR rollups keep only standalone PR work. This removes workflow issues from the issue list and duplicate counting across tables.

All rollup list responses now embed the per-task records (taskType, sandbox, stats), and the dashboard shows three expandable tables: "Workflow Issues", "Issue / PR Sandboxes" (rows labeled #N / PR #M when the issue sandbox led to a PR), and "PR Sandboxes".