### PR TITLE
feat(watch): automate PR reviews when CI passes

### DIFF
--- a/factory/design/pr-automated-review.md
+++ b/factory/design/pr-automated-review.md
@@ -1,0 +1,97 @@
+# Automated Pull Request Review Architecture & Design
+
+This document describes the design, lifecycle, and identity model for automated AI Pull Request code reviews within the `factory watch` orchestration daemon.
+
+---
+
+## 1. Overview & Motivation
+
+Pull Requests created by automated workflows (such as migration checklists in `.agents/workflows/kcc-example.txt`) or standalone issue-fix agents require rigorous, independent code review before human approval or merging.
+
+Rather than coupling review lifecycle loops into individual workflow scripts, the AI Factory uses a **Watch-Driven Automated Review** model combined with **Markdown-Bounded Contextual Hints**:
+- **Universal Triggering**: Every bot-created PR automatically receives a code review as soon as its Continuous Integration (CI) checks pass on the current HEAD SHA.
+- **Context-Aware Criteria (`## Review Instructions`)**: Workflows and PR authors can provide domain-specific review rules (such as `generate.sh` verification or round-trip fuzzer checklists) directly inside the PR description or its referenced parent Issue body.
+- **Identity Isolation**: Reviews are executed in a dedicated Kubernetes Sandbox Pod under a distinct **Reviewer Bot** identity (`reviewbot-robot`), maintaining separation of duties from the Coder Bot (`lovelace-coder-bot`, etc.).
+
+---
+
+## 2. End-to-End Lifecycle Flow
+
+```mermaid
+graph TD
+    A[Coder Bot Pushes Commit HEAD SHA] --> B[CI Checks Run]
+    B -->|Failure| C[Queue pr-investigate Task]
+    C -->|Coder Fixes CI| A
+    B -->|Success Green CI| D{Is HEAD SHA reviewed by Reviewer Bot?}
+    D -->|Yes| E{New Review Comments?}
+    D -->|No| F[Parse '## Review Instructions' from PR / Parent Issue Body]
+    F --> G[Queue pr-review Task with Instructions]
+    G --> H[Run Sandbox Pod: factory-pr-NUM-review as Reviewer Bot]
+    H --> I[Reviewer Bot Posts Review / Comments to GitHub]
+    I --> E
+    E -->|Yes| J[Queue pr-comments Task for Coder Bot]
+    J -->|Coder Pushes Fixes| A
+    E -->|No / Approved| K[PR Ready for Human LGTM / Merge]
+```
+
+---
+
+## 3. Review Instructions Specification (`## Review Instructions`)
+
+### A. Why Issue/PR Body Sections Over Labels
+- **Universal Compatibility**: Many repositories restrict arbitrary labels or limit label creation permissions. Issue/PR Markdown descriptions work across all repositories.
+- **Multi-Line & Structured**: Supports bulleted lists of files or raw text instructions without the 50-character limit of GitHub labels.
+- **Inheritance**: If a PR references a parent Issue (`Fixes #123`, `Closes #123`), review instructions defined in the parent Issue are automatically inherited.
+
+### B. Section Syntax & Parsing Rules
+The helper `ExtractReviewInstructions` (`factory/pkg/commands/review_instructions.go`) parses Markdown content following these rules:
+
+```markdown
+## Review Instructions
+- `.gemini/skills/generate-sh-checker/SKILL.md`
+- Ensure all exported functions have GoDoc comments.
+- `.gemini/skills/kcc-direct-controller-implementer/SKILL.md`
+
+### Sub-notes for Reviewer
+Pay special attention to field conversion accuracy.
+
+## Next Section
+```
+
+1. **Header Discovery**: Matches any line starting with `#` through `######` followed by `Review Instructions` (case-insensitive). Records heading level $L$ (number of `#` characters).
+2. **Multi-Line Span**: Reads all subsequent lines until it encounters any heading of equal or higher level (`#` up to $L$ `#`s). Sub-headings deeper than $L$ are retained inside the section.
+3. **Path & Bullet Cleanup**: Strips Markdown list prefixes (`- `, `* `, `1. `) and enclosing backticks around paths (e.g. `` `.gemini/skills/foo/SKILL.md` `` $\rightarrow$ `.gemini/skills/foo/SKILL.md`).
+4. **Resolution**:
+   - If an instruction matches a file path in the repository, `factory pr review` loads the file contents at `headSHA`.
+   - If an instruction is plain text, it is treated as direct prompt instructions.
+
+---
+
+## 4. Execution Sandbox & Reviewer Identity
+
+### A. Role Resolution (`selectUserForTask`)
+When `watch.go` dequeues a `pr-review` task, it routes execution through `selectUserForTask` (`factory/pkg/commands/watch.go:L2755`):
+```go
+case taskType == "pr-review":
+    role = "reviewer"
+```
+
+### B. Configured Reviewer User (`FactoryConfig.Roles["reviewer"].Users`)
+In the repository configuration (`overseer/examples/kcc.yaml`):
+```yaml
+roles:
+  reviewer:
+    users:
+      - reviewbot-robot
+  coder:
+    users:
+      - lovelace-coder-bot
+      - hopper-coder-bot
+      - ada-coder-bot
+```
+- `selectUserForTask` selects **`reviewbot-robot`** (or the repository's configured `reviewer` user pool).
+
+### C. Pod Execution & API Identity
+- `factory pr review` runs inside a dedicated Kubernetes Pod (`factory-pr-<num>-review`) in the configured namespace.
+- It mounts the onboarded Kubernetes secret for `reviewbot-robot`, containing that account's `GITHUB_TOKEN`.
+- All inline review comments, approvals (`APPROVED`), and change requests (`CHANGES_REQUESTED`) posted to GitHub are authored by **`reviewbot-robot`**.

--- a/factory/design/watch-design-note.md
+++ b/factory/design/watch-design-note.md
@@ -108,6 +108,11 @@ When processing a PR, the scan evaluates conditions and queues tasks in three ph
 * **Retry on Recovery**: If the previous investigation task is in `processed/` but has status `"Failed"` or if 6 hours have passed since the last investigation (`time.Since(lastInvestigatedTime) > 6*time.Hour`), the watcher queues a retry for `pr-investigate`.
 * **Assignment**: The bot user remains assigned to the PR while tasks are executing or pending.
 
+### Phase 4: Automated Code Review (`pr-review`)
+* **Trigger**: CI checks are passing (`!hasFailure && !isConflicting`), PR is not yet approved (`!isApproved`), no new unaddressed comments exist (`!hasNewComments`), and the current `HEAD SHA` has not yet been reviewed by the Reviewer Bot identity (`state.lastReviewedSHA != headSHA`).
+* **Contextual Instructions**: Parses the PR description and any referenced parent Issue body for a `## Review Instructions` section (`ExtractReviewInstructions`) and passes them via `--instruction <path>`.
+* **Identity Selection**: Routes to a user in the `reviewer` pool (e.g., `reviewbot-robot`), executing inside a dedicated Sandbox Pod (`factory-pr-<num>-review`). See detailed architecture in [pr-automated-review.md](file:///usr/local/google/home/barni/workspace/src/github.com/barney-s/gemini-for-kubernetes-development/factory/design/pr-automated-review.md).
+
 ---
 
 ## 7. Identity & Assignee Resolution (`selectUserForTask`)

--- a/factory/pkg/commands/review_instructions.go
+++ b/factory/pkg/commands/review_instructions.go
@@ -1,0 +1,82 @@
+package commands
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	reviewHeaderRe = regexp.MustCompile(`(?i)^(#{1,6})\s+Review\s+Instructions\s*$`)
+	listPrefixRe   = regexp.MustCompile(`^(?:[-*]|\d+\.)\s+`)
+)
+
+// ExtractReviewInstructions parses one or more markdown bodies (e.g. PR description, parent Issue body)
+// and returns all lines under a "#/## Review Instructions" section up until the next heading of equal or higher level.
+func ExtractReviewInstructions(bodies ...string) []string {
+	for _, body := range bodies {
+		instructions := parseReviewInstructionsSection(body)
+		if len(instructions) > 0 {
+			return instructions
+		}
+	}
+	return nil
+}
+
+func parseReviewInstructionsSection(body string) []string {
+	if strings.TrimSpace(body) == "" {
+		return nil
+	}
+
+	lines := strings.Split(body, "\n")
+	var instructions []string
+	inSection := false
+	sectionLevel := 0
+
+	for _, rawLine := range lines {
+		line := strings.TrimSpace(rawLine)
+
+		if !inSection {
+			if m := reviewHeaderRe.FindStringSubmatch(line); m != nil {
+				inSection = true
+				sectionLevel = len(m[1]) // number of '#' characters
+			}
+			continue
+		}
+
+		// Check if we hit a heading of equal or higher level (# up to sectionLevel)
+		if strings.HasPrefix(line, "#") {
+			hashes := 0
+			for _, ch := range line {
+				if ch == '#' {
+					hashes++
+				} else {
+					break
+				}
+			}
+			// If followed by space and heading level <= sectionLevel, terminate section
+			if hashes <= sectionLevel && len(line) > hashes && (line[hashes] == ' ' || line[hashes] == '\t') {
+				break
+			}
+		}
+
+		if line == "" || strings.HasPrefix(line, "<!--") {
+			continue
+		}
+
+		// Strip list bullet prefixes ('- ', '* ', '1. ')
+		cleaned := listPrefixRe.ReplaceAllString(line, "")
+		cleaned = strings.TrimSpace(cleaned)
+
+		// Strip enclosing backticks around file paths (`.gemini/...`)
+		if strings.HasPrefix(cleaned, "`") && strings.HasSuffix(cleaned, "`") && len(cleaned) >= 2 {
+			cleaned = cleaned[1 : len(cleaned)-1]
+			cleaned = strings.TrimSpace(cleaned)
+		}
+
+		if cleaned != "" {
+			instructions = append(instructions, cleaned)
+		}
+	}
+
+	return instructions
+}

--- a/factory/pkg/commands/review_instructions_test.go
+++ b/factory/pkg/commands/review_instructions_test.go
@@ -1,0 +1,85 @@
+package commands
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtractReviewInstructions(t *testing.T) {
+	tests := []struct {
+		name     string
+		bodies   []string
+		expected []string
+	}{
+		{
+			name:     "empty bodies",
+			bodies:   []string{"", "   "},
+			expected: nil,
+		},
+		{
+			name: "single PR body with review instructions and terminating equal heading",
+			bodies: []string{`# Overview
+Some description of the PR.
+
+## Review Instructions
+- '.gemini/skills/generate-sh-checker/SKILL.md'
+- Ensure all exported functions have GoDoc comments.
+- '.gemini/skills/kcc-direct-controller-implementer/SKILL.md'
+
+### Notes for Reviewer
+Pay special attention to the conversion logic in _types.go.
+
+## Testing Done
+- Ran make test
+`},
+			expected: []string{
+				"'.gemini/skills/generate-sh-checker/SKILL.md'",
+				"Ensure all exported functions have GoDoc comments.",
+				"'.gemini/skills/kcc-direct-controller-implementer/SKILL.md'",
+				"### Notes for Reviewer",
+				"Pay special attention to the conversion logic in _types.go.",
+			},
+		},
+		{
+			name: "backtick stripping around file path",
+			bodies: []string{`## Review Instructions
+- ` + "`" + `.gemini/skills/generate-sh-checker/SKILL.md` + "`" + `
+- Normal instruction line
+`},
+			expected: []string{
+				".gemini/skills/generate-sh-checker/SKILL.md",
+				"Normal instruction line",
+			},
+		},
+		{
+			name: "fallback to parent issue body when PR body has no section",
+			bodies: []string{
+				"PR body without section\nFixes #123",
+				"Parent issue body\n## Review Instructions\n- .gemini/skills/foo/SKILL.md",
+			},
+			expected: []string{
+				".gemini/skills/foo/SKILL.md",
+			},
+		},
+		{
+			name: "stops at higher level heading",
+			bodies: []string{`## Review Instructions
+- Rule 1
+# Major Section
+- Not included
+`},
+			expected: []string{
+				"Rule 1",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := ExtractReviewInstructions(tc.bodies...)
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Fatalf("ExtractReviewInstructions() = %#v, expected %#v", actual, tc.expected)
+			}
+		})
+	}
+}

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -351,20 +351,21 @@ func countRunningSandboxTasks(ctx context.Context, kubeClient *clients.Kubernete
 }
 
 type QueueTask struct {
-	Type        string    `yaml:"type"` // "issue-fix", "pr-investigate", "pr-comments", "pr-iterate", "pr-review", "agent-chore"
-	URL         string    `yaml:"url"`
-	Number      int       `yaml:"number"`
-	Priority    string    `yaml:"priority"` // "critical", "urgent", "important", "high", "medium", "low"
-	Phase       int       `yaml:"phase"`    // 1: Rebase/iterate, 2: Comments, 3: Investigate/Fix, 4: Chores
-	CreatedAt   time.Time `yaml:"createdAt"`
-	Assignee    string    `yaml:"assignee,omitempty"`
-	Status      string    `yaml:"status"` // "Pending", "Running", "Completed", "Failed"
-	Error       string    `yaml:"error,omitempty"`
-	AgentFile   string    `yaml:"agentFile,omitempty"` // For chore tasks
-	SessionID   string    `yaml:"sessionId,omitempty"` // For workflow sessions
-	CommitSHA   string    `yaml:"commitSHA,omitempty"`
-	Recovered   bool      `yaml:"recovered,omitempty"`
-	CompletedAt time.Time `yaml:"completedAt,omitempty"`
+	Type         string    `yaml:"type"` // "issue-fix", "pr-investigate", "pr-comments", "pr-iterate", "pr-review", "agent-chore"
+	URL          string    `yaml:"url"`
+	Number       int       `yaml:"number"`
+	Priority     string    `yaml:"priority"` // "critical", "urgent", "important", "high", "medium", "low"
+	Phase        int       `yaml:"phase"`    // 1: Rebase/iterate, 2: Comments, 3: Investigate/Fix, 4: Chores
+	CreatedAt    time.Time `yaml:"createdAt"`
+	Assignee     string    `yaml:"assignee,omitempty"`
+	Status       string    `yaml:"status"` // "Pending", "Running", "Completed", "Failed"
+	Error        string    `yaml:"error,omitempty"`
+	AgentFile    string    `yaml:"agentFile,omitempty"` // For chore tasks
+	SessionID    string    `yaml:"sessionId,omitempty"` // For workflow sessions
+	CommitSHA    string    `yaml:"commitSHA,omitempty"`
+	Instructions []string  `yaml:"instructions,omitempty"`
+	Recovered    bool      `yaml:"recovered,omitempty"`
+	CompletedAt  time.Time `yaml:"completedAt,omitempty"`
 }
 
 type ChoreRunState struct {
@@ -970,6 +971,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 		lastSHA                  string
 		lastInvestigatedTime     time.Time
 		lastCommentAddressedTime time.Time
+		lastReviewedSHA          string
 	}
 
 	processedIssues := make(map[int]time.Time)
@@ -1565,6 +1567,69 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 								}
 							}
 						}
+					} else if !hasFailure && !isApproved && state.lastReviewedSHA != headSHA {
+						hasBotReviewAfterLastCommit := false
+						for _, r := range reviews {
+							if shouldIgnoreUser(r.GetUser(), githubLogin, bots) && (r.GetSubmittedAt().After(lastCommitTime) || r.GetCommitID() == headSHA) {
+								hasBotReviewAfterLastCommit = true
+								break
+							}
+						}
+
+						if !hasBotReviewAfterLastCommit {
+							if os.Getenv("DRY_RUN") == "true" {
+								continue
+							}
+							filename := fmt.Sprintf("task-pr-%d-review.yaml", num)
+							if !taskExists(incomingDir, processingDir, filename) {
+								sandboxName := resolveSandboxName(ctx, kubeClient, ghClient, "pr-review", num, owner, repo)
+								running, err := isSandboxTaskRunning(ctx, kubeClient, rootFlags.Namespace, sandboxName)
+								if err != nil {
+									klog.Errorf("Failed to check if sandbox %s is running: %v", sandboxName, err)
+									continue
+								} else if running {
+									klog.Infof("Skipping PR #%d review because there is an in-flight sandbox %s.", num, sandboxName)
+								} else {
+									var bodies []string
+									if pr.GetBody() != "" {
+										bodies = append(bodies, pr.GetBody())
+									}
+									for refIssueNum := range getReferencedIssues(pr) {
+										refIssue, _, err := ghClient.Issues.Get(ctx, owner, repo, refIssueNum)
+										if err == nil && refIssue.GetBody() != "" {
+											bodies = append(bodies, refIssue.GetBody())
+										}
+									}
+									instructions := ExtractReviewInstructions(bodies...)
+
+									prURL := fmt.Sprintf("https://github.com/%s/%s/pull/%d", owner, repo, num)
+									task := &QueueTask{
+										Type:         "pr-review",
+										URL:          prURL,
+										Number:       num,
+										Priority:     getPRPriority(prIssue),
+										Phase:        2,
+										CreatedAt:    pr.GetCreatedAt(),
+										Status:       "Pending",
+										CommitSHA:    headSHA,
+										Instructions: instructions,
+									}
+
+									if dryRun {
+										fmt.Printf("[DRYRUN] Would queue review task for PR #%d: %s\n", num, prURL)
+									} else {
+										fmt.Printf("Queueing review task for PR #%d (Instructions: %d)...\n", num, len(instructions))
+										state.lastReviewedSHA = headSHA
+										processedPRs[num] = state
+										if err := writeTaskAtomically(incomingDir, filename, task); err != nil {
+											klog.Errorf("Failed to queue review task for PR #%d: %v", num, err)
+										} else {
+											writeTaskJournalEvent(queueDir, filename, task, "Created", 0)
+										}
+									}
+								}
+							}
+						}
 					}
 				}
 			}
@@ -2151,6 +2216,9 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 						args = []string{"pr", "iterate", "--pr-url", t.URL, "--prompt", "Please resolve merge conflicts in this PR by rebasing onto the latest master/main branch and resolving any conflicts that arise."}
 					case "pr-review":
 						args = []string{"pr", "review", "--pr-url", t.URL, "--publish", "yes"}
+						for _, inst := range t.Instructions {
+							args = append(args, "--instruction", inst)
+						}
 					case "agent-chore":
 						args = []string{"agent", "create", "--url", t.URL, "--agent", t.AgentFile}
 						if t.SessionID != "" {


### PR DESCRIPTION
- Add ExtractReviewInstructions helper to parse multi-line review instructions from PR descriptions and referenced parent issue bodies
- Support Markdown section parsing up to next heading of equal or higher level, stripping list bullets and enclosing backticks
- Automatically queue 'pr-review' task in watch loop when a PR has green CI, no open comments, and has not yet been reviewed on HEAD SHA
- Add design doc factory/design/pr-automated-review.md and update watch-design-note.md


- **Documentation**: Added comprehensive design document [`factory/design/pr-automated-review.md`](file:///usr/local/google/home/barni/workspace/src/github.com/barney-s/gemini-for-kubernetes-development/factory/design/pr-automated-review.md) and updated [`factory/design/watch-design-note.md`](file:///usr/local/google/home/barni/workspace/src/github.com/barney-s/gemini-for-kubernetes-development/factory/design/watch-design-note.md) with Phase 4 Automated Code Review.
- **Review Instructions Parser**: Implemented [`ExtractReviewInstructions`](file:///usr/local/google/home/barni/workspace/src/github.com/barney-s/gemini-for-kubernetes-development/factory/pkg/commands/review_instructions.go) and unit tests in [`review_instructions_test.go`](file:///usr/local/google/home/barni/workspace/src/github.com/barney-s/gemini-for-kubernetes-development/factory/pkg/commands/review_instructions_test.go) to parse `## Review Instructions` sections from PR descriptions and referenced Parent Issues.
- **Automated PR Review Queuing**: Integrated automatic `pr-review` task queuing in [`watch.go`](file:///usr/local/google/home/barni/workspace/src/github.com/barney-s/gemini-for-kubernetes-development/factory/pkg/commands/watch.go) when CI is green and the current `HEAD SHA` has not yet been reviewed by the Reviewer Bot identity.