### PR TITLE
fix(review): authenticate GitHub client with user token when posting review

### DIFF
--- a/factory/pkg/commands/review.go
+++ b/factory/pkg/commands/review.go
@@ -234,6 +234,10 @@ func runReview(ctx context.Context, prURL string, publishPolicy string, instruct
 	}
 	githubLogin := string(secret.Data[KeyGithubLogin])
 	githubEmail := string(secret.Data[KeyGithubEmail])
+	userToken := string(secret.Data[KeyGithubToken])
+	if userToken != "" {
+		ghClient = github.NewClientWithToken(ctx, userToken)
+	}
 
 	structuredParams := tasks.StructuredReviewParams{
 		PullRequest:  *pr,

--- a/factory/pkg/github/github.go
+++ b/factory/pkg/github/github.go
@@ -53,6 +53,15 @@ func NewClient(ctx context.Context) (*githubv39.Client, error) {
 	return githubv39.NewClient(tc), nil
 }
 
+// NewClientWithToken creates a new GitHub client using an explicit access token.
+func NewClientWithToken(ctx context.Context, token string) *githubv39.Client {
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: token},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+	return githubv39.NewClient(tc)
+}
+
 // ListAllIssueComments retrieves all comments for an issue or pull request handling pagination.
 func ListAllIssueComments(ctx context.Context, client *githubv39.Client, owner, repo string, num int) ([]*githubv39.IssueComment, error) {
 	var allComments []*githubv39.IssueComment


### PR DESCRIPTION
we were using the wrong (Watcher) bot credentials for posting review: 
https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/11621#pullrequestreview-4708303216