### PR TITLE
fix(watch): stop scheduling tasks mid-cycle if DO NOT PROCESS drain mode is active

### DIFF
--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -2078,6 +2078,10 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 			activeSandboxesInCycle := make(map[string]bool)
 
 			for _, item := range tasksToRun {
+				if isDoNotProcess(queueDir) {
+					klog.Infof("[DO NOT PROCESS] Drain mode detected during cycle execution. Stopping scheduling of remaining queued tasks.")
+					break
+				}
 				if actionsTaken >= maxActions {
 					fmt.Printf("Reached maximum actions limit (%d) for this cycle. Stopping execution.\n", maxActions)
 					break


### PR DESCRIPTION
Check isDoNotProcess inside the tasksToRun execution loop so that if drain mode is activated mid-cycle while processing queued tasks, the controller stops scheduling any remaining queued tasks immediately.