### PR TITLE
overseer: Fix pr review loop guardrails

### DIFF
--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -1475,12 +1475,12 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 					// Find the latest timestamp of any reply made by an allowlisted bot user
 					var latestBotReplyTime time.Time
 					for _, c := range comments {
-						if shouldIgnoreUser(c.GetUser(), githubLogin, bots) && c.GetCreatedAt().After(latestBotReplyTime) {
+						if isBotReply(c.GetUser(), githubLogin, bots) && c.GetCreatedAt().After(latestBotReplyTime) {
 							latestBotReplyTime = c.GetCreatedAt()
 						}
 					}
 					for _, r := range reviews {
-						if shouldIgnoreUser(r.GetUser(), githubLogin, bots) && r.GetSubmittedAt().After(latestBotReplyTime) {
+						if isBotReply(r.GetUser(), githubLogin, bots) && r.GetSubmittedAt().After(latestBotReplyTime) {
 							latestBotReplyTime = r.GetSubmittedAt()
 						}
 					}
@@ -1606,7 +1606,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 					} else if !hasFailure && !isApproved && state.lastReviewedSHA != headSHA && shouldAutoReviewPR(ctx, ghClient, owner, repo, pr, prIssue, triggerLabel) {
 						hasBotReviewAfterLastCommit := false
 						for _, r := range reviews {
-							if shouldIgnoreUser(r.GetUser(), githubLogin, bots) && (r.GetSubmittedAt().After(lastCommitTime) || r.GetCommitID() == headSHA) {
+							if isBotReply(r.GetUser(), githubLogin, bots) && (r.GetSubmittedAt().After(lastCommitTime) || r.GetCommitID() == headSHA) {
 								hasBotReviewAfterLastCommit = true
 								break
 							}
@@ -2563,6 +2563,22 @@ func isPRApprovedOrLGTM(pr *githubv39.PullRequest, prIssue *githubv39.Issue, rev
 	}
 
 	return hasApproved && !hasChangesRequested
+}
+
+func isBotReply(user *githubv39.User, githubLogin string, allowlistedBots []string) bool {
+	if user == nil {
+		return false
+	}
+	login := user.GetLogin()
+	if strings.EqualFold(login, githubLogin) {
+		return true
+	}
+	for _, b := range allowlistedBots {
+		if strings.EqualFold(login, b) {
+			return true
+		}
+	}
+	return shouldIgnoreUser(user, githubLogin, nil)
 }
 
 func shouldIgnoreUser(user *githubv39.User, githubLogin string, allowlistedBots []string) bool {

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -1486,6 +1486,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 					}
 
 					var unackCommentIDs []int64
+					var unackPRCommentIDs []int64
 					for _, c := range comments {
 						if shouldIgnoreUser(c.GetUser(), githubLogin, bots) {
 							continue
@@ -1540,7 +1541,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 									}
 									if rc.GetCreatedAt().After(lastCommitTime) && rc.GetCreatedAt().After(state.lastCommentAddressedTime) && rc.GetCreatedAt().After(latestBotReplyTime) {
 										hasNewComments = true
-										break
+										unackPRCommentIDs = append(unackPRCommentIDs, rc.GetID())
 									}
 								}
 							}
@@ -1592,6 +1593,9 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 									fmt.Printf("Queueing address-comments task for PR #%d...\n", num)
 									for _, cid := range unackCommentIDs {
 										addIssueCommentReaction(ctx, ghClient, owner, repo, cid, "eyes")
+									}
+									for _, cid := range unackPRCommentIDs {
+										addPullRequestCommentReaction(ctx, ghClient, owner, repo, cid, "eyes")
 									}
 									state.lastCommentAddressedTime = time.Now()
 									processedPRs[num] = state
@@ -2996,6 +3000,16 @@ func addIssueCommentReaction(ctx context.Context, ghClient *githubv39.Client, ow
 	_, _, err := ghClient.Reactions.CreateIssueCommentReaction(ctx, owner, repo, commentID, content)
 	if err != nil {
 		klog.Warningf("Failed to create reaction '%s' on comment %d: %v", content, commentID, err)
+	}
+}
+
+func addPullRequestCommentReaction(ctx context.Context, ghClient *githubv39.Client, owner, repo string, commentID int64, content string) {
+	if ghClient == nil {
+		return
+	}
+	_, _, err := ghClient.Reactions.CreatePullRequestCommentReaction(ctx, owner, repo, commentID, content)
+	if err != nil {
+		klog.Warningf("Failed to create reaction '%s' on PR comment %d: %v", content, commentID, err)
 	}
 }
 

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -1486,7 +1486,6 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 					}
 
 					var unackCommentIDs []int64
-					var unackPRCommentIDs []int64
 					for _, c := range comments {
 						if shouldIgnoreUser(c.GetUser(), githubLogin, bots) {
 							continue
@@ -1541,7 +1540,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 									}
 									if rc.GetCreatedAt().After(lastCommitTime) && rc.GetCreatedAt().After(state.lastCommentAddressedTime) && rc.GetCreatedAt().After(latestBotReplyTime) {
 										hasNewComments = true
-										unackPRCommentIDs = append(unackPRCommentIDs, rc.GetID())
+										break
 									}
 								}
 							}
@@ -1593,9 +1592,6 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 									fmt.Printf("Queueing address-comments task for PR #%d...\n", num)
 									for _, cid := range unackCommentIDs {
 										addIssueCommentReaction(ctx, ghClient, owner, repo, cid, "eyes")
-									}
-									for _, cid := range unackPRCommentIDs {
-										addPullRequestCommentReaction(ctx, ghClient, owner, repo, cid, "eyes")
 									}
 									state.lastCommentAddressedTime = time.Now()
 									processedPRs[num] = state
@@ -3000,16 +2996,6 @@ func addIssueCommentReaction(ctx context.Context, ghClient *githubv39.Client, ow
 	_, _, err := ghClient.Reactions.CreateIssueCommentReaction(ctx, owner, repo, commentID, content)
 	if err != nil {
 		klog.Warningf("Failed to create reaction '%s' on comment %d: %v", content, commentID, err)
-	}
-}
-
-func addPullRequestCommentReaction(ctx context.Context, ghClient *githubv39.Client, owner, repo string, commentID int64, content string) {
-	if ghClient == nil {
-		return
-	}
-	_, _, err := ghClient.Reactions.CreatePullRequestCommentReaction(ctx, owner, repo, commentID, content)
-	if err != nil {
-		klog.Warningf("Failed to create reaction '%s' on PR comment %d: %v", content, commentID, err)
 	}
 }
 


### PR DESCRIPTION
1. **Prevent Duplicate `address-comments` Runs After Coder Bot Replies**
   - **Problem**: When an allowlisted Coder Bot addressed review comments and replied on the PR, `overseer-kcc` ignored its reply timestamp because `shouldIgnoreUser` returned `false` for allowlisted bots. Consequently, `overseer-kcc` queued a duplicate `address-comments` task on the very next scan cycle.
   - **Fix**: Added the `isBotReply` helper function in `watch.go` so that replies posted by allowlisted Coder Bots or the Watcher Bot properly update `latestBotReplyTime`. Once a Coder Bot replies, `overseer-kcc` recognizes that comments up to that point have been handled.

2. **Prevent Duplicate Automated Re-Reviews on Unchanged Commits**
   - **Problem**: When evaluating whether a PR had already received an automated review on the latest commit (`headSHA`), `overseer-kcc` ignored reviews submitted by `reviewbot-robot` because `shouldIgnoreUser` returned `false` for allowlisted bots. This caused `overseer-kcc` to repeatedly queue automated review tasks on the same commit.
   - **Fix**: Updated the `hasBotReviewAfterLastCommit` check in `watch.go` to use `isBotReply`. Once `reviewbot-robot` submits a review on the current commit, `overseer-kcc` marks the commit as reviewed and stops queuing duplicate review tasks.