### PR TITLE
feat: track subject age/status and daily usage in token-usage collector

### DIFF
--- a/factory/design/token-usage-collection.md
+++ b/factory/design/token-usage-collection.md
@@ -69,7 +69,12 @@ The three rollups are **mutually exclusive** — every record is counted in exac
 * **Per issue** ("Issue / PR sandboxes"): remaining records count toward issue N if `issue == N` or N is in `issues` — the issue sandbox plus any PR work it led to. Rows with linked PRs are labeled `#N / PR #M`. Issues owned by a workflow session are excluded.
 * **Per PR** ("PR sandboxes"): what is left — standalone PR work (reviews, investigations, adoptions) with no issue or workflow linkage.
 
-All rollup list responses include the per-task `records` (with `taskType` and `sandbox`) for drill-down in the dashboard.
+All rollup list responses include the per-task `records` (with `taskType`, `sandbox`, and `recordedAt`) for drill-down in the dashboard.
+
+Two additions on top of the record rollups:
+
+* **Daily usage** (`GET /v1/usage/rollups/daily`): records grouped by the UTC day of `recordedAt`. `recordedAt` is stamped when a task's usage is **first** pushed and preserved across upserts (a later sweep re-post cannot move usage to a different day).
+* **Subjects** (`POST /v1/subjects`, stored in `subjects.jsonl`): GitHub metadata of the entity usage is attributed to — `issue-<n>` / `pr-<n>` keys with `state` (open/closed), `createdAt`, and `closedAt`. Producers upsert subjects from the task hooks (open state, creation time) and from the watch-loop cleanup functions (closed state, close time); merge semantics never let an empty field blank out a known value. Rollups join on the subject key so the dashboard can show open/closed status and age (creation→close, or creation→now while open).
 
 Endpoints: `GET /v1/usage/rollups/{issues,prs,workflows}[?repo=]` and `GET /v1/usage/rollups/workflows/{session}` (detail with per-task records).
 

--- a/factory/pkg/commands/agent.go
+++ b/factory/pkg/commands/agent.go
@@ -391,6 +391,18 @@ func RunAgent(ctx context.Context, flags AgentFlags, ephemeralStorage string, se
 		}
 	}
 	usagereport.HarvestTask(ctx, client, taskDir, usageMeta)
+	if usagereport.Enabled() {
+		if usageMeta.Issue != 0 {
+			if issue, _, err := ghClient.Issues.Get(ctx, owner, repo, usageMeta.Issue); err == nil {
+				usagereport.ReportIssueSubject(ctx, owner+"/"+repo, issue)
+			}
+		}
+		if usageMeta.PR != 0 {
+			if subjectPR, _, err := ghClient.PullRequests.Get(ctx, owner, repo, usageMeta.PR); err == nil {
+				usagereport.ReportPRSubject(ctx, owner+"/"+repo, subjectPR)
+			}
+		}
+	}
 
 	if rootFlags.Cleanup {
 		fmt.Printf("Cleaning up sandbox '%s'...\n", sandboxName)

--- a/factory/pkg/commands/fix.go
+++ b/factory/pkg/commands/fix.go
@@ -358,6 +358,12 @@ func runFix(ctx context.Context, targetURL, prompt, name string, noPR, watch boo
 		Issue:    issueNum,
 		PR:       prNum,
 	})
+	usagereport.ReportIssueSubject(ctx, owner+"/"+repo, issue)
+	if prNum > 0 && usagereport.Enabled() {
+		if createdPR, _, err := ghClient.PullRequests.Get(ctx, owner, repo, prNum); err == nil {
+			usagereport.ReportPRSubject(ctx, owner+"/"+repo, createdPR)
+		}
+	}
 
 	if prNum > 0 {
 		fmt.Printf("Aliasing sandbox %s to PR #%d...\n", sandboxName, prNum)

--- a/factory/pkg/commands/pr.go
+++ b/factory/pkg/commands/pr.go
@@ -296,6 +296,7 @@ func runInvestigate(ctx context.Context, prURL, prompt string, continueSession b
 		PR:       prNum,
 		Issues:   referencedIssueList(pr),
 	})
+	usagereport.ReportPRSubject(ctx, owner+"/"+repo, pr)
 
 	fmt.Println("\nInvestigate execution completed.")
 	return nil
@@ -565,6 +566,7 @@ func runAddressComments(ctx context.Context, prURL, prompt string, continueSessi
 		PR:       prNum,
 		Issues:   referencedIssueList(pr),
 	})
+	usagereport.ReportPRSubject(ctx, owner+"/"+repo, pr)
 
 	fmt.Println("\nAddress-comments execution completed.")
 	return nil
@@ -1016,6 +1018,7 @@ func runIterate(ctx context.Context, prURL, prompt string, continueSession bool,
 		PR:       prNum,
 		Issues:   referencedIssueList(pr),
 	})
+	usagereport.ReportPRSubject(ctx, owner+"/"+repo, pr)
 
 	fmt.Println("\nIterate execution completed.")
 	return nil
@@ -1311,6 +1314,7 @@ func runAdopt(ctx context.Context, prURL, adoptAction, strategy string, ephemera
 		Sandbox:  sandboxName,
 		PR:       prNum,
 	})
+	usagereport.ReportPRSubject(ctx, owner+"/"+repo, pr)
 
 	fmt.Println("\nAdopt execution completed.")
 

--- a/factory/pkg/commands/review.go
+++ b/factory/pkg/commands/review.go
@@ -306,6 +306,7 @@ func runReview(ctx context.Context, prURL string, publishPolicy string, instruct
 		PR:       prNum,
 		Issues:   referencedIssueList(pr),
 	})
+	usagereport.ReportPRSubject(ctx, owner+"/"+repo, pr)
 
 	fmt.Println("\nReview execution completed. Reading output...")
 

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -2520,6 +2520,7 @@ func cleanupClosedPRSandboxes(ctx context.Context, ghClient *githubv39.Client, k
 			meta.PR = num
 			meta.Issues = referencedIssueList(pr)
 			usagereport.HarvestSandbox(ctx, namespace, name, meta)
+			usagereport.ReportPRSubject(ctx, owner+"/"+repo, pr)
 			if err := manager.DeleteSandbox(ctx, namespace, name); err != nil {
 				klog.Errorf("Failed to delete sandbox '%s' for closed PR #%d: %v", name, num, err)
 			}
@@ -2578,6 +2579,7 @@ func cleanupClosedIssueSandboxes(ctx context.Context, ghClient *githubv39.Client
 			meta := sandboxUsageMeta(&item, owner+"/"+repo)
 			meta.Issue = num
 			usagereport.HarvestSandbox(ctx, namespace, name, meta)
+			usagereport.ReportIssueSubject(ctx, owner+"/"+repo, issue)
 			if strings.HasPrefix(name, "wf-issue-") {
 				usagereport.PostWorkflowSummaryIfNeeded(ctx, ghClient, owner, repo, num)
 			}

--- a/factory/pkg/tokenusage/server.go
+++ b/factory/pkg/tokenusage/server.go
@@ -37,9 +37,11 @@ func NewServer(storageRoot string) (*Server, error) {
 	}
 	s := &Server{store: store, mux: http.NewServeMux()}
 	s.mux.HandleFunc("POST /v1/usage", s.handleIngest)
+	s.mux.HandleFunc("POST /v1/subjects", s.handleSubjectIngest)
 	s.mux.HandleFunc("GET /v1/usage/records", s.handleRecords)
 	s.mux.HandleFunc("GET /v1/usage/rollups/issues", s.handleRollupIssues)
 	s.mux.HandleFunc("GET /v1/usage/rollups/prs", s.handleRollupPRs)
+	s.mux.HandleFunc("GET /v1/usage/rollups/daily", s.handleRollupDaily)
 	s.mux.HandleFunc("GET /v1/usage/rollups/workflows", s.handleRollupWorkflows)
 	s.mux.HandleFunc("GET /v1/usage/rollups/workflows/{session}", s.handleWorkflowDetail)
 	s.mux.HandleFunc("POST /v1/workflows/{session}/mark-summarized", s.handleMarkSummarized)
@@ -67,6 +69,28 @@ func (s *Server) handleIngest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) handleSubjectIngest(w http.ResponseWriter, r *http.Request) {
+	var sub Subject
+	if err := json.NewDecoder(r.Body).Decode(&sub); err != nil {
+		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := s.store.PutSubject(sub); err != nil {
+		if strings.Contains(err.Error(), "key is required") {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		log.Printf("subject ingest failed for key %q: %v", sub.Key, err)
+		http.Error(w, "storage error", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) handleRollupDaily(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, map[string]any{"rollups": s.store.RollupByDay(r.URL.Query().Get("repo"))})
 }
 
 func (s *Server) handleRecords(w http.ResponseWriter, r *http.Request) {

--- a/factory/pkg/tokenusage/server_test.go
+++ b/factory/pkg/tokenusage/server_test.go
@@ -71,7 +71,8 @@ func TestServerEndToEnd(t *testing.T) {
 		Key: "wf-issue-3:/workspaces/tasks/agent-x", Repo: "org/repo",
 		TaskType: "agent-chore", Sandbox: "wf-issue-3", Issue: 3,
 		Workflow: "issue-3", WorkflowName: "chore",
-		Stats: statsFor("gemini-2.5-pro", 10, 20, 30),
+		RecordedAt: "2026-07-14T09:00:00Z",
+		Stats:      statsFor("gemini-2.5-pro", 10, 20, 30),
 	}
 	if resp := postJSON(t, ts.URL+"/v1/usage", rec); resp.StatusCode != http.StatusOK {
 		t.Fatalf("ingest: status %d", resp.StatusCode)
@@ -96,6 +97,29 @@ func TestServerEndToEnd(t *testing.T) {
 	getJSON(t, ts.URL+"/v1/usage/rollups/workflows?repo=org/repo", &rollups)
 	if len(rollups.Rollups) != 1 || rollups.Rollups[0].Key != "issue-3" {
 		t.Fatalf("workflow rollups: got %+v", rollups.Rollups)
+	}
+
+	// Subject ingest joins onto rollups.
+	if resp := postJSON(t, ts.URL+"/v1/subjects", Subject{
+		Key: "issue-3", Repo: "org/repo", Kind: "issue", Number: 3,
+		State: "open", CreatedAt: "2026-07-10T00:00:00Z",
+	}); resp.StatusCode != http.StatusOK {
+		t.Fatalf("subject ingest: status %d", resp.StatusCode)
+	}
+	if resp := postJSON(t, ts.URL+"/v1/subjects", Subject{}); resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("subject ingest without key: expected 400, got %d", resp.StatusCode)
+	}
+	getJSON(t, ts.URL+"/v1/usage/rollups/workflows?repo=org/repo", &rollups)
+	if rollups.Rollups[0].State != "open" || rollups.Rollups[0].CreatedAt != "2026-07-10T00:00:00Z" {
+		t.Errorf("workflow rollup subject join: got %+v", rollups.Rollups[0])
+	}
+
+	var daily struct {
+		Rollups []Rollup `json:"rollups"`
+	}
+	getJSON(t, ts.URL+"/v1/usage/rollups/daily?repo=org/repo", &daily)
+	if len(daily.Rollups) != 1 || daily.Rollups[0].Key != "2026-07-14" || daily.Rollups[0].TaskCount != 1 {
+		t.Errorf("daily rollup: got %+v", daily.Rollups)
 	}
 
 	var detail Rollup

--- a/factory/pkg/tokenusage/store.go
+++ b/factory/pkg/tokenusage/store.go
@@ -29,15 +29,17 @@ import (
 	"sync"
 )
 
-// Store persists usage records as a JSONL append log and keeps a full
-// in-memory index, rebuilt by replaying the log at startup. On replay the
-// last line for a key wins, so upserts are plain appends.
+// Store persists usage records and subjects as JSONL append logs and keeps
+// full in-memory indexes, rebuilt by replaying the logs at startup. On
+// replay the last line for a key wins, so upserts are plain appends.
 type Store struct {
-	mu         sync.Mutex
-	root       string
-	records    map[string]UsageRecord
-	summarized map[string]bool // workflow session -> summary comment posted
-	log        *os.File
+	mu          sync.Mutex
+	root        string
+	records     map[string]UsageRecord
+	subjects    map[string]Subject
+	summarized  map[string]bool // workflow session -> summary comment posted
+	log         *os.File
+	subjectsLog *os.File
 }
 
 func NewStore(root string) (*Store, error) {
@@ -47,9 +49,13 @@ func NewStore(root string) (*Store, error) {
 	s := &Store{
 		root:       root,
 		records:    map[string]UsageRecord{},
+		subjects:   map[string]Subject{},
 		summarized: map[string]bool{},
 	}
-	if err := s.replay(); err != nil {
+	if err := replayLog(s.recordsPath(), func(rec UsageRecord) string { return rec.Key }, s.records); err != nil {
+		return nil, err
+	}
+	if err := replayLog(s.subjectsPath(), func(sub Subject) string { return sub.Key }, s.subjects); err != nil {
 		return nil, err
 	}
 	if err := s.loadSummarized(); err != nil {
@@ -60,14 +66,24 @@ func NewStore(root string) (*Store, error) {
 		return nil, fmt.Errorf("opening records log: %w", err)
 	}
 	s.log = log
+	subjectsLog, err := os.OpenFile(s.subjectsPath(), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		_ = log.Close()
+		return nil, fmt.Errorf("opening subjects log: %w", err)
+	}
+	s.subjectsLog = subjectsLog
 	return s, nil
 }
 
 func (s *Store) recordsPath() string    { return filepath.Join(s.root, "records.jsonl") }
+func (s *Store) subjectsPath() string   { return filepath.Join(s.root, "subjects.jsonl") }
 func (s *Store) summarizedPath() string { return filepath.Join(s.root, "summarized.json") }
 
-func (s *Store) replay() error {
-	f, err := os.Open(s.recordsPath())
+// replayLog rebuilds an in-memory index from a JSONL append log; the last
+// line for a key wins. Corrupt lines (e.g. torn write on crash) are skipped
+// rather than refusing to start.
+func replayLog[T any](path string, keyOf func(T) string, into map[string]T) error {
+	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -82,14 +98,12 @@ func (s *Store) replay() error {
 		if line == "" {
 			continue
 		}
-		var rec UsageRecord
-		if err := json.Unmarshal([]byte(line), &rec); err != nil {
-			// Skip corrupt lines (e.g. torn write on crash) rather than
-			// refusing to start.
+		var v T
+		if err := json.Unmarshal([]byte(line), &v); err != nil {
 			continue
 		}
-		if rec.Key != "" {
-			s.records[rec.Key] = rec
+		if key := keyOf(v); key != "" {
+			into[key] = v
 		}
 	}
 	return scanner.Err()
@@ -106,16 +120,23 @@ func (s *Store) loadSummarized() error {
 	return json.Unmarshal(data, &s.summarized)
 }
 
-// Put upserts a record by key. Identical re-posts are skipped without
-// touching the log.
+// Put upserts a record by key. The first RecordedAt for a key is preserved
+// across upserts so daily aggregation buckets stay stable (a sweep re-post
+// of an already-pushed task must not move its usage to a later day).
+// Identical re-posts are skipped without touching the log.
 func (s *Store) Put(rec UsageRecord) error {
 	if rec.Key == "" {
 		return fmt.Errorf("record key is required")
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if existing, ok := s.records[rec.Key]; ok && reflect.DeepEqual(existing, rec) {
-		return nil
+	if existing, ok := s.records[rec.Key]; ok {
+		if existing.RecordedAt != "" {
+			rec.RecordedAt = existing.RecordedAt
+		}
+		if reflect.DeepEqual(existing, rec) {
+			return nil
+		}
 	}
 	line, err := json.Marshal(rec)
 	if err != nil {
@@ -128,6 +149,57 @@ func (s *Store) Put(rec UsageRecord) error {
 		return fmt.Errorf("syncing records log: %w", err)
 	}
 	s.records[rec.Key] = rec
+	return nil
+}
+
+// PutSubject upserts subject metadata by key, merging with the stored
+// subject: empty incoming fields never blank out known values, so a late
+// "closed" update without createdAt keeps the original creation time.
+func (s *Store) PutSubject(sub Subject) error {
+	if sub.Key == "" {
+		return fmt.Errorf("subject key is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing, ok := s.subjects[sub.Key]; ok {
+		if sub.Repo == "" {
+			sub.Repo = existing.Repo
+		}
+		if sub.Kind == "" {
+			sub.Kind = existing.Kind
+		}
+		if sub.Number == 0 {
+			sub.Number = existing.Number
+		}
+		if sub.State == "" {
+			sub.State = existing.State
+		}
+		if sub.CreatedAt == "" {
+			sub.CreatedAt = existing.CreatedAt
+		}
+		if sub.ClosedAt == "" {
+			sub.ClosedAt = existing.ClosedAt
+		}
+		if sub.UpdatedAt == "" {
+			sub.UpdatedAt = existing.UpdatedAt
+		}
+		merged := sub
+		merged.UpdatedAt = existing.UpdatedAt
+		if reflect.DeepEqual(existing, merged) {
+			return nil // only UpdatedAt would change; skip the churn
+		}
+	}
+	line, err := json.Marshal(sub)
+	if err != nil {
+		return err
+	}
+	if _, err := s.subjectsLog.Write(append(line, '\n')); err != nil {
+		return fmt.Errorf("appending subject: %w", err)
+	}
+	if err := s.subjectsLog.Sync(); err != nil {
+		return fmt.Errorf("syncing subjects log: %w", err)
+	}
+	s.subjects[sub.Key] = sub
 	return nil
 }
 
@@ -205,7 +277,7 @@ func (s *Store) List(f ListFilter) []UsageRecord {
 // (they appear in the workflow rollups instead).
 func (s *Store) RollupByIssue(repo string) []Rollup {
 	wfIssues := s.workflowIssueSet(repo)
-	return s.rollup(repo, func(rec UsageRecord) []string {
+	return s.rollup(repo, "issue", func(rec UsageRecord) []string {
 		if recordInWorkflow(rec, wfIssues) {
 			return nil
 		}
@@ -230,12 +302,28 @@ func (s *Store) RollupByIssue(repo string) []Rollup {
 // rollups instead).
 func (s *Store) RollupByPR(repo string) []Rollup {
 	wfIssues := s.workflowIssueSet(repo)
-	return s.rollup(repo, func(rec UsageRecord) []string {
+	return s.rollup(repo, "pr", func(rec UsageRecord) []string {
 		if rec.PR == 0 || recordInWorkflow(rec, wfIssues) || recordTouchesAnyIssue(rec) {
 			return nil
 		}
 		return []string{strconv.Itoa(rec.PR)}
 	})
+}
+
+// RollupByDay groups all records by the day (UTC date of RecordedAt, which
+// is when the task's usage was first pushed), newest day first.
+func (s *Store) RollupByDay(repo string) []Rollup {
+	out := s.rollup(repo, "", func(rec UsageRecord) []string {
+		if len(rec.RecordedAt) < 10 {
+			return []string{"unknown"}
+		}
+		return []string{rec.RecordedAt[:10]}
+	})
+	// rollup sorts ascending; days read better newest first.
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	return out
 }
 
 // workflowIssueSet returns the issue numbers owned by a workflow session
@@ -336,8 +424,22 @@ func (s *Store) WorkflowRollup(repo, session string, includeRecords bool) *Rollu
 	if r.TaskCount == 0 {
 		return nil
 	}
+	// A workflow session "issue-N" is subject issue-N.
+	s.attachSubjectLocked(&r, session)
 	sortRollup(&r)
 	return &r
+}
+
+// attachSubjectLocked copies subject metadata onto a rollup; the caller must
+// hold s.mu.
+func (s *Store) attachSubjectLocked(r *Rollup, subjectKey string) {
+	sub, ok := s.subjects[subjectKey]
+	if !ok {
+		return
+	}
+	r.State = sub.State
+	r.CreatedAt = sub.CreatedAt
+	r.ClosedAt = sub.ClosedAt
 }
 
 // workflowSessionIssue parses "issue-N" session ids; returns 0 otherwise.
@@ -353,7 +455,10 @@ func workflowSessionIssue(session string) int {
 	return n
 }
 
-func (s *Store) rollup(repo string, keysFor func(UsageRecord) []string) []Rollup {
+// rollup groups records by the keys keysFor yields. When subjectKind is
+// non-empty, each group is joined with the subject "<subjectKind>-<key>" to
+// expose state and age timestamps.
+func (s *Store) rollup(repo string, subjectKind string, keysFor func(UsageRecord) []string) []Rollup {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	groups := map[string]*Rollup{}
@@ -373,6 +478,9 @@ func (s *Store) rollup(repo string, keysFor func(UsageRecord) []string) []Rollup
 	}
 	out := make([]Rollup, 0, len(groups))
 	for _, g := range groups {
+		if subjectKind != "" {
+			s.attachSubjectLocked(g, subjectKind+"-"+g.Key)
+		}
 		sortRollup(g)
 		out = append(out, *g)
 	}
@@ -443,9 +551,13 @@ func (s *Store) MarkSummarized(session string) (alreadyPosted bool, err error) {
 	return false, nil
 }
 
-// Close closes the append log.
+// Close closes the append logs.
 func (s *Store) Close() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.log.Close()
+	err := s.log.Close()
+	if err2 := s.subjectsLog.Close(); err == nil {
+		err = err2
+	}
+	return err
 }

--- a/factory/pkg/tokenusage/store_test.go
+++ b/factory/pkg/tokenusage/store_test.go
@@ -181,6 +181,107 @@ func TestRollups(t *testing.T) {
 	}
 }
 
+func TestPutPreservesFirstRecordedAt(t *testing.T) {
+	s, _ := newTestStore(t)
+	rec := UsageRecord{
+		Key: "sb:/workspaces/tasks/fix-1", Repo: "org/repo", RecordedAt: "2026-07-13T10:00:00Z",
+		Stats: statsFor("m", 1, 1, 2),
+	}
+	mustPut(t, s, rec)
+	// Sweep re-post with a later timestamp but identical stats: must be a
+	// no-op keeping the original day bucket.
+	rec.RecordedAt = "2026-07-15T10:00:00Z"
+	mustPut(t, s, rec)
+	got := s.List(ListFilter{})[0]
+	if got.RecordedAt != "2026-07-13T10:00:00Z" {
+		t.Errorf("expected first RecordedAt preserved, got %s", got.RecordedAt)
+	}
+	// Updated stats still keep the original timestamp.
+	rec.Stats = statsFor("m", 2, 2, 4)
+	rec.RecordedAt = "2026-07-16T10:00:00Z"
+	mustPut(t, s, rec)
+	got = s.List(ListFilter{})[0]
+	if got.RecordedAt != "2026-07-13T10:00:00Z" || got.Stats.Models["m"].Tokens.Total != 4 {
+		t.Errorf("expected updated stats with original RecordedAt, got %+v", got)
+	}
+}
+
+func TestRollupByDay(t *testing.T) {
+	s, _ := newTestStore(t)
+	mustPut(t, s, UsageRecord{Key: "a:1", Repo: "org/repo", RecordedAt: "2026-07-13T10:00:00Z", Stats: statsFor("m", 10, 5, 15)})
+	mustPut(t, s, UsageRecord{Key: "b:1", Repo: "org/repo", RecordedAt: "2026-07-13T23:59:00Z", Stats: statsFor("m", 1, 1, 2)})
+	mustPut(t, s, UsageRecord{Key: "c:1", Repo: "org/repo", RecordedAt: "2026-07-14T00:01:00Z", Stats: statsFor("m", 3, 3, 6)})
+
+	days := s.RollupByDay("org/repo")
+	if len(days) != 2 {
+		t.Fatalf("expected 2 days, got %+v", days)
+	}
+	// Newest day first.
+	if days[0].Key != "2026-07-14" || days[1].Key != "2026-07-13" {
+		t.Errorf("expected newest-first days, got %s, %s", days[0].Key, days[1].Key)
+	}
+	if days[1].TaskCount != 2 || days[1].Stats.Models["m"].Tokens.Total != 17 {
+		t.Errorf("2026-07-13 rollup: got %+v", days[1])
+	}
+	if len(days[0].Records) != 1 {
+		t.Errorf("expected records in daily rollup, got %+v", days[0])
+	}
+}
+
+func TestSubjects(t *testing.T) {
+	s, dir := newTestStore(t)
+	mustPut(t, s, UsageRecord{Key: "fix-55:t1", Repo: "org/repo", Issue: 55, PR: 200, Stats: statsFor("m", 1, 1, 2)})
+	mustPut(t, s, UsageRecord{Key: "wf-42:t1", Repo: "org/repo", Issue: 42, Workflow: "issue-42", Stats: statsFor("m", 1, 1, 2)})
+
+	if err := s.PutSubject(Subject{
+		Key: "issue-55", Repo: "org/repo", Kind: "issue", Number: 55,
+		State: "open", CreatedAt: "2026-07-10T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("PutSubject: %v", err)
+	}
+	// Later "closed" update without createdAt must keep the creation time.
+	if err := s.PutSubject(Subject{
+		Key: "issue-55", State: "closed", ClosedAt: "2026-07-14T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("PutSubject update: %v", err)
+	}
+	if err := s.PutSubject(Subject{
+		Key: "issue-42", Kind: "issue", Number: 42, State: "open", CreatedAt: "2026-07-01T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("PutSubject wf: %v", err)
+	}
+	if err := s.PutSubject(Subject{Key: ""}); err == nil {
+		t.Error("expected error for empty subject key")
+	}
+
+	issues := s.RollupByIssue("org/repo")
+	if len(issues) != 1 || issues[0].Key != "55" {
+		t.Fatalf("issue rollup: got %+v", issues)
+	}
+	if issues[0].State != "closed" || issues[0].CreatedAt != "2026-07-10T00:00:00Z" || issues[0].ClosedAt != "2026-07-14T00:00:00Z" {
+		t.Errorf("issue rollup subject join: got %+v", issues[0])
+	}
+
+	wfs := s.RollupByWorkflow("org/repo")
+	if len(wfs) != 1 || wfs[0].State != "open" || wfs[0].CreatedAt != "2026-07-01T00:00:00Z" {
+		t.Errorf("workflow rollup subject join: got %+v", wfs)
+	}
+
+	// Subjects persist across restart.
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	s2, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = s2.Close() }()
+	issues = s2.RollupByIssue("org/repo")
+	if len(issues) != 1 || issues[0].State != "closed" || issues[0].CreatedAt != "2026-07-10T00:00:00Z" {
+		t.Errorf("subject replay: got %+v", issues)
+	}
+}
+
 func TestMarkSummarized(t *testing.T) {
 	s, dir := newTestStore(t)
 	already, err := s.MarkSummarized("issue-42")

--- a/factory/pkg/tokenusage/types.go
+++ b/factory/pkg/tokenusage/types.go
@@ -24,6 +24,8 @@ limitations under the License.
 // the token-usage.json files written by the task scripts in factory/pkg/tasks.
 package tokenusage
 
+import "fmt"
+
 // Stats captures accumulated usage statistics from LLM invocations,
 // keyed by model name.
 type Stats struct {
@@ -76,16 +78,44 @@ type UsageRecord struct {
 }
 
 // Rollup is an aggregate of usage records grouped by some key
-// (issue number, PR number, or workflow session).
+// (issue number, PR number, workflow session, or day).
 type Rollup struct {
-	Key          string        `json:"key"`
-	Repo         string        `json:"repo,omitempty"`
-	WorkflowName string        `json:"workflowName,omitempty"`
-	TaskCount    int           `json:"taskCount"`
-	Issues       []int         `json:"issues,omitempty"`
-	PRs          []int         `json:"prs,omitempty"`
-	Stats        Stats         `json:"stats"`
-	Records      []UsageRecord `json:"records,omitempty"` // only in detail responses
+	Key          string `json:"key"`
+	Repo         string `json:"repo,omitempty"`
+	WorkflowName string `json:"workflowName,omitempty"`
+	TaskCount    int    `json:"taskCount"`
+	Issues       []int  `json:"issues,omitempty"`
+	PRs          []int  `json:"prs,omitempty"`
+
+	// Subject metadata (joined from the matching Subject, when reported):
+	// GitHub state and timestamps of the underlying issue/PR, used to show
+	// age and open/closed status.
+	State     string `json:"state,omitempty"` // "open" | "closed"
+	CreatedAt string `json:"createdAt,omitempty"`
+	ClosedAt  string `json:"closedAt,omitempty"`
+
+	Stats   Stats         `json:"stats"`
+	Records []UsageRecord `json:"records,omitempty"`
+}
+
+// Subject tracks GitHub metadata of an entity that usage is attributed to
+// (an issue or a PR): open/closed state and creation/close timestamps.
+// Producers upsert subjects alongside usage records; rollups join on the
+// subject key to expose age and status.
+type Subject struct {
+	Key       string `json:"key"` // "issue-<n>" or "pr-<n>"
+	Repo      string `json:"repo,omitempty"`
+	Kind      string `json:"kind"` // "issue" | "pr"
+	Number    int    `json:"number"`
+	State     string `json:"state,omitempty"`     // "open" | "closed"
+	CreatedAt string `json:"createdAt,omitempty"` // RFC3339, GitHub creation time
+	ClosedAt  string `json:"closedAt,omitempty"`  // RFC3339, set once closed
+	UpdatedAt string `json:"updatedAt,omitempty"` // RFC3339, last upsert
+}
+
+// SubjectKey builds the canonical subject key for a kind and number.
+func SubjectKey(kind string, number int) string {
+	return fmt.Sprintf("%s-%d", kind, number)
 }
 
 // MergeStats accumulates src into dst per model.

--- a/factory/pkg/usagereport/report.go
+++ b/factory/pkg/usagereport/report.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/envd"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/tokenusage"
 )
 
 const requestTimeout = 5 * time.Second
@@ -82,17 +83,77 @@ func ReadTaskUsage(ctx context.Context, client *envd.Client, taskDir string) (*S
 
 // Publish upserts a usage record in the collector.
 func Publish(ctx context.Context, rec UsageRecord) error {
+	return postJSON(ctx, "/v1/usage", rec)
+}
+
+// PublishSubject upserts issue/PR metadata (state, timestamps) in the
+// collector, which joins it onto rollups to expose age and status.
+func PublishSubject(ctx context.Context, sub Subject) error {
+	return postJSON(ctx, "/v1/subjects", sub)
+}
+
+// ReportIssueSubject publishes an issue's state and timestamps.
+// Best-effort: no-op when disabled or issue is nil; failures are logged.
+func ReportIssueSubject(ctx context.Context, repo string, issue *githubv39.Issue) {
+	if !Enabled() || issue == nil || issue.GetNumber() == 0 {
+		return
+	}
+	sub := Subject{
+		Key:       tokenusage.SubjectKey("issue", issue.GetNumber()),
+		Repo:      repo,
+		Kind:      "issue",
+		Number:    issue.GetNumber(),
+		State:     issue.GetState(),
+		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	if t := issue.GetCreatedAt(); !t.IsZero() {
+		sub.CreatedAt = t.UTC().Format(time.RFC3339)
+	}
+	if t := issue.GetClosedAt(); !t.IsZero() {
+		sub.ClosedAt = t.UTC().Format(time.RFC3339)
+	}
+	if err := PublishSubject(ctx, sub); err != nil {
+		klog.Warningf("usagereport: publishing subject %s: %v", sub.Key, err)
+	}
+}
+
+// ReportPRSubject publishes a PR's state and timestamps.
+// Best-effort: no-op when disabled or pr is nil; failures are logged.
+func ReportPRSubject(ctx context.Context, repo string, pr *githubv39.PullRequest) {
+	if !Enabled() || pr == nil || pr.GetNumber() == 0 {
+		return
+	}
+	sub := Subject{
+		Key:       tokenusage.SubjectKey("pr", pr.GetNumber()),
+		Repo:      repo,
+		Kind:      "pr",
+		Number:    pr.GetNumber(),
+		State:     pr.GetState(),
+		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	if t := pr.GetCreatedAt(); !t.IsZero() {
+		sub.CreatedAt = t.UTC().Format(time.RFC3339)
+	}
+	if t := pr.GetClosedAt(); !t.IsZero() {
+		sub.ClosedAt = t.UTC().Format(time.RFC3339)
+	}
+	if err := PublishSubject(ctx, sub); err != nil {
+		klog.Warningf("usagereport: publishing subject %s: %v", sub.Key, err)
+	}
+}
+
+func postJSON(ctx context.Context, path string, v any) error {
 	base := collectorURL()
 	if base == "" {
 		return nil
 	}
-	body, err := json.Marshal(rec)
+	body, err := json.Marshal(v)
 	if err != nil {
 		return err
 	}
 	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, base+"/v1/usage", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, base+path, bytes.NewReader(body))
 	if err != nil {
 		return err
 	}

--- a/factory/pkg/usagereport/types.go
+++ b/factory/pkg/usagereport/types.go
@@ -32,4 +32,5 @@ type (
 	TokenUsage  = tokenusage.TokenUsage
 	UsageRecord = tokenusage.UsageRecord
 	Rollup      = tokenusage.Rollup
+	Subject     = tokenusage.Subject
 )

--- a/repo-agent/review-ui/ui/src/TokenUsage.js
+++ b/repo-agent/review-ui/ui/src/TokenUsage.js
@@ -46,7 +46,30 @@ const TokenHeaderCells = () => (
     </>
 );
 
-const RollupTable = ({ title, subtitle, rollups, keyLabel, renderKey }) => {
+// Age of the subject: creation to close (if closed) or to now (if open).
+const ageOf = (r) => {
+    if (!r.createdAt) return '-';
+    const end = r.closedAt ? new Date(r.closedAt) : new Date();
+    const diffMs = end - new Date(r.createdAt);
+    if (isNaN(diffMs) || diffMs < 0) return '-';
+    const hours = Math.floor(diffMs / 3600000);
+    const days = Math.floor(hours / 24);
+    return days > 0 ? `${days}d ${hours % 24}h` : `${hours}h`;
+};
+
+const StatusBadge = ({ state }) => {
+    if (!state) return <span style={{ color: 'var(--text-secondary)' }}>-</span>;
+    const isOpen = state === 'open';
+    return (
+        <span style={{
+            padding: '2px 10px', borderRadius: '12px', fontSize: '12px', fontWeight: '600',
+            backgroundColor: isOpen ? 'rgba(35, 134, 54, 0.15)' : 'rgba(130, 80, 223, 0.15)',
+            color: isOpen ? '#2da44e' : '#8250df',
+        }}>{state}</span>
+    );
+};
+
+const RollupTable = ({ title, subtitle, rollups, keyLabel, renderKey, showSubject }) => {
     const [expanded, setExpanded] = useState(null);
     return (
         <div style={{ backgroundColor: 'var(--bg-card)', borderRadius: '8px', boxShadow: 'var(--shadow-card)', padding: '16px', marginBottom: '24px' }}>
@@ -59,6 +82,8 @@ const RollupTable = ({ title, subtitle, rollups, keyLabel, renderKey }) => {
                     <thead>
                         <tr>
                             <th style={thStyle}>{keyLabel}</th>
+                            {showSubject && <th style={thStyle}>Status</th>}
+                            {showSubject && <th style={{ ...thStyle, textAlign: 'right' }}>Age</th>}
                             <th style={{ ...thStyle, textAlign: 'right' }}>Tasks</th>
                             <TokenHeaderCells />
                         </tr>
@@ -75,14 +100,17 @@ const RollupTable = ({ title, subtitle, rollups, keyLabel, renderKey }) => {
                                             <span style={{ marginRight: '6px' }}>{isOpen ? '▾' : '▸'}</span>
                                             {renderKey ? renderKey(r) : r.key}
                                         </td>
+                                        {showSubject && <td style={tdStyle}><StatusBadge state={r.state} /></td>}
+                                        {showSubject && <td style={{ ...numStyle, whiteSpace: 'nowrap' }} title={r.createdAt ? `created ${r.createdAt}${r.closedAt ? `, closed ${r.closedAt}` : ''}` : ''}>{ageOf(r)}</td>}
                                         <td style={numStyle}>{fmt(r.taskCount)}</td>
                                         <TokenCells s={s} />
                                     </tr>
                                     {isOpen && (r.records || []).map(rec => (
                                         <tr key={rec.key} style={{ backgroundColor: 'var(--bg-comment-card)' }}>
-                                            <td style={{ ...tdStyle, paddingLeft: '36px', fontSize: '13px' }}>
+                                            <td style={{ ...tdStyle, paddingLeft: '36px', fontSize: '13px' }} colSpan={showSubject ? 3 : 1}>
                                                 {rec.taskType || '-'} · {rec.sandbox || '-'}
                                                 {rec.pr ? ` · PR #${rec.pr}` : ''}{rec.issue ? ` · issue #${rec.issue}` : ''}
+                                                {rec.recordedAt ? ` · ${rec.recordedAt.slice(0, 10)}` : ''}
                                             </td>
                                             <td style={numStyle}>-</td>
                                             <TokenCells s={sumStats(rec.stats)} />
@@ -101,6 +129,7 @@ const RollupTable = ({ title, subtitle, rollups, keyLabel, renderKey }) => {
 const prList = (prs) => (prs || []).map(n => `#${n}`).join(', ');
 
 const TokenUsage = ({ onBack }) => {
+    const [daily, setDaily] = useState([]);
     const [workflows, setWorkflows] = useState([]);
     const [issues, setIssues] = useState([]);
     const [prs, setPRs] = useState([]);
@@ -126,6 +155,7 @@ const TokenUsage = ({ onBack }) => {
                 });
 
         Promise.all([
+            get('v1/usage/rollups/daily', setDaily),
             get('v1/usage/rollups/workflows', setWorkflows),
             get('v1/usage/rollups/issues', setIssues),
             get('v1/usage/rollups/prs', setPRs),
@@ -155,11 +185,18 @@ const TokenUsage = ({ onBack }) => {
             )}
 
             <RollupTable
+                title="Daily Usage"
+                subtitle="All usage grouped by the day it was first recorded (UTC)."
+                rollups={daily}
+                keyLabel="Date"
+            />
+            <RollupTable
                 title="Workflow Issues"
                 subtitle="Workflow sandboxes (wf-issue-*), including all tasks and PRs spawned by the workflow."
                 rollups={workflows}
                 keyLabel="Workflow"
                 renderKey={r => `${r.workflowName ? `${r.workflowName} · ` : ''}${r.key}${r.prs?.length ? ` (PRs: ${prList(r.prs)})` : ''}`}
+                showSubject
             />
             <RollupTable
                 title="Issue / PR Sandboxes"
@@ -167,6 +204,7 @@ const TokenUsage = ({ onBack }) => {
                 rollups={issues}
                 keyLabel="Issue"
                 renderKey={r => `#${r.key}${r.prs?.length ? ` / PR ${prList(r.prs)}` : ''}`}
+                showSubject
             />
             <RollupTable
                 title="PR Sandboxes"
@@ -174,6 +212,7 @@ const TokenUsage = ({ onBack }) => {
                 rollups={prs}
                 keyLabel="Pull Request"
                 renderKey={r => `#${r.key}`}
+                showSubject
             />
         </div>
     );


### PR DESCRIPTION
Add a Subject entity (issue-<n>/pr-<n>) storing GitHub state, createdAt and closedAt in a subjects.jsonl append log. Task hooks push open-state subjects (fix/pr/review/agent commands), and the watch-loop cleanup functions push closed state with the close time. Merge semantics never blank known fields. Rollups join on the subject key so the dashboard shows open/closed status and age per workflow, issue, and PR.

Add GET /v1/usage/rollups/daily grouping records by the UTC day of recordedAt; Put now preserves the first recordedAt across upserts so a sweep re-post cannot move usage to a later day.

Dashboard: new Daily Usage table plus Status and Age columns on the workflow/issue/PR tables, with record dates in the drill-down rows.