### PR TITLE
docs(workflow): instruct agents to run ./hack/record-gcp in Step 6

### DIFF
--- a/.agents/workflows/kcc-example.txt
+++ b/.agents/workflows/kcc-example.txt
@@ -213,8 +213,12 @@ The direct controller must be implemented to manage reconciliation logic (Adapte
     Find the tests added under pkg/test/resourcefixture/testdata/basic for the {kind}.
     Include only those tests that are not using direct annotation `alpha.cnrm.cloud.google.com/reconciler: direct` in `create.yaml`
 
-    For each test, follow .gemini/skills/solve-migration-diff-issues/SKILL.md to test the direct migration for {kind}
-    We may need to update the mocks to conform to the new controller changes (these were run against realgcp)
+    For each test, follow .gemini/skills/solve-migration-diff-issues/SKILL.md to test the direct migration for {kind}.
+    You MUST re-record the HTTP cassettes against live GCP by running `./hack/record-gcp TestMigrationToDirect/fixtures/<fixture-name>$` so that the recorded GCP traffic conforms to the new direct controller behavior. Do NOT rely solely on mockgcp.
+
+    GCP RECORDING PR REPORTING REQUIREMENT:
+    In the created PR description, you MUST explicitly document whether `./hack/record-gcp` was successfully run against real GCP. If it was run, state the GCP project used. If it was not run (e.g., due to disabled APIs, missing permissions, or rate limits), you must document the specific command run, the full error message encountered, and the fallback approach you used.
+
     If you find any shortcomings in these skills (that likely apply to other resources), you may update them. Also keep a journal of any less general observations etc. To avoid git merge conflicts, use a file under .gemini/skills/solve-migration-diff-issues/journal/, named after the kind or a similarly unique name.
 
     The created PR must include these labels: `direct-migration` and `overseer`


### PR DESCRIPTION
- Update Step 6 (Validate direct promotion) in kcc-example.txt to explicitly mandate running ./hack/record-gcp against real GCP.
- Add GCP RECORDING PR REPORTING REQUIREMENT so PR descriptions explicitly document real GCP recording status.