### PR TITLE
fix: investigation comments

### DIFF
--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -1357,39 +1357,13 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 				if hasFailure {
 					filename := fmt.Sprintf("task-pr-%d-investigate.yaml", num)
 					if !taskExists(incomingDir, processingDir, filename) {
-						lastResetTime := lastCommitTime
-						if listCommentsErr == nil {
-							for _, c := range comments {
-								isPoolBot := false
-								for _, bot := range allBotUsers {
-									if strings.EqualFold(c.GetUser().GetLogin(), bot) {
-										isPoolBot = true
-										break
-									}
-								}
-								// Advance reset timestamp when any human comments OR when the bot previously paused automated investigation
-								if (!isPoolBot || strings.Contains(c.GetBody(), "pausing automated investigation")) && c.GetCreatedAt().After(lastResetTime) {
-									lastResetTime = c.GetCreatedAt()
-								}
-							}
-						}
-
 						investigationCount := 0
 						if listCommentsErr == nil {
-							for _, c := range comments {
-								isPoolBot := false
-								for _, bot := range allBotUsers {
-									if strings.EqualFold(c.GetUser().GetLogin(), bot) {
-										isPoolBot = true
-										break
-									}
-								}
-								if isPoolBot &&
-									strings.Contains(c.GetBody(), "started investigating CI check failures") &&
-									c.GetCreatedAt().After(lastResetTime) {
-									investigationCount++
-								}
+							var bots []string
+							if cfg != nil {
+								bots = cfg.AllowlistedBots
 							}
+							investigationCount = getInvestigationCount(comments, lastCommitTime, allBotUsers, githubLogin, bots)
 						}
 
 						if investigationCount >= 3 {
@@ -2630,6 +2604,40 @@ func hasStopLabel(labels []*githubv39.Label, triggerLabel string) bool {
 		}
 	}
 	return false
+}
+
+func getInvestigationCount(comments []*githubv39.IssueComment, lastCommitTime time.Time, allBotUsers []string, githubLogin string, bots []string) int {
+	lastResetTime := lastCommitTime
+	for _, c := range comments {
+		isPoolBot := false
+		for _, bot := range allBotUsers {
+			if strings.EqualFold(c.GetUser().GetLogin(), bot) {
+				isPoolBot = true
+				break
+			}
+		}
+		isHuman := !isPoolBot && !shouldIgnoreUser(c.GetUser(), githubLogin, bots)
+		if (isHuman || strings.Contains(c.GetBody(), "pausing automated investigation")) && c.GetCreatedAt().After(lastResetTime) {
+			lastResetTime = c.GetCreatedAt()
+		}
+	}
+
+	investigationCount := 0
+	for _, c := range comments {
+		isPoolBot := false
+		for _, bot := range allBotUsers {
+			if strings.EqualFold(c.GetUser().GetLogin(), bot) {
+				isPoolBot = true
+				break
+			}
+		}
+		if isPoolBot &&
+			strings.Contains(c.GetBody(), "started investigating CI check failures") &&
+			c.GetCreatedAt().After(lastResetTime) {
+			investigationCount++
+		}
+	}
+	return investigationCount
 }
 
 func getStopLabel(triggerLabel string) string {

--- a/factory/pkg/commands/watch_test.go
+++ b/factory/pkg/commands/watch_test.go
@@ -266,3 +266,95 @@ func TestWorkflowCooldownCompletedAt(t *testing.T) {
 		t.Fatalf("lastRunTime = %v, want %v", lastRunTime, completedAt)
 	}
 }
+
+func TestGetInvestigationCount(t *testing.T) {
+	tests := []struct {
+		name          string
+		comments      []*githubv39.IssueComment
+		allBotUsers   []string
+		githubLogin   string
+		allowlist     []string
+		expectedCount int
+	}{
+		{
+			name:          "No comments, should be 0",
+			comments:      []*githubv39.IssueComment{},
+			expectedCount: 0,
+		},
+		{
+			name: "Only bot investigate comments, should be counted",
+			comments: []*githubv39.IssueComment{
+				{
+					User:      &githubv39.User{Login: stringPtr("pool-bot")},
+					Body:      stringPtr("🤖 AI Factory started investigating CI check failures"),
+					CreatedAt: timePtr(time.Now().Add(-2 * time.Hour)),
+				},
+				{
+					User:      &githubv39.User{Login: stringPtr("pool-bot")},
+					Body:      stringPtr("🤖 AI Factory started investigating CI check failures"),
+					CreatedAt: timePtr(time.Now().Add(-1 * time.Hour)),
+				},
+			},
+			allBotUsers:   []string{"pool-bot"},
+			expectedCount: 2,
+		},
+		{
+			name: "Prow comments should not reset the circuit breaker",
+			comments: []*githubv39.IssueComment{
+				{
+					User:      &githubv39.User{Login: stringPtr("pool-bot")},
+					Body:      stringPtr("🤖 AI Factory started investigating CI check failures"),
+					CreatedAt: timePtr(time.Now().Add(-3 * time.Hour)),
+				},
+				{
+					User:      &githubv39.User{Login: stringPtr("google-oss-prow"), Type: stringPtr("Bot")},
+					Body:      stringPtr("Some prow CI failure"),
+					CreatedAt: timePtr(time.Now().Add(-2 * time.Hour)),
+				},
+				{
+					User:      &githubv39.User{Login: stringPtr("pool-bot")},
+					Body:      stringPtr("🤖 AI Factory started investigating CI check failures"),
+					CreatedAt: timePtr(time.Now().Add(-1 * time.Hour)),
+				},
+			},
+			allBotUsers:   []string{"pool-bot"},
+			expectedCount: 2,
+		},
+		{
+			name: "Human comments should reset the circuit breaker",
+			comments: []*githubv39.IssueComment{
+				{
+					User:      &githubv39.User{Login: stringPtr("pool-bot")},
+					Body:      stringPtr("🤖 AI Factory started investigating CI check failures"),
+					CreatedAt: timePtr(time.Now().Add(-3 * time.Hour)),
+				},
+				{
+					User:      &githubv39.User{Login: stringPtr("real-human"), Type: stringPtr("User")},
+					Body:      stringPtr("Can you look into this?"),
+					CreatedAt: timePtr(time.Now().Add(-2 * time.Hour)),
+				},
+				{
+					User:      &githubv39.User{Login: stringPtr("pool-bot")},
+					Body:      stringPtr("🤖 AI Factory started investigating CI check failures"),
+					CreatedAt: timePtr(time.Now().Add(-1 * time.Hour)),
+				},
+			},
+			allBotUsers:   []string{"pool-bot"},
+			expectedCount: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lastCommitTime := time.Now().Add(-24 * time.Hour)
+			count := getInvestigationCount(tc.comments, lastCommitTime, tc.allBotUsers, tc.githubLogin, tc.allowlist)
+			if count != tc.expectedCount {
+				t.Errorf("expected count %d, got %d", tc.expectedCount, count)
+			}
+		})
+	}
+}
+
+func timePtr(t time.Time) *time.Time {
+	return &t
+}


### PR DESCRIPTION
My thesis is that the bots being chatty causes GitHub to mark them as spammy.

This fix in particular looks at the investigation loop bug where the bots keep commenting about fixing / addressing feedback. Also added a test.

Somewhat address #1135 but not all