### PR TITLE
feat(overseer): add configurable sandbox CPU and memory limits to Oveseer CRD

### DIFF
--- a/factory/pkg/commands/root.go
+++ b/factory/pkg/commands/root.go
@@ -34,6 +34,10 @@ type RootFlags struct {
 	Background       bool
 	Cleanup          bool
 	EphemeralStorage string
+	CPURequest       string
+	CPULimit         string
+	MemoryRequest    string
+	MemoryLimit      string
 	Secrets          []string
 	ResolvedSecrets  []factorysandbox.SecretMount
 	Envs             []string
@@ -62,6 +66,10 @@ coding tasks without local side effects or host dependencies.`,
 	cmd.PersistentFlags().BoolVar(&rootFlags.Background, "background", false, "Run the CLI command as a background daemon process and redirect output to a log file")
 	cmd.PersistentFlags().BoolVar(&rootFlags.Cleanup, "cleanup", false, "Delete the sandbox after the task is run or watch completes")
 	cmd.PersistentFlags().StringVar(&rootFlags.EphemeralStorage, "ephemeral-storage", "", "Sandbox ephemeral storage request/limit size")
+	cmd.PersistentFlags().StringVar(&rootFlags.CPURequest, "cpu-request", "", "Sandbox CPU request (e.g. 2000m)")
+	cmd.PersistentFlags().StringVar(&rootFlags.CPULimit, "cpu-limit", "", "Sandbox CPU limit (e.g. 8000m)")
+	cmd.PersistentFlags().StringVar(&rootFlags.MemoryRequest, "memory-request", "", "Sandbox memory request (e.g. 4Gi)")
+	cmd.PersistentFlags().StringVar(&rootFlags.MemoryLimit, "memory-limit", "", "Sandbox memory limit (e.g. 16Gi)")
 	cmd.PersistentFlags().StringSliceVar(&rootFlags.Secrets, "secret", nil, "Inject a secret with format secretName:mountPath (can be specified multiple times)")
 	cmd.PersistentFlags().StringArrayVar(&rootFlags.Envs, "env", nil, "Inject an environment variable with format KEY=VALUE (can be specified multiple times)")
 	cmd.PersistentFlags().BoolVar(&rootFlags.Detached, "detached", false, "Run the task in the background of the sandbox pod and return immediately")
@@ -221,6 +229,31 @@ func ResolveRootFlags(cmd *cobra.Command) (*config.FactoryConfig, error) {
 	}
 	if rootFlags.EphemeralStorage == "" {
 		rootFlags.EphemeralStorage = "6Gi"
+	}
+	if !cmd.Flags().Changed("cpu-request") && cfg.SandboxCPURequest != "" {
+		rootFlags.CPURequest = cfg.SandboxCPURequest
+	}
+	if !cmd.Flags().Changed("cpu-limit") && cfg.SandboxCPULimit != "" {
+		rootFlags.CPULimit = cfg.SandboxCPULimit
+	}
+	if !cmd.Flags().Changed("memory-request") && cfg.SandboxMemoryRequest != "" {
+		rootFlags.MemoryRequest = cfg.SandboxMemoryRequest
+	}
+	if !cmd.Flags().Changed("memory-limit") && cfg.SandboxMemoryLimit != "" {
+		rootFlags.MemoryLimit = cfg.SandboxMemoryLimit
+	}
+
+	if rootFlags.CPURequest != "" {
+		_ = os.Setenv("SANDBOX_CPU_REQUEST", rootFlags.CPURequest)
+	}
+	if rootFlags.CPULimit != "" {
+		_ = os.Setenv("SANDBOX_CPU_LIMIT", rootFlags.CPULimit)
+	}
+	if rootFlags.MemoryRequest != "" {
+		_ = os.Setenv("SANDBOX_MEMORY_REQUEST", rootFlags.MemoryRequest)
+	}
+	if rootFlags.MemoryLimit != "" {
+		_ = os.Setenv("SANDBOX_MEMORY_LIMIT", rootFlags.MemoryLimit)
 	}
 
 	if cmd.Flags().Changed("secret") {

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -2144,6 +2144,18 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 					if rootFlags.EphemeralStorage != "" {
 						args = append(args, "--ephemeral-storage", rootFlags.EphemeralStorage)
 					}
+					if rootFlags.CPURequest != "" {
+						args = append(args, "--cpu-request", rootFlags.CPURequest)
+					}
+					if rootFlags.CPULimit != "" {
+						args = append(args, "--cpu-limit", rootFlags.CPULimit)
+					}
+					if rootFlags.MemoryRequest != "" {
+						args = append(args, "--memory-request", rootFlags.MemoryRequest)
+					}
+					if rootFlags.MemoryLimit != "" {
+						args = append(args, "--memory-limit", rootFlags.MemoryLimit)
+					}
 					if taskTimeout > 0 {
 						args = append(args, "--timeout", taskTimeout.String())
 					}

--- a/factory/pkg/config/config.go
+++ b/factory/pkg/config/config.go
@@ -28,23 +28,23 @@ type RoleConfig struct {
 }
 
 type FactoryConfig struct {
-	MaxActiveReviews  int                   `yaml:"maxActiveReviews"`
-	MaxActiveIssues   int                   `yaml:"maxActiveIssues"`
-	Chores            ChoresConfig          `yaml:"chores"`
-	EphemeralStorage  string                `yaml:"ephemeralStorage"`
-	Image             string                `yaml:"image"`
+	MaxActiveReviews     int                   `yaml:"maxActiveReviews"`
+	MaxActiveIssues      int                   `yaml:"maxActiveIssues"`
+	Chores               ChoresConfig          `yaml:"chores"`
+	EphemeralStorage     string                `yaml:"ephemeralStorage"`
+	Image                string                `yaml:"image"`
 	WorkspaceDiskSize    string                `yaml:"workspaceDiskSize"`
 	SandboxCPURequest    string                `yaml:"sandboxCPURequest"`
 	SandboxCPULimit      string                `yaml:"sandboxCPULimit"`
 	SandboxMemoryRequest string                `yaml:"sandboxMemoryRequest"`
 	SandboxMemoryLimit   string                `yaml:"sandboxMemoryLimit"`
-	AdditionalLabels  []string              `yaml:"additionalLabels"`
-	TriggerLabel      string                `yaml:"triggerLabel"`
-	AllowlistedBots   []string              `yaml:"allowlistedBots"`
-	Secrets           []SecretMount         `yaml:"secrets"`
-	Env               []EnvVar              `yaml:"env"`
-	MinNumber         int                   `yaml:"minNumber"`
-	Roles             map[string]RoleConfig `yaml:"roles"`
+	AdditionalLabels     []string              `yaml:"additionalLabels"`
+	TriggerLabel         string                `yaml:"triggerLabel"`
+	AllowlistedBots      []string              `yaml:"allowlistedBots"`
+	Secrets              []SecretMount         `yaml:"secrets"`
+	Env                  []EnvVar              `yaml:"env"`
+	MinNumber            int                   `yaml:"minNumber"`
+	Roles                map[string]RoleConfig `yaml:"roles"`
 }
 
 func LoadConfig() (*FactoryConfig, error) {

--- a/factory/pkg/config/config.go
+++ b/factory/pkg/config/config.go
@@ -33,7 +33,11 @@ type FactoryConfig struct {
 	Chores            ChoresConfig          `yaml:"chores"`
 	EphemeralStorage  string                `yaml:"ephemeralStorage"`
 	Image             string                `yaml:"image"`
-	WorkspaceDiskSize string                `yaml:"workspaceDiskSize"`
+	WorkspaceDiskSize    string                `yaml:"workspaceDiskSize"`
+	SandboxCPURequest    string                `yaml:"sandboxCPURequest"`
+	SandboxCPULimit      string                `yaml:"sandboxCPULimit"`
+	SandboxMemoryRequest string                `yaml:"sandboxMemoryRequest"`
+	SandboxMemoryLimit   string                `yaml:"sandboxMemoryLimit"`
 	AdditionalLabels  []string              `yaml:"additionalLabels"`
 	TriggerLabel      string                `yaml:"triggerLabel"`
 	AllowlistedBots   []string              `yaml:"allowlistedBots"`

--- a/factory/pkg/sandbox/manifests.go
+++ b/factory/pkg/sandbox/manifests.go
@@ -36,6 +36,10 @@ type DevSandboxOptions struct {
 	Replicas          int64
 	WorkspaceDiskSize string
 	EphemeralStorage  string
+	CPURequest        string
+	CPULimit          string
+	MemoryRequest     string
+	MemoryLimit       string
 	Secrets           []SecretMount
 	Env               []EnvVar
 }
@@ -73,17 +77,33 @@ func NewAgentSandbox(opt AgentSandboxOptions) (*unstructured.Unstructured, *core
 	if resources.Limits == nil {
 		resources.Limits = make(corev1.ResourceList)
 	}
+	memReq := "2Gi"
+	if opt.MemoryRequest != "" {
+		memReq = opt.MemoryRequest
+	}
 	if resources.Requests.Memory().IsZero() {
-		resources.Requests[corev1.ResourceMemory] = resource.MustParse("2Gi")
+		resources.Requests[corev1.ResourceMemory] = resource.MustParse(memReq)
+	}
+	memLim := "6Gi"
+	if opt.MemoryLimit != "" {
+		memLim = opt.MemoryLimit
 	}
 	if resources.Limits.Memory().IsZero() {
-		resources.Limits[corev1.ResourceMemory] = resource.MustParse("6Gi")
+		resources.Limits[corev1.ResourceMemory] = resource.MustParse(memLim)
+	}
+	cpuReq := "500m"
+	if opt.CPURequest != "" {
+		cpuReq = opt.CPURequest
 	}
 	if resources.Requests.Cpu().IsZero() {
-		resources.Requests[corev1.ResourceCPU] = resource.MustParse("500m")
+		resources.Requests[corev1.ResourceCPU] = resource.MustParse(cpuReq)
+	}
+	cpuLim := "4000m"
+	if opt.CPULimit != "" {
+		cpuLim = opt.CPULimit
 	}
 	if resources.Limits.Cpu().IsZero() {
-		resources.Limits[corev1.ResourceCPU] = resource.MustParse("4000m")
+		resources.Limits[corev1.ResourceCPU] = resource.MustParse(cpuLim)
 	}
 
 	ephemeralStorage := opt.EphemeralStorage

--- a/factory/pkg/sandbox/sandbox.go
+++ b/factory/pkg/sandbox/sandbox.go
@@ -15,6 +15,21 @@ import (
 	"k8s.io/klog/v2"
 )
 
+func fillEnvResources(opts *DevSandboxOptions) {
+	if opts.CPURequest == "" {
+		opts.CPURequest = os.Getenv("SANDBOX_CPU_REQUEST")
+	}
+	if opts.CPULimit == "" {
+		opts.CPULimit = os.Getenv("SANDBOX_CPU_LIMIT")
+	}
+	if opts.MemoryRequest == "" {
+		opts.MemoryRequest = os.Getenv("SANDBOX_MEMORY_REQUEST")
+	}
+	if opts.MemoryLimit == "" {
+		opts.MemoryLimit = os.Getenv("SANDBOX_MEMORY_LIMIT")
+	}
+}
+
 func EnsureFixSandbox(ctx context.Context, kubeClient *clients.KubernetesClient, namespace, repoName, taskID, cloneURL, htmlURL, taskTitle, image, diskSize, ephemeralStorage string, secrets []SecretMount, envs []EnvVar, user string) (string, error) {
 	name := fmt.Sprintf("fix-%s-%s", repoName, taskID)
 
@@ -65,6 +80,7 @@ func EnsureFixSandbox(ctx context.Context, kubeClient *clients.KubernetesClient,
 		},
 	}
 
+	fillEnvResources(&opt.DevSandboxOptions)
 	sbObj, svc := NewAgentSandbox(opt)
 
 	_, err = kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Create(ctx, sbObj, metav1.CreateOptions{})
@@ -138,6 +154,7 @@ func EnsureAgentSandbox(ctx context.Context, kubeClient *clients.KubernetesClien
 		},
 	}
 
+	fillEnvResources(&opt.DevSandboxOptions)
 	sbObj, svc := NewAgentSandbox(opt)
 
 	_, err = kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Create(ctx, sbObj, metav1.CreateOptions{})
@@ -203,6 +220,7 @@ func EnsureAdoptSandbox(ctx context.Context, kubeClient *clients.KubernetesClien
 		},
 	}
 
+	fillEnvResources(&opt.DevSandboxOptions)
 	sbObj, svc := NewAgentSandbox(opt)
 
 	_, err = kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Create(ctx, sbObj, metav1.CreateOptions{})
@@ -323,6 +341,7 @@ func EnsureReviewSandbox(ctx context.Context, kubeClient *clients.KubernetesClie
 		RepoName:   repo,
 	}
 
+	fillEnvResources(&opt.DevSandboxOptions)
 	sb, svc := NewReviewSandbox(opt)
 
 	_, err = kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Create(ctx, sb, metav1.CreateOptions{})

--- a/overseer/examples/kcc.yaml
+++ b/overseer/examples/kcc.yaml
@@ -17,6 +17,10 @@ spec:
   ephemeralStorage: 10Gi
   image: ghcr.io/gke-labs/gemini-for-kubernetes-development/factory-golang:latest
   workspaceDiskSize: 40Gi
+  sandboxCPURequest: "2000m"
+  sandboxCPULimit: "8000m"
+  sandboxMemoryRequest: "4Gi"
+  sandboxMemoryLimit: "16Gi"
   secrets:
     - name: projectaccess
       mountPath: "/etc/pakey"

--- a/overseer/images/overseer/run.sh
+++ b/overseer/images/overseer/run.sh
@@ -27,6 +27,18 @@ function writeFactoryConfig {
     if [ -n "$WORKSPACE_DISK_SIZE" ]; then
         echo "workspaceDiskSize: $WORKSPACE_DISK_SIZE" >> "$CFG_FILE"
     fi
+    if [ -n "$SANDBOX_CPU_REQUEST" ]; then
+        echo "sandboxCPURequest: $SANDBOX_CPU_REQUEST" >> "$CFG_FILE"
+    fi
+    if [ -n "$SANDBOX_CPU_LIMIT" ]; then
+        echo "sandboxCPULimit: $SANDBOX_CPU_LIMIT" >> "$CFG_FILE"
+    fi
+    if [ -n "$SANDBOX_MEMORY_REQUEST" ]; then
+        echo "sandboxMemoryRequest: $SANDBOX_MEMORY_REQUEST" >> "$CFG_FILE"
+    fi
+    if [ -n "$SANDBOX_MEMORY_LIMIT" ]; then
+        echo "sandboxMemoryLimit: $SANDBOX_MEMORY_LIMIT" >> "$CFG_FILE"
+    fi
     if [ -n "$MIN_NUMBER" ]; then
         echo "minNumber: $MIN_NUMBER" >> "$CFG_FILE"
     fi

--- a/overseer/k8s/crds/overseer.gemini.google.com_overseers.yaml
+++ b/overseer/k8s/crds/overseer.gemini.google.com_overseers.yaml
@@ -136,11 +136,19 @@ spec:
                       type: array
                   type: object
                 type: object
+              sandboxCPULimit:
+                type: string
+              sandboxCPURequest:
+                type: string
               sandboxEvictionAge:
                 default: 7d
                 type: string
               sandboxIdleTimeout:
                 default: 1h
+                type: string
+              sandboxMemoryLimit:
+                type: string
+              sandboxMemoryRequest:
                 type: string
               secrets:
                 items:

--- a/overseer/pkg/api/v1alpha1/overseer_types.go
+++ b/overseer/pkg/api/v1alpha1/overseer_types.go
@@ -114,6 +114,22 @@ type OverseerSpec struct {
 	// +kubebuilder:default="10Gi"
 	EphemeralStorage string `json:"ephemeralStorage,omitempty"`
 
+	// SandboxCPURequest specifies the CPU request for child sandboxes.
+	// +kubebuilder:validation:Optional
+	SandboxCPURequest string `json:"sandboxCPURequest,omitempty"`
+
+	// SandboxCPULimit specifies the CPU limit for child sandboxes.
+	// +kubebuilder:validation:Optional
+	SandboxCPULimit string `json:"sandboxCPULimit,omitempty"`
+
+	// SandboxMemoryRequest specifies the memory request for child sandboxes.
+	// +kubebuilder:validation:Optional
+	SandboxMemoryRequest string `json:"sandboxMemoryRequest,omitempty"`
+
+	// SandboxMemoryLimit specifies the memory limit for child sandboxes.
+	// +kubebuilder:validation:Optional
+	SandboxMemoryLimit string `json:"sandboxMemoryLimit,omitempty"`
+
 	// Review configuration for PRs
 	// +kubebuilder:validation:Optional
 	Review ReviewSpec `json:"review"`

--- a/overseer/pkg/overseer/overseer.go
+++ b/overseer/pkg/overseer/overseer.go
@@ -202,6 +202,22 @@ func newOverseerSandboxFromOverseer(o *overseerv1alpha1.Overseer, name, namespac
 			"value": o.Spec.EphemeralStorage,
 		},
 		map[string]interface{}{
+			"name":  "SANDBOX_CPU_REQUEST",
+			"value": o.Spec.SandboxCPURequest,
+		},
+		map[string]interface{}{
+			"name":  "SANDBOX_CPU_LIMIT",
+			"value": o.Spec.SandboxCPULimit,
+		},
+		map[string]interface{}{
+			"name":  "SANDBOX_MEMORY_REQUEST",
+			"value": o.Spec.SandboxMemoryRequest,
+		},
+		map[string]interface{}{
+			"name":  "SANDBOX_MEMORY_LIMIT",
+			"value": o.Spec.SandboxMemoryLimit,
+		},
+		map[string]interface{}{
 			"name":  "ALLOW_GEMINI_ORCHESTRATION",
 			"value": fmt.Sprintf("%t", o.Spec.EnableGeminiOrchestrator),
 		},


### PR DESCRIPTION
1. **Overseer CRD & Example Configuration**
   - Added `sandboxCPURequest`, `sandboxCPULimit`, `sandboxMemoryRequest`, and `sandboxMemoryLimit` fields to `OverseerSpec` and regenerated the CRD OpenAPI schema (`overseer.gemini.google.com_overseers.yaml`).
   - Updated `overseer/examples/kcc.yaml` to allocate **`2000m` CPU request / `8000m` (8 cores) CPU limit** and **`4Gi` memory request / `16Gi` memory limit** for KCC sandboxes.

2. **Overseer Controller & Config Bridge**
   - Updated the Overseer controller (`overseer.go`) to inject `SANDBOX_CPU_REQUEST`, `SANDBOX_CPU_LIMIT`, `SANDBOX_MEMORY_REQUEST`, and `SANDBOX_MEMORY_LIMIT` environment variables into the Overseer container.
   - Updated `run.sh` inside the Overseer image so these settings are written directly to `/workspaces/.factory.cfg`.

3. **Factory CLI & Pod Sizing**
   - Added `--cpu-request`, `--cpu-limit`, `--memory-request`, and `--memory-limit` persistent flags to the `factory` CLI, falling back automatically to `.factory.cfg` settings when omitted.
   - Updated `factory watch` to pass these CPU and memory flags down when launching CLI task commands (`factory pr investigate`, `factory issue fix`, etc.).
   - Updated `NewAgentSandbox` (`manifests.go`) so created sandbox pods use custom CPU/Memory overrides instead of the hardcoded `500m/4000m` CPU and `2Gi/6Gi` memory defaults.