### PR TITLE
fix(resilience): add guardrails for 0-byte exit_code files and zombie processes

### DIFF
--- a/factory/images/factory-golang/Dockerfile
+++ b/factory/images/factory-golang/Dockerfile
@@ -39,13 +39,13 @@ RUN apt-get update && apt-get install -y git tmux nodejs npm sudo curl apt-trans
 
 # Install Google Cloud CLI
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+    curl -fsSL --retry 5 --retry-connrefused --retry-delay 3 https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     apt-get update && apt-get install -y google-cloud-cli
 
 RUN npm install -g @google/gemini-cli @anthropic-ai/claude-code
 
 # Install code-server
-RUN curl -fsSL https://code-server.dev/install.sh | sh
+RUN curl -fsSL --retry 5 --retry-connrefused --retry-delay 3 https://code-server.dev/install.sh | sh
 RUN code-server --install-extension golang.go --install-extension vscodevim.vim
 
 COPY --from=build-gh /bin/gh /bin/gh

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -251,12 +251,15 @@ func isSandboxTaskRunning(ctx context.Context, kubeClient *clients.KubernetesCli
 			checkCmd := `task_dir=$(ls -td /workspaces/tasks/* 2>/dev/null | head -1)
 			if [ -z "$task_dir" ]; then
 				echo "NOTASKS"
-			elif [ -f "$task_dir/exit_code" ]; then
+			elif [ -s "$task_dir/exit_code" ]; then
 				cat "$task_dir/exit_code"
 			else
 				pid=$(cat "$task_dir/pid" 2>/dev/null)
-				if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then
-					echo "137" # Report SIGKILL/Crashed fallback exit code
+				if [ -n "$pid" ]; then
+					stat=$(ps -o stat= -p "$pid" 2>/dev/null | cut -c 1)
+					if ! kill -0 "$pid" 2>/dev/null || [ "$stat" = "Z" ]; then
+						echo "137" # Report SIGKILL/Crashed/Zombie fallback exit code
+					fi
 				fi
 			fi`
 			if err := client.Exec(ctx, checkCmd, "/workspaces", nil, nil, &buf, nil); err == nil {

--- a/factory/pkg/envd/client.go
+++ b/factory/pkg/envd/client.go
@@ -377,7 +377,7 @@ func (c *Client) RunTaskResilient(ctx context.Context, cmdStr string, envs map[s
 
 	// Check if task is already running or completed in the sandbox pod
 	var checkBuf bytes.Buffer
-	checkStatusCmd := fmt.Sprintf("if [ -f %s ]; then cat %s; fi", exitCodeFile, exitCodeFile)
+	checkStatusCmd := fmt.Sprintf("if [ -s %s ]; then cat %s; fi", exitCodeFile, exitCodeFile)
 	isCompleted := false
 	if err := c.Exec(ctx, checkStatusCmd, "/workspaces", nil, nil, &checkBuf, nil); err == nil {
 		if strings.TrimSpace(checkBuf.String()) != "" {
@@ -388,7 +388,7 @@ func (c *Client) RunTaskResilient(ctx context.Context, cmdStr string, envs map[s
 	isAlreadyRunning := false
 	if !isCompleted {
 		var pidBuf bytes.Buffer
-		checkPidCmd := fmt.Sprintf("if [ -f %s ]; then pid=$(cat %s); if kill -0 $pid 2>/dev/null; then echo \"alive\"; fi; fi", pidFile, pidFile)
+		checkPidCmd := fmt.Sprintf("if [ -s %s ]; then pid=$(cat %s 2>/dev/null); if [ -n \"$pid\" ]; then stat=$(ps -o stat= -p \"$pid\" 2>/dev/null | cut -c 1); if kill -0 \"$pid\" 2>/dev/null && [ \"$stat\" != \"Z\" ]; then echo \"alive\"; fi; fi; fi", pidFile, pidFile)
 		if err := c.Exec(ctx, checkPidCmd, "/workspaces", nil, nil, &pidBuf, nil); err == nil {
 			if strings.TrimSpace(pidBuf.String()) == "alive" {
 				isAlreadyRunning = true

--- a/repo-agent/images/dind-golang/Dockerfile
+++ b/repo-agent/images/dind-golang/Dockerfile
@@ -22,17 +22,17 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
 # 2. Add apt repositories (Docker, NodeSource, Google Cloud, Helm)
 RUN mkdir -p /etc/apt/keyrings && \
     # Docker
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc && \
+    curl -fsSL --retry 5 --retry-connrefused --retry-delay 3 https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc && \
     chmod a+r /etc/apt/keyrings/docker.asc && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo \"$VERSION_CODENAME\") stable" > /etc/apt/sources.list.d/docker.list && \
     # NodeSource
-    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    curl -fsSL --retry 5 --retry-connrefused --retry-delay 3 https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" > /etc/apt/sources.list.d/nodesource.list && \
     # Google Cloud
-    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /etc/apt/keyrings/cloud.google.com.gpg && \
+    curl -fsSL --retry 5 --retry-connrefused --retry-delay 3 https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /etc/apt/keyrings/cloud.google.com.gpg && \
     echo "deb [signed-by=/etc/apt/keyrings/cloud.google.com.gpg] https://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
     # Helm
-    curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | gpg --dearmor -o /etc/apt/keyrings/helm.gpg && \
+    curl -fsSL --retry 5 --retry-connrefused --retry-delay 3 https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | gpg --dearmor -o /etc/apt/keyrings/helm.gpg && \
     echo "deb [signed-by=/etc/apt/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" > /etc/apt/sources.list.d/helm-stable-debian.list
 
 # 3. Install all apt packages

--- a/repo-agent/images/generic-golang/Dockerfile
+++ b/repo-agent/images/generic-golang/Dockerfile
@@ -53,13 +53,13 @@ RUN apt-get update && apt-get install -y git tmux nodejs npm sudo curl apt-trans
 
 # Install Google Cloud CLI
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+    curl -fsSL --retry 5 --retry-connrefused --retry-delay 3 https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     apt-get update && apt-get install -y google-cloud-cli
 
 RUN npm install -g @google/gemini-cli @anthropic-ai/claude-code
 
 # Install code-server
-RUN curl -fsSL https://code-server.dev/install.sh | sh
+RUN curl -fsSL --retry 5 --retry-connrefused --retry-delay 3 https://code-server.dev/install.sh | sh
 RUN code-server --install-extension golang.go --install-extension vscodevim.vim
 
 COPY --from=build-repo-sandbox /repo-sandbox /repo-agent/repo-sandbox

--- a/repo-agent/pkg/agentserver/server.go
+++ b/repo-agent/pkg/agentserver/server.go
@@ -100,7 +100,7 @@ func serveTasksList(w http.ResponseWriter, r *http.Request) {
 		status := "Pending"
 		var ec interface{}
 
-		if exitBytes, err := os.ReadFile(filepath.Join(p, "exit_code")); err == nil {
+		if exitBytes, err := os.ReadFile(filepath.Join(p, "exit_code")); err == nil && len(strings.TrimSpace(string(exitBytes))) > 0 {
 			code := strings.TrimSpace(string(exitBytes))
 			ec = code
 			if code == "0" {
@@ -108,14 +108,15 @@ func serveTasksList(w http.ResponseWriter, r *http.Request) {
 			} else {
 				status = "Failed"
 			}
-		} else if pidBytes, err := os.ReadFile(filepath.Join(p, "pid")); err == nil {
+		} else if pidBytes, err := os.ReadFile(filepath.Join(p, "pid")); err == nil && len(strings.TrimSpace(string(pidBytes))) > 0 {
 			pidStr := strings.TrimSpace(string(pidBytes))
 			var pid int
 			if _, err := fmt.Sscanf(pidStr, "%d", &pid); err == nil {
-				if proc, err := os.FindProcess(pid); err == nil && proc.Signal(syscall.Signal(0)) == nil {
+				if isProcessAliveAndNotZombie(pid) {
 					status = "Running"
 				} else {
 					status = "Crashed"
+					ec = "137"
 				}
 			}
 		}
@@ -193,4 +194,19 @@ func serveTelemetryFile(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	http.ServeFile(w, r, telemetryPath)
+}
+
+func isProcessAliveAndNotZombie(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil || proc.Signal(syscall.Signal(0)) != nil {
+		return false
+	}
+	statBytes, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err == nil {
+		parts := strings.Fields(string(statBytes))
+		if len(parts) >= 3 && strings.HasPrefix(parts[2], "Z") {
+			return false
+		}
+	}
+	return true
 }

--- a/repo-agent/pkg/api/handlers_overseer.go
+++ b/repo-agent/pkg/api/handlers_overseer.go
@@ -449,18 +449,23 @@ if os.path.exists(tasks_dir):
         if not os.path.isdir(p): continue
         status = "Pending"
         ec = None
-        if os.path.exists(os.path.join(p, "exit_code")):
+        if os.path.exists(os.path.join(p, "exit_code")) and os.path.getsize(os.path.join(p, "exit_code")) > 0:
             try:
                 with open(os.path.join(p, "exit_code")) as f: ec = f.read().strip()
                 status = "Completed" if ec == "0" else "Failed"
             except: pass
-        elif os.path.exists(os.path.join(p, "pid")):
+        elif os.path.exists(os.path.join(p, "pid")) and os.path.getsize(os.path.join(p, "pid")) > 0:
             try:
                 with open(os.path.join(p, "pid")) as f: pid = int(f.read().strip())
-                try:
-                    os.kill(pid, 0)
-                    status = "Running"
-                except OSError: status = "Crashed"
+                stat = ""
+                if os.path.exists(f"/proc/{pid}/stat"):
+                    with open(f"/proc/{pid}/stat") as sf: stat = sf.read().split()[2] if len(sf.read().split()) > 2 else ""
+                if stat.startswith("Z"): status = "Crashed"; ec = "137"
+                else:
+                    try:
+                        os.kill(pid, 0)
+                        status = "Running"
+                    except OSError: status = "Crashed"; ec = "137"
             except: pass
         res.append({"metadata": {"name": d, "namespace": "%s"}, "spec": {"taskType": d}, "status": {"state": status, "exitCode": ec}})
 print(json.dumps(res))
@@ -474,13 +479,14 @@ else
       if [ "$first" = true ]; then first=false; else echo ","; fi
       status="Pending"
       ec="null"
-      if [ -f "/workspaces/tasks/$d/exit_code" ]; then
+      if [ -s "/workspaces/tasks/$d/exit_code" ]; then
         code=$(cat "/workspaces/tasks/$d/exit_code" 2>/dev/null | tr -d "\r\n")
         ec="\"$code\""
         if [ "$code" = "0" ]; then status="Completed"; else status="Failed"; fi
-      elif [ -f "/workspaces/tasks/$d/pid" ]; then
+      elif [ -s "/workspaces/tasks/$d/pid" ]; then
         pid=$(cat "/workspaces/tasks/$d/pid" 2>/dev/null | tr -d "\r\n")
-        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then status="Running"; else status="Crashed"; fi
+        stat=$(ps -o stat= -p "$pid" 2>/dev/null | cut -c 1)
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && [ "$stat" != "Z" ]; then status="Running"; else status="Crashed"; ec="\"137\""; fi
       fi
       printf "{\"metadata\":{\"name\":\"%%s\",\"namespace\":\"%s\"},\"spec\":{\"taskType\":\"%%s\"},\"status\":{\"state\":\"%%s\",\"exitCode\":%%s}}" "$d" "$d" "$status" "$ec"
     done


### PR DESCRIPTION
When a sandbox pod experiences disk exhaustion (ENOSPC) or crashes during task termination, `exit_code` and `pid` files may be created on disk with 0 bytes. Furthermore, if a child process terminates without being reaped by PID 1 (e.g. non-init entrypoint), it remains in the process table as a zombie (`<defunct>`, stat `Z`).

Previously, `overseer` and `agentserver` checked file existence (`-f` / `os.path.exists`) and process existence (`kill -0`), causing sandboxes with empty 0-byte `exit_code` files or zombie processes to be permanently marked as `Running` / busy.

This PR adds multi-layered resilience guardrails across task runners and servers:
1. **File Size Validation**: Replaced `-f` / `exists()` with `-s` / `getsize() > 0` checks when reading `exit_code` and `pid` files in `watch.go`, `envd/client.go`, `agentserver/server.go`, and `handlers_overseer.go`.
2. **Zombie Process Filtering**: Added `/proc/<pid>/stat` and `ps -o stat=` checks to verify that processes responding to `kill -0` are not in zombie state (`Z`). Zombie processes are treated as terminated/crashed, unblocking the sandbox task state.