### PR TITLE
fix(watch): prevent false positive in isSandboxTaskRunning when sandbox has no task dir

### DIFF
--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -249,7 +249,9 @@ func isSandboxTaskRunning(ctx context.Context, kubeClient *clients.KubernetesCli
 			var buf bytes.Buffer
 			// Check exit_code of the latest task, and fallback to checking process viability via PID
 			checkCmd := `task_dir=$(ls -td /workspaces/tasks/* 2>/dev/null | head -1)
-			if [ -f "$task_dir/exit_code" ]; then
+			if [ -z "$task_dir" ]; then
+				echo "NOTASKS"
+			elif [ -f "$task_dir/exit_code" ]; then
 				cat "$task_dir/exit_code"
 			else
 				pid=$(cat "$task_dir/pid" 2>/dev/null)
@@ -259,7 +261,9 @@ func isSandboxTaskRunning(ctx context.Context, kubeClient *clients.KubernetesCli
 			fi`
 			if err := client.Exec(ctx, checkCmd, "/workspaces", nil, nil, &buf, nil); err == nil {
 				exitStr := strings.TrimSpace(buf.String())
-				if exitStr != "" {
+				if exitStr == "NOTASKS" {
+					return false, nil
+				} else if exitStr != "" {
 					// Task has finished!
 					taskState := "Completed"
 					if exitStr != "0" {

--- a/overseer/scripts/update-overseer-factory.sh
+++ b/overseer/scripts/update-overseer-factory.sh
@@ -39,7 +39,8 @@ while true; do
     
     for sb in $SB_NAMES; do
         STATE=$(kubectl get sandbox.agents.x-k8s.io "$sb" -n "$NAMESPACE" -o jsonpath='{.metadata.annotations.sandbox\.gemini\.google\.com/last-task-state}' 2>/dev/null || true)
-        if [ -z "$STATE" ] || [ "$STATE" = "Running" ]; then
+        REPLICAS=$(kubectl get sandbox.agents.x-k8s.io "$sb" -n "$NAMESPACE" -o jsonpath='{.spec.replicas}' 2>/dev/null || echo 0)
+        if [ "$STATE" = "Running" ] && [ "${REPLICAS:-0}" -gt 0 ]; then
             ACTIVE_COUNT=$((ACTIVE_COUNT + 1))
         fi
     done


### PR DESCRIPTION
- When a sandbox pod restarts or has empty /workspaces/tasks, checkCmd returned empty string and fell through to return true (running)
- Return false when no task directory exists so idle/restarted sandboxes accept scheduled PR tasks