### PR TITLE
fix(tasks): force PR branch checkouts and recycle dirty sandboxes on task failure

### DIFF
--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -2189,8 +2189,8 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 						t.CompletedAt = time.Now()
 						writeTaskJournalEvent(queueDir, taskFilename, t, "Failed", duration)
 
-						// Force clean up sandbox if the task timed out
-						if taskCtx.Err() == context.DeadlineExceeded {
+						// Force clean up sandbox if the task failed or timed out so next retry gets a clean workspace
+						if taskErr != nil {
 							var sandboxName string
 							switch t.Type {
 							case "issue-fix":
@@ -2210,10 +2210,10 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 							}
 
 							if sandboxName != "" {
-								klog.Warningf("Task %s timed out after %s! Force cleaning up sandbox '%s'...", taskFilename, taskTimeout, sandboxName)
+								klog.Warningf("Task %s failed (%v)! Cleaning up dirty sandbox '%s' so next run gets a fresh workspace...", taskFilename, taskErr, sandboxName)
 								manager := k8s.NewManager(kubeClient)
 								if err := manager.DeleteSandbox(ctx, rootFlags.Namespace, sandboxName); err != nil {
-									klog.Errorf("Failed to delete sandbox '%s' on timeout: %v", sandboxName, err)
+									klog.Errorf("Failed to delete sandbox '%s' on task failure: %v", sandboxName, err)
 								}
 							}
 						}

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -2189,8 +2189,8 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 						t.CompletedAt = time.Now()
 						writeTaskJournalEvent(queueDir, taskFilename, t, "Failed", duration)
 
-						// Force clean up sandbox if the task failed or timed out so next retry gets a clean workspace
-						if taskErr != nil {
+						// Force clean up sandbox if the task timed out
+						if taskCtx.Err() == context.DeadlineExceeded {
 							var sandboxName string
 							switch t.Type {
 							case "issue-fix":
@@ -2210,10 +2210,10 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 							}
 
 							if sandboxName != "" {
-								klog.Warningf("Task %s failed (%v)! Cleaning up dirty sandbox '%s' so next run gets a fresh workspace...", taskFilename, taskErr, sandboxName)
+								klog.Warningf("Task %s timed out after %s! Force cleaning up sandbox '%s'...", taskFilename, taskTimeout, sandboxName)
 								manager := k8s.NewManager(kubeClient)
 								if err := manager.DeleteSandbox(ctx, rootFlags.Namespace, sandboxName); err != nil {
-									klog.Errorf("Failed to delete sandbox '%s' on task failure: %v", sandboxName, err)
+									klog.Errorf("Failed to delete sandbox '%s' on timeout: %v", sandboxName, err)
 								}
 							}
 						}

--- a/factory/pkg/tasks/address_feedback.sh
+++ b/factory/pkg/tasks/address_feedback.sh
@@ -110,7 +110,7 @@ function checkoutPRBranch {
     (cd "/workspaces/${REPO_NAME}" && git rebase --abort 2>/dev/null || true)
     (cd "/workspaces/${REPO_NAME}" && git merge --abort 2>/dev/null || true)
     (cd "/workspaces/${REPO_NAME}" && git cherry-pick --abort 2>/dev/null || true)
-    (cd "/workspaces/${REPO_NAME}" && git reset --hard HEAD && git clean -fd && /usr/bin/gh pr checkout ${PR_NUMBER} && (git reset --hard @{u} 2>/dev/null || git reset --hard FETCH_HEAD))
+    (cd "/workspaces/${REPO_NAME}" && git reset --hard HEAD && git clean -fd && /usr/bin/gh pr checkout ${PR_NUMBER} --force && (git reset --hard @{u} 2>/dev/null || git reset --hard FETCH_HEAD))
 }
 
 function configureGemini {

--- a/factory/pkg/tasks/fix_issue.sh
+++ b/factory/pkg/tasks/fix_issue.sh
@@ -149,7 +149,7 @@ function checkForExistingPR {
         git cherry-pick --abort 2>/dev/null || true
         git reset --hard HEAD
         git clean -fd
-        /usr/bin/gh pr checkout "$pr_number"
+        /usr/bin/gh pr checkout "$pr_number" --force
 
         local output_file="$(dirname "${PROMPT_FILE}")/agent-output.txt"
 

--- a/factory/pkg/tasks/investigate_failures.sh
+++ b/factory/pkg/tasks/investigate_failures.sh
@@ -111,7 +111,7 @@ function checkoutPRBranch {
     (cd "/workspaces/${REPO_NAME}" && git rebase --abort 2>/dev/null || true)
     (cd "/workspaces/${REPO_NAME}" && git merge --abort 2>/dev/null || true)
     (cd "/workspaces/${REPO_NAME}" && git cherry-pick --abort 2>/dev/null || true)
-    (cd "/workspaces/${REPO_NAME}" && git reset --hard HEAD && git clean -fd && /usr/bin/gh pr checkout ${PR_NUMBER} && (git reset --hard @{u} 2>/dev/null || git reset --hard FETCH_HEAD))
+    (cd "/workspaces/${REPO_NAME}" && git reset --hard HEAD && git clean -fd && /usr/bin/gh pr checkout ${PR_NUMBER} --force && (git reset --hard @{u} 2>/dev/null || git reset --hard FETCH_HEAD))
 }
 
 function fetchLogs {

--- a/factory/pkg/tasks/iterate.sh
+++ b/factory/pkg/tasks/iterate.sh
@@ -121,7 +121,7 @@ function setupGitRepos {
         (cd "/workspaces/${REPO_NAME}" && git rebase --abort 2>/dev/null || true)
         (cd "/workspaces/${REPO_NAME}" && git merge --abort 2>/dev/null || true)
         (cd "/workspaces/${REPO_NAME}" && git cherry-pick --abort 2>/dev/null || true)
-        (cd "/workspaces/${REPO_NAME}" && git reset --hard HEAD && git clean -fd && /usr/bin/gh pr checkout "$PRID")
+        (cd "/workspaces/${REPO_NAME}" && git reset --hard HEAD && git clean -fd && /usr/bin/gh pr checkout "$PRID" --force)
     elif [ -n "$BRANCH_NAME" ]; then
         echo "Checking out branch $BRANCH_NAME"
         (cd "/workspaces/${REPO_NAME}" && git rebase --abort 2>/dev/null || true)

--- a/factory/pkg/tasks/review.sh
+++ b/factory/pkg/tasks/review.sh
@@ -106,7 +106,7 @@ function checkoutPRBranch {
     (cd "/workspaces/${REPO_NAME}" && git rebase --abort 2>/dev/null || true)
     (cd "/workspaces/${REPO_NAME}" && git merge --abort 2>/dev/null || true)
     (cd "/workspaces/${REPO_NAME}" && git cherry-pick --abort 2>/dev/null || true)
-    (cd "/workspaces/${REPO_NAME}" && git reset --hard HEAD && git clean -fd && /usr/bin/gh pr checkout ${PR_NUMBER} && (git reset --hard @{u} 2>/dev/null || git reset --hard FETCH_HEAD))
+    (cd "/workspaces/${REPO_NAME}" && git reset --hard HEAD && git clean -fd && /usr/bin/gh pr checkout ${PR_NUMBER} --force && (git reset --hard @{u} 2>/dev/null || git reset --hard FETCH_HEAD))
 }
 
 function configureGemini {

--- a/factory/pkg/tasks/run_agent.sh
+++ b/factory/pkg/tasks/run_agent.sh
@@ -324,7 +324,7 @@ function runAgent {
         (cd "/workspaces/${REPO_NAME}" && git rebase --abort 2>/dev/null || true)
         (cd "/workspaces/${REPO_NAME}" && git merge --abort 2>/dev/null || true)
         (cd "/workspaces/${REPO_NAME}" && git cherry-pick --abort 2>/dev/null || true)
-        (cd "/workspaces/${REPO_NAME}" && git reset --hard HEAD && git clean -fd && /usr/bin/gh pr checkout ${PR_NUMBER} && git pull origin HEAD || true)
+        (cd "/workspaces/${REPO_NAME}" && git reset --hard HEAD && git clean -fd && /usr/bin/gh pr checkout ${PR_NUMBER} --force && git pull origin HEAD || true)
         BRANCH_NAME=$(git branch --show-current)
     else
         # Create a unique branch for this agent run if skip PR is not true

--- a/repo-agent/pkg/tasks/address_feedback.sh
+++ b/repo-agent/pkg/tasks/address_feedback.sh
@@ -115,7 +115,7 @@ function checkoutPRBranch {
     (cd "/workspaces/${REPO_NAME}" && git rebase --abort 2>/dev/null || true)
     (cd "/workspaces/${REPO_NAME}" && git merge --abort 2>/dev/null || true)
     (cd "/workspaces/${REPO_NAME}" && git cherry-pick --abort 2>/dev/null || true)
-    (cd "/workspaces/${REPO_NAME}" && git reset --hard HEAD && git clean -fd && /usr/bin/gh pr checkout ${PR_NUMBER})
+    (cd "/workspaces/${REPO_NAME}" && git reset --hard HEAD && git clean -fd && /usr/bin/gh pr checkout ${PR_NUMBER} --force)
 }
 
 function configureGemini {

--- a/repo-agent/pkg/tasks/fix_issue.sh
+++ b/repo-agent/pkg/tasks/fix_issue.sh
@@ -144,7 +144,7 @@ function checkForExistingPR {
         git cherry-pick --abort 2>/dev/null || true
         git reset --hard HEAD
         git clean -fd
-        /usr/bin/gh pr checkout "$pr_number"
+        /usr/bin/gh pr checkout "$pr_number" --force
 
         local output_file="$(dirname "${PROMPT_FILE}")/agent-output.txt"
 

--- a/repo-agent/pkg/tasks/investigate_failures.sh
+++ b/repo-agent/pkg/tasks/investigate_failures.sh
@@ -114,7 +114,7 @@ function checkoutPRBranch {
     (cd "/workspaces/${REPO_NAME}" && git rebase --abort 2>/dev/null || true)
     (cd "/workspaces/${REPO_NAME}" && git merge --abort 2>/dev/null || true)
     (cd "/workspaces/${REPO_NAME}" && git cherry-pick --abort 2>/dev/null || true)
-    (cd "/workspaces/${REPO_NAME}" && git reset --hard HEAD && git clean -fd && /usr/bin/gh pr checkout ${PR_NUMBER})
+    (cd "/workspaces/${REPO_NAME}" && git reset --hard HEAD && git clean -fd && /usr/bin/gh pr checkout ${PR_NUMBER} --force)
 }
 
 function fetchLogs {

--- a/repo-agent/pkg/tasks/iterate.sh
+++ b/repo-agent/pkg/tasks/iterate.sh
@@ -120,7 +120,7 @@ function setupGitRepos {
         (cd "/workspaces/${REPO_NAME}" && git rebase --abort 2>/dev/null || true)
         (cd "/workspaces/${REPO_NAME}" && git merge --abort 2>/dev/null || true)
         (cd "/workspaces/${REPO_NAME}" && git cherry-pick --abort 2>/dev/null || true)
-        (cd "/workspaces/${REPO_NAME}" && git reset --hard HEAD && git clean -fd && /usr/bin/gh pr checkout "$PRID")
+        (cd "/workspaces/${REPO_NAME}" && git reset --hard HEAD && git clean -fd && /usr/bin/gh pr checkout "$PRID" --force)
     elif [ -n "$BRANCH_NAME" ]; then
         echo "Checking out branch $BRANCH_NAME"
         (cd "/workspaces/${REPO_NAME}" && git rebase --abort 2>/dev/null || true)

--- a/repo-agent/pkg/tasks/rollback.sh
+++ b/repo-agent/pkg/tasks/rollback.sh
@@ -93,7 +93,7 @@ function checkoutPRBranch {
     (cd "/workspaces/${REPO_NAME}" && git rebase --abort 2>/dev/null || true)
     (cd "/workspaces/${REPO_NAME}" && git merge --abort 2>/dev/null || true)
     (cd "/workspaces/${REPO_NAME}" && git cherry-pick --abort 2>/dev/null || true)
-    (cd "/workspaces/${REPO_NAME}" && git reset --hard HEAD && git clean -fd && /usr/bin/gh pr checkout ${PR_NUMBER})
+    (cd "/workspaces/${REPO_NAME}" && git reset --hard HEAD && git clean -fd && /usr/bin/gh pr checkout ${PR_NUMBER} --force)
 }
 
 function runRollback {


### PR DESCRIPTION
- Add --force to gh pr checkout across all 11 task scripts in factory and repo-agent so diverged local PR branches reset cleanly instead of failing fast-forward
- Update watch.go so any failed task triggers sandbox cleanup, ensuring subsequent runs start in a clean workspace