### PR TITLE
fix: review comment churn

### DIFF
--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -1003,14 +1003,6 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 		timeoutChan = time.After(watchTimeout)
 	}
 
-	type prWatchState struct {
-		lastSHA                  string
-		lastInvestigatedTime     time.Time
-		lastCommentAddressedTime time.Time
-		lastReviewedSHA          string
-		unassignedSHA            string
-	}
-
 	processedIssues := make(map[int]time.Time)
 	processedPRs := make(map[int]prWatchState)
 	if files, err := os.ReadDir(processedDir); err == nil {
@@ -1045,41 +1037,25 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 
 				isComments := strings.HasSuffix(name, "-comments")
 				isInvestigate := strings.HasSuffix(name, "-investigate")
+				isReview := strings.HasSuffix(name, "-review")
+				isIterate := strings.HasSuffix(name, "-iterate")
 
 				var numStr string
 				if isComments {
 					numStr = strings.TrimSuffix(name, "-comments")
 				} else if isInvestigate {
 					numStr = strings.TrimSuffix(name, "-investigate")
+				} else if isReview {
+					numStr = strings.TrimSuffix(name, "-review")
+				} else if isIterate {
+					numStr = strings.TrimSuffix(name, "-iterate")
 				}
 
 				if numStr != "" {
 					if num, err := strconv.Atoi(numStr); err == nil {
 						state := processedPRs[num]
-						var t QueueTask
-						hasTask := false
-						if data, err := os.ReadFile(filePath); err == nil {
-							if err := yaml.Unmarshal(data, &t); err == nil {
-								hasTask = true
-								if t.CommitSHA != "" {
-									state.lastSHA = t.CommitSHA
-								}
-							}
-						}
-
-						if info, err := f.Info(); err == nil {
-							tTime := info.ModTime()
-							if hasTask && !t.CompletedAt.IsZero() {
-								tTime = t.CompletedAt
-							}
-							if isComments {
-								state.lastCommentAddressedTime = tTime
-							} else if isInvestigate {
-								state.lastInvestigatedTime = tTime
-							}
-						}
-
-						processedPRs[num] = state
+						info, _ := f.Info()
+						processedPRs[num] = parseProcessedPRTask(filePath, name, info, state)
 					}
 				}
 			}
@@ -2618,6 +2594,52 @@ func shouldUnassignStaleBot(lastSHA, unassignedSHA, headSHA, assignedBot string)
 		return false
 	}
 	return true
+}
+
+type prWatchState struct {
+	lastSHA                  string
+	lastInvestigatedTime     time.Time
+	lastCommentAddressedTime time.Time
+	lastReviewedSHA          string
+	unassignedSHA            string
+}
+
+func parseProcessedPRTask(filePath string, name string, fInfo os.FileInfo, state prWatchState) prWatchState {
+	isComments := strings.HasSuffix(name, "-comments")
+	isInvestigate := strings.HasSuffix(name, "-investigate")
+	isReview := strings.HasSuffix(name, "-review")
+
+	var t QueueTask
+	hasTask := false
+	if data, err := os.ReadFile(filePath); err == nil {
+		if err := yaml.Unmarshal(data, &t); err == nil {
+			hasTask = true
+			if t.CommitSHA != "" {
+				state.lastSHA = t.CommitSHA
+			}
+		}
+	}
+
+	if fInfo != nil {
+		tTime := fInfo.ModTime()
+		if hasTask && !t.CompletedAt.IsZero() {
+			tTime = t.CompletedAt
+		}
+		if isComments {
+			if tTime.After(state.lastCommentAddressedTime) {
+				state.lastCommentAddressedTime = tTime
+			}
+		} else if isInvestigate {
+			if tTime.After(state.lastInvestigatedTime) {
+				state.lastInvestigatedTime = tTime
+			}
+		} else if isReview {
+			if hasTask && t.CommitSHA != "" {
+				state.lastReviewedSHA = t.CommitSHA
+			}
+		}
+	}
+	return state
 }
 
 func getInvestigationCount(comments []*githubv39.IssueComment, lastCommitTime time.Time, allBotUsers []string, githubLogin string, bots []string) int {

--- a/factory/pkg/commands/watch_test.go
+++ b/factory/pkg/commands/watch_test.go
@@ -427,3 +427,65 @@ func TestShouldUnassignStaleBot(t *testing.T) {
 		})
 	}
 }
+
+func TestParseProcessedPRTask(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// 1. Create a review task file
+	reviewTaskPath := filepath.Join(tempDir, "task-pr-123-review.yaml")
+	reviewTaskData := []byte(`
+type: pr-review
+commitSHA: "abcd123"
+`)
+	if err := os.WriteFile(reviewTaskPath, reviewTaskData, 0644); err != nil {
+		t.Fatalf("failed to write review task file: %v", err)
+	}
+
+	// 2. Create a comments task file
+	commentsTaskPath := filepath.Join(tempDir, "task-pr-123-comments.yaml")
+	commentsTaskData := []byte(`
+type: pr-comments
+completedAt: "2026-07-23T12:00:00Z"
+`)
+	if err := os.WriteFile(commentsTaskPath, commentsTaskData, 0644); err != nil {
+		t.Fatalf("failed to write comments task file: %v", err)
+	}
+
+	// 3. Create an investigate task file
+	investigateTaskPath := filepath.Join(tempDir, "task-pr-123-investigate.yaml")
+	investigateTaskData := []byte(`
+type: pr-investigate
+completedAt: "2026-07-23T13:00:00Z"
+`)
+	if err := os.WriteFile(investigateTaskPath, investigateTaskData, 0644); err != nil {
+		t.Fatalf("failed to write investigate task file: %v", err)
+	}
+
+	initialState := prWatchState{}
+
+	// Process review task
+	fInfoReview, _ := os.Stat(reviewTaskPath)
+	state := parseProcessedPRTask(reviewTaskPath, "task-pr-123-review", fInfoReview, initialState)
+	if state.lastReviewedSHA != "abcd123" {
+		t.Errorf("expected lastReviewedSHA to be 'abcd123', got '%s'", state.lastReviewedSHA)
+	}
+	if state.lastSHA != "abcd123" {
+		t.Errorf("expected lastSHA to be 'abcd123', got '%s'", state.lastSHA)
+	}
+
+	// Process comments task
+	fInfoComments, _ := os.Stat(commentsTaskPath)
+	state = parseProcessedPRTask(commentsTaskPath, "task-pr-123-comments", fInfoComments, state)
+	expectedCommentTime, _ := time.Parse(time.RFC3339, "2026-07-23T12:00:00Z")
+	if !state.lastCommentAddressedTime.Equal(expectedCommentTime) {
+		t.Errorf("expected lastCommentAddressedTime to be %v, got %v", expectedCommentTime, state.lastCommentAddressedTime)
+	}
+
+	// Process investigate task
+	fInfoInvestigate, _ := os.Stat(investigateTaskPath)
+	state = parseProcessedPRTask(investigateTaskPath, "task-pr-123-investigate", fInfoInvestigate, state)
+	expectedInvestigateTime, _ := time.Parse(time.RFC3339, "2026-07-23T13:00:00Z")
+	if !state.lastInvestigatedTime.Equal(expectedInvestigateTime) {
+		t.Errorf("expected lastInvestigatedTime to be %v, got %v", expectedInvestigateTime, state.lastInvestigatedTime)
+	}
+}


### PR DESCRIPTION
builds on #1218 

main fix revolves around `lastReviewedSHA` and remembering it so we don't see  the bots reviewing the same sha forever

<img width="696" height="970" alt="image" src="https://github.com/user-attachments/assets/2f149045-cc50-44bf-9939-c0dd7f86cf93" />
