### PR TITLE
fix(watch): use QueueTask.CompletedAt for workflow cooldown checks

### DIFF
--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -655,8 +655,15 @@ func queueIssueTasks(ctx context.Context, ghClient *githubv39.Client, kubeClient
 		// Check if the workflow session already completed recently
 		processedPath := filepath.Join(processedDir, filename)
 		if info, err := os.Stat(processedPath); err == nil {
+			lastRunTime := info.ModTime()
+			if data, err := os.ReadFile(processedPath); err == nil {
+				var t QueueTask
+				if err := yaml.Unmarshal(data, &t); err == nil && !t.CompletedAt.IsZero() {
+					lastRunTime = t.CompletedAt
+				}
+			}
 			cooldown := getWorkflowCooldown(ctx, ghClient, owner, repo, workflowPath)
-			if time.Since(info.ModTime()) < cooldown {
+			if time.Since(lastRunTime) < cooldown {
 				continue
 			}
 		}

--- a/factory/pkg/commands/watch_test.go
+++ b/factory/pkg/commands/watch_test.go
@@ -1,10 +1,14 @@
 package commands
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	githubv39 "github.com/google/go-github/v39/github"
+	"sigs.k8s.io/yaml"
 )
 
 func TestShouldRunChoreAt(t *testing.T) {
@@ -233,3 +237,33 @@ func TestGetMissingLabelsForPR(t *testing.T) {
 		})
 	}
 }
+
+func TestWorkflowCooldownCompletedAt(t *testing.T) {
+	tempDir := t.TempDir()
+	processedPath := filepath.Join(tempDir, "task-workflow-test-issue-1.yaml")
+
+	// Task completed 5 hours ago
+	completedAt := time.Now().Add(-5 * time.Hour)
+	taskYAML := fmt.Sprintf("completedAt: %s\n", completedAt.Format(time.RFC3339Nano))
+	if err := os.WriteFile(processedPath, []byte(taskYAML), 0644); err != nil {
+		t.Fatalf("Failed to write test task yaml: %v", err)
+	}
+
+	info, err := os.Stat(processedPath)
+	if err != nil {
+		t.Fatalf("Stat failed: %v", err)
+	}
+
+	lastRunTime := info.ModTime()
+	if data, err := os.ReadFile(processedPath); err == nil {
+		var q QueueTask
+		if err := yaml.Unmarshal(data, &q); err == nil && !q.CompletedAt.IsZero() {
+			lastRunTime = q.CompletedAt
+		}
+	}
+
+	if !lastRunTime.Equal(completedAt) {
+		t.Fatalf("lastRunTime = %v, want %v", lastRunTime, completedAt)
+	}
+}
+

--- a/factory/pkg/commands/watch_test.go
+++ b/factory/pkg/commands/watch_test.go
@@ -266,4 +266,3 @@ func TestWorkflowCooldownCompletedAt(t *testing.T) {
 		t.Fatalf("lastRunTime = %v, want %v", lastRunTime, completedAt)
 	}
 }
-


### PR DESCRIPTION
Use completedAt from the processed task YAML file instead of filesystem ModTime() so git sync operations do not reset workflow cooldown timers.