### PR TITLE
fix(tasks): add HTTPS URL insteadOf fallback to setupGit across all task scripts

### DIFF
--- a/factory/pkg/tasks/address_feedback.sh
+++ b/factory/pkg/tasks/address_feedback.sh
@@ -66,7 +66,9 @@ EOF
     fi
 
     echo "running gh auth setup-git"
-    gh auth setup-git
+    gh auth setup-git || true
+    echo "configuring git url fallback"
+    git config --global url."https://${GH_USER}:${GITHUB_USER_TOKEN}@github.com/".insteadOf "https://github.com/"
 
     echo "Configuring global git ignore"
     git config --global core.excludesfile "${USER_HOME}/.gitignore_global"

--- a/factory/pkg/tasks/adopt.sh
+++ b/factory/pkg/tasks/adopt.sh
@@ -54,7 +54,9 @@ EOF
     fi
 
     echo "running gh auth setup-git"
-    gh auth setup-git
+    gh auth setup-git || true
+    echo "configuring git url fallback"
+    git config --global url."https://${GH_USER}:${GITHUB_USER_TOKEN}@github.com/".insteadOf "https://github.com/"
 
     echo "Configuring global git ignore"
     git config --global core.excludesfile "${USER_HOME}/.gitignore_global"

--- a/factory/pkg/tasks/fix_issue.sh
+++ b/factory/pkg/tasks/fix_issue.sh
@@ -69,7 +69,9 @@ EOF
     fi
 
     echo "running gh auth setup-git"
-    gh auth setup-git
+    gh auth setup-git || true
+    echo "configuring git url fallback"
+    git config --global url."https://${GH_USER}:${GITHUB_USER_TOKEN}@github.com/".insteadOf "https://github.com/"
 
     echo "Configuring global git ignore"
     git config --global core.excludesfile "${USER_HOME}/.gitignore_global"

--- a/factory/pkg/tasks/investigate_failures.sh
+++ b/factory/pkg/tasks/investigate_failures.sh
@@ -67,7 +67,9 @@ EOF
     fi
 
     echo "running gh auth setup-git"
-    gh auth setup-git
+    gh auth setup-git || true
+    echo "configuring git url fallback"
+    git config --global url."https://${GH_USER}:${GITHUB_USER_TOKEN}@github.com/".insteadOf "https://github.com/"
 
     echo "Configuring global git ignore"
     git config --global core.excludesfile "${USER_HOME}/.gitignore_global"

--- a/factory/pkg/tasks/iterate.sh
+++ b/factory/pkg/tasks/iterate.sh
@@ -75,7 +75,9 @@ EOF
     fi
 
     echo "running gh auth setup-git"
-    gh auth setup-git
+    gh auth setup-git || true
+    echo "configuring git url fallback"
+    git config --global url."https://${GH_USER}:${GITHUB_USER_TOKEN}@github.com/".insteadOf "https://github.com/"
 
     echo "Configuring global git ignore"
     git config --global core.excludesfile /root/.gitignore_global

--- a/factory/pkg/tasks/review.sh
+++ b/factory/pkg/tasks/review.sh
@@ -62,7 +62,9 @@ EOF
     fi
 
     echo "running gh auth setup-git"
-    gh auth setup-git
+    gh auth setup-git || true
+    echo "configuring git url fallback"
+    git config --global url."https://${GH_USER}:${GITHUB_USER_TOKEN}@github.com/".insteadOf "https://github.com/"
 
     echo "Configuring global git ignore"
     git config --global core.excludesfile /root/.gitignore_global

--- a/factory/pkg/tasks/run_agent.sh
+++ b/factory/pkg/tasks/run_agent.sh
@@ -67,7 +67,9 @@ EOF
     fi
 
     echo "running gh auth setup-git"
-    gh auth setup-git
+    gh auth setup-git || true
+    echo "configuring git url fallback"
+    git config --global url."https://${GH_USER}:${GITHUB_USER_TOKEN}@github.com/".insteadOf "https://github.com/"
 
     echo "Configuring git pull rebase"
     git config --global pull.rebase true

--- a/repo-agent/pkg/tasks/address_feedback.sh
+++ b/repo-agent/pkg/tasks/address_feedback.sh
@@ -74,7 +74,9 @@ EOF
     fi
 
     echo "running gh auth setup-git"
-    gh auth setup-git
+    gh auth setup-git || true
+    echo "configuring git url fallback"
+    git config --global url."https://${GH_USER}:${GITHUB_USER_TOKEN}@github.com/".insteadOf "https://github.com/"
 
     echo "Configuring global git ignore"
     git config --global core.excludesfile /root/.gitignore_global

--- a/repo-agent/pkg/tasks/chore.sh
+++ b/repo-agent/pkg/tasks/chore.sh
@@ -65,7 +65,9 @@ EOF
         git config --global user.name "${GITHUB_USER_NAME}"
     fi
 
-    gh auth setup-git
+    gh auth setup-git || true
+    echo "configuring git url fallback"
+    git config --global url."https://${GH_USER}:${GITHUB_USER_TOKEN}@github.com/".insteadOf "https://github.com/"
 }
 
 function setupGitRepos {

--- a/repo-agent/pkg/tasks/dev_setup.sh
+++ b/repo-agent/pkg/tasks/dev_setup.sh
@@ -50,7 +50,9 @@ EOF
     git config --global user.name "${GITHUB_USER_NAME}"
 
     echo "running gh auth setup-git"
-    gh auth setup-git
+    gh auth setup-git || true
+    echo "configuring git url fallback"
+    git config --global url."https://${GH_USER}:${GITHUB_USER_TOKEN}@github.com/".insteadOf "https://github.com/"
 
     echo "Configuring global git ignore"
     git config --global core.excludesfile /root/.gitignore_global

--- a/repo-agent/pkg/tasks/fix_issue.sh
+++ b/repo-agent/pkg/tasks/fix_issue.sh
@@ -75,7 +75,9 @@ EOF
     fi
 
     echo "running gh auth setup-git"
-    gh auth setup-git
+    gh auth setup-git || true
+    echo "configuring git url fallback"
+    git config --global url."https://${GH_USER}:${GITHUB_USER_TOKEN}@github.com/".insteadOf "https://github.com/"
 
     echo "Configuring global git ignore"
     git config --global core.excludesfile /root/.gitignore_global

--- a/repo-agent/pkg/tasks/investigate_failures.sh
+++ b/repo-agent/pkg/tasks/investigate_failures.sh
@@ -73,7 +73,9 @@ EOF
     fi
 
     echo "running gh auth setup-git"
-    gh auth setup-git
+    gh auth setup-git || true
+    echo "configuring git url fallback"
+    git config --global url."https://${GH_USER}:${GITHUB_USER_TOKEN}@github.com/".insteadOf "https://github.com/"
 
     echo "Configuring global git ignore"
     git config --global core.excludesfile /root/.gitignore_global

--- a/repo-agent/pkg/tasks/iterate.sh
+++ b/repo-agent/pkg/tasks/iterate.sh
@@ -65,7 +65,9 @@ EOF
     fi
 
     echo "running gh auth setup-git"
-    gh auth setup-git
+    gh auth setup-git || true
+    echo "configuring git url fallback"
+    git config --global url."https://${GH_USER}:${GITHUB_USER_TOKEN}@github.com/".insteadOf "https://github.com/"
 
     if [ "${DISABLE_GITHUB_PROXY:-false}" != "true" ]; then
         if [ ! -f /usr/local/bin/gh ]; then

--- a/repo-agent/pkg/tasks/rollback.sh
+++ b/repo-agent/pkg/tasks/rollback.sh
@@ -52,7 +52,9 @@ EOF
         git config --global user.name "${GITHUB_USER_NAME}"
     fi
 
-    gh auth setup-git
+    gh auth setup-git || true
+    echo "configuring git url fallback"
+    git config --global url."https://${GH_USER}:${GITHUB_USER_TOKEN}@github.com/".insteadOf "https://github.com/"
 }
 
 function setupGitRepos {


### PR DESCRIPTION
- Configure git config --global url."https://${GH_USER}:${GITHUB_USER_TOKEN}@github.com/".insteadOf "https://github.com/" after gh auth setup-git
- Prevents Git authentication failures when Personal Access Tokens lack the read:org scope required by gh auth git-credential