### PR TITLE
feat(telemetry): collect and surface top slowest shell commands in usage service & UI

### DIFF
--- a/factory/pkg/tasks/address_feedback.sh
+++ b/factory/pkg/tasks/address_feedback.sh
@@ -226,19 +226,22 @@ try:
     session_files = gb.glob("/root/.gemini/tmp/*/chats/session-*.jsonl") + gb.glob("/workspaces/.home/.gemini/tmp/*/chats/session-*.jsonl")
     if session_files:
         latest_session = max(session_files, key=os.path.getmtime)
-        tool_metrics = {"total_tool_calls": 0, "total_tool_duration_sec": 0, "tools": {}}
+        tool_metrics = {"total_tool_calls": 0, "total_tool_duration_sec": 0, "tools": {}, "shell_calls": []}
         pending = {}
+        all_shell_calls = []
         with open(latest_session, "r", errors="ignore") as f:
             for line in f:
                 try:
                     data = json.loads(line)
                     ts = parse_iso(data.get("timestamp"))
                     if not ts: continue
+                    ts_str = data.get("timestamp", "")
                     if "toolCalls" in data and isinstance(data["toolCalls"], list):
                         for fc in data["toolCalls"]:
-                            cmd = fc.get("args", {}).get("command", "") or fc.get("args", {}).get("CommandLine", "") or fc.get("args", {}).get("TargetFile", "") or str(fc.get("args", {}))
-                            if len(str(cmd)) > 120: cmd = str(cmd)[:120] + "..."
-                            pending[fc.get("id")] = {"name": fc.get("name", "unknown"), "start": ts, "cmd": cmd}
+                            tname = fc.get("name", "unknown")
+                            args = fc.get("args", {})
+                            cmd = args.get("command", "") or args.get("CommandLine", "") or args.get("TargetFile", "") or str(args)
+                            pending[fc.get("id")] = {"name": tname, "start": ts, "ts_str": ts_str, "cmd": str(cmd)}
                     c = data.get("content", "")
                     if isinstance(c, list):
                         for part in c:
@@ -249,16 +252,26 @@ try:
                                     sinfo = pending.pop(cid)
                                     dur = round((ts - sinfo["start"]).total_seconds(), 3)
                                     tname = sinfo["name"]
+                                    full_cmd = sinfo.get("cmd", "")
+                                    trunc_cmd = full_cmd[:300] + ("..." if len(full_cmd) > 300 else "")
                                     tstat = tool_metrics["tools"].setdefault(tname, {"count": 0, "total_sec": 0, "max_sec": 0, "slowest_cmd": ""})
                                     tstat["count"] += 1
                                     tstat["total_sec"] = round(tstat["total_sec"] + dur, 3)
                                     if dur >= tstat["max_sec"]:
                                         tstat["max_sec"] = dur
-                                        tstat["slowest_cmd"] = sinfo.get("cmd", "")
+                                        tstat["slowest_cmd"] = trunc_cmd[:120] + ("..." if len(trunc_cmd) > 120 else "")
                                     tool_metrics["total_tool_calls"] += 1
                                     tool_metrics["total_tool_duration_sec"] = round(tool_metrics["total_tool_duration_sec"] + dur, 3)
+                                    if tname == "run_shell_command":
+                                        all_shell_calls.append({
+                                            "cmd": trunc_cmd,
+                                            "duration_sec": dur,
+                                            "timestamp": sinfo.get("ts_str", ts.isoformat())
+                                        })
                 except Exception:
                     pass
+        all_shell_calls.sort(key=lambda x: x["duration_sec"], reverse=True)
+        tool_metrics["shell_calls"] = all_shell_calls[:50]
         with open(os.path.join(task_dir, "tool-telemetry.json"), "w") as tf:
             json.dump(tool_metrics, tf, indent=2)
 except Exception:

--- a/factory/pkg/tasks/adopt.sh
+++ b/factory/pkg/tasks/adopt.sh
@@ -174,19 +174,22 @@ try:
     session_files = gb.glob("/root/.gemini/tmp/*/chats/session-*.jsonl") + gb.glob("/workspaces/.home/.gemini/tmp/*/chats/session-*.jsonl")
     if session_files:
         latest_session = max(session_files, key=os.path.getmtime)
-        tool_metrics = {"total_tool_calls": 0, "total_tool_duration_sec": 0, "tools": {}}
+        tool_metrics = {"total_tool_calls": 0, "total_tool_duration_sec": 0, "tools": {}, "shell_calls": []}
         pending = {}
+        all_shell_calls = []
         with open(latest_session, "r", errors="ignore") as f:
             for line in f:
                 try:
                     data = json.loads(line)
                     ts = parse_iso(data.get("timestamp"))
                     if not ts: continue
+                    ts_str = data.get("timestamp", "")
                     if "toolCalls" in data and isinstance(data["toolCalls"], list):
                         for fc in data["toolCalls"]:
-                            cmd = fc.get("args", {}).get("command", "") or fc.get("args", {}).get("CommandLine", "") or fc.get("args", {}).get("TargetFile", "") or str(fc.get("args", {}))
-                            if len(str(cmd)) > 120: cmd = str(cmd)[:120] + "..."
-                            pending[fc.get("id")] = {"name": fc.get("name", "unknown"), "start": ts, "cmd": cmd}
+                            tname = fc.get("name", "unknown")
+                            args = fc.get("args", {})
+                            cmd = args.get("command", "") or args.get("CommandLine", "") or args.get("TargetFile", "") or str(args)
+                            pending[fc.get("id")] = {"name": tname, "start": ts, "ts_str": ts_str, "cmd": str(cmd)}
                     c = data.get("content", "")
                     if isinstance(c, list):
                         for part in c:
@@ -197,16 +200,26 @@ try:
                                     sinfo = pending.pop(cid)
                                     dur = round((ts - sinfo["start"]).total_seconds(), 3)
                                     tname = sinfo["name"]
+                                    full_cmd = sinfo.get("cmd", "")
+                                    trunc_cmd = full_cmd[:300] + ("..." if len(full_cmd) > 300 else "")
                                     tstat = tool_metrics["tools"].setdefault(tname, {"count": 0, "total_sec": 0, "max_sec": 0, "slowest_cmd": ""})
                                     tstat["count"] += 1
                                     tstat["total_sec"] = round(tstat["total_sec"] + dur, 3)
                                     if dur >= tstat["max_sec"]:
                                         tstat["max_sec"] = dur
-                                        tstat["slowest_cmd"] = sinfo.get("cmd", "")
+                                        tstat["slowest_cmd"] = trunc_cmd[:120] + ("..." if len(trunc_cmd) > 120 else "")
                                     tool_metrics["total_tool_calls"] += 1
                                     tool_metrics["total_tool_duration_sec"] = round(tool_metrics["total_tool_duration_sec"] + dur, 3)
+                                    if tname == "run_shell_command":
+                                        all_shell_calls.append({
+                                            "cmd": trunc_cmd,
+                                            "duration_sec": dur,
+                                            "timestamp": sinfo.get("ts_str", ts.isoformat())
+                                        })
                 except Exception:
                     pass
+        all_shell_calls.sort(key=lambda x: x["duration_sec"], reverse=True)
+        tool_metrics["shell_calls"] = all_shell_calls[:50]
         with open(os.path.join(task_dir, "tool-telemetry.json"), "w") as tf:
             json.dump(tool_metrics, tf, indent=2)
 except Exception:

--- a/factory/pkg/tasks/fix_issue.sh
+++ b/factory/pkg/tasks/fix_issue.sh
@@ -284,19 +284,22 @@ try:
     session_files = gb.glob("/root/.gemini/tmp/*/chats/session-*.jsonl") + gb.glob("/workspaces/.home/.gemini/tmp/*/chats/session-*.jsonl")
     if session_files:
         latest_session = max(session_files, key=os.path.getmtime)
-        tool_metrics = {"total_tool_calls": 0, "total_tool_duration_sec": 0, "tools": {}}
+        tool_metrics = {"total_tool_calls": 0, "total_tool_duration_sec": 0, "tools": {}, "shell_calls": []}
         pending = {}
+        all_shell_calls = []
         with open(latest_session, "r", errors="ignore") as f:
             for line in f:
                 try:
                     data = json.loads(line)
                     ts = parse_iso(data.get("timestamp"))
                     if not ts: continue
+                    ts_str = data.get("timestamp", "")
                     if "toolCalls" in data and isinstance(data["toolCalls"], list):
                         for fc in data["toolCalls"]:
-                            cmd = fc.get("args", {}).get("command", "") or fc.get("args", {}).get("CommandLine", "") or fc.get("args", {}).get("TargetFile", "") or str(fc.get("args", {}))
-                            if len(str(cmd)) > 120: cmd = str(cmd)[:120] + "..."
-                            pending[fc.get("id")] = {"name": fc.get("name", "unknown"), "start": ts, "cmd": cmd}
+                            tname = fc.get("name", "unknown")
+                            args = fc.get("args", {})
+                            cmd = args.get("command", "") or args.get("CommandLine", "") or args.get("TargetFile", "") or str(args)
+                            pending[fc.get("id")] = {"name": tname, "start": ts, "ts_str": ts_str, "cmd": str(cmd)}
                     c = data.get("content", "")
                     if isinstance(c, list):
                         for part in c:
@@ -307,16 +310,26 @@ try:
                                     sinfo = pending.pop(cid)
                                     dur = round((ts - sinfo["start"]).total_seconds(), 3)
                                     tname = sinfo["name"]
+                                    full_cmd = sinfo.get("cmd", "")
+                                    trunc_cmd = full_cmd[:300] + ("..." if len(full_cmd) > 300 else "")
                                     tstat = tool_metrics["tools"].setdefault(tname, {"count": 0, "total_sec": 0, "max_sec": 0, "slowest_cmd": ""})
                                     tstat["count"] += 1
                                     tstat["total_sec"] = round(tstat["total_sec"] + dur, 3)
                                     if dur >= tstat["max_sec"]:
                                         tstat["max_sec"] = dur
-                                        tstat["slowest_cmd"] = sinfo.get("cmd", "")
+                                        tstat["slowest_cmd"] = trunc_cmd[:120] + ("..." if len(trunc_cmd) > 120 else "")
                                     tool_metrics["total_tool_calls"] += 1
                                     tool_metrics["total_tool_duration_sec"] = round(tool_metrics["total_tool_duration_sec"] + dur, 3)
+                                    if tname == "run_shell_command":
+                                        all_shell_calls.append({
+                                            "cmd": trunc_cmd,
+                                            "duration_sec": dur,
+                                            "timestamp": sinfo.get("ts_str", ts.isoformat())
+                                        })
                 except Exception:
                     pass
+        all_shell_calls.sort(key=lambda x: x["duration_sec"], reverse=True)
+        tool_metrics["shell_calls"] = all_shell_calls[:50]
         with open(os.path.join(task_dir, "tool-telemetry.json"), "w") as tf:
             json.dump(tool_metrics, tf, indent=2)
 except Exception:

--- a/factory/pkg/tasks/investigate_failures.sh
+++ b/factory/pkg/tasks/investigate_failures.sh
@@ -250,19 +250,22 @@ try:
     session_files = gb.glob("/root/.gemini/tmp/*/chats/session-*.jsonl") + gb.glob("/workspaces/.home/.gemini/tmp/*/chats/session-*.jsonl")
     if session_files:
         latest_session = max(session_files, key=os.path.getmtime)
-        tool_metrics = {"total_tool_calls": 0, "total_tool_duration_sec": 0, "tools": {}}
+        tool_metrics = {"total_tool_calls": 0, "total_tool_duration_sec": 0, "tools": {}, "shell_calls": []}
         pending = {}
+        all_shell_calls = []
         with open(latest_session, "r", errors="ignore") as f:
             for line in f:
                 try:
                     data = json.loads(line)
                     ts = parse_iso(data.get("timestamp"))
                     if not ts: continue
+                    ts_str = data.get("timestamp", "")
                     if "toolCalls" in data and isinstance(data["toolCalls"], list):
                         for fc in data["toolCalls"]:
-                            cmd = fc.get("args", {}).get("command", "") or fc.get("args", {}).get("CommandLine", "") or fc.get("args", {}).get("TargetFile", "") or str(fc.get("args", {}))
-                            if len(str(cmd)) > 120: cmd = str(cmd)[:120] + "..."
-                            pending[fc.get("id")] = {"name": fc.get("name", "unknown"), "start": ts, "cmd": cmd}
+                            tname = fc.get("name", "unknown")
+                            args = fc.get("args", {})
+                            cmd = args.get("command", "") or args.get("CommandLine", "") or args.get("TargetFile", "") or str(args)
+                            pending[fc.get("id")] = {"name": tname, "start": ts, "ts_str": ts_str, "cmd": str(cmd)}
                     c = data.get("content", "")
                     if isinstance(c, list):
                         for part in c:
@@ -273,16 +276,26 @@ try:
                                     sinfo = pending.pop(cid)
                                     dur = round((ts - sinfo["start"]).total_seconds(), 3)
                                     tname = sinfo["name"]
+                                    full_cmd = sinfo.get("cmd", "")
+                                    trunc_cmd = full_cmd[:300] + ("..." if len(full_cmd) > 300 else "")
                                     tstat = tool_metrics["tools"].setdefault(tname, {"count": 0, "total_sec": 0, "max_sec": 0, "slowest_cmd": ""})
                                     tstat["count"] += 1
                                     tstat["total_sec"] = round(tstat["total_sec"] + dur, 3)
                                     if dur >= tstat["max_sec"]:
                                         tstat["max_sec"] = dur
-                                        tstat["slowest_cmd"] = sinfo.get("cmd", "")
+                                        tstat["slowest_cmd"] = trunc_cmd[:120] + ("..." if len(trunc_cmd) > 120 else "")
                                     tool_metrics["total_tool_calls"] += 1
                                     tool_metrics["total_tool_duration_sec"] = round(tool_metrics["total_tool_duration_sec"] + dur, 3)
+                                    if tname == "run_shell_command":
+                                        all_shell_calls.append({
+                                            "cmd": trunc_cmd,
+                                            "duration_sec": dur,
+                                            "timestamp": sinfo.get("ts_str", ts.isoformat())
+                                        })
                 except Exception:
                     pass
+        all_shell_calls.sort(key=lambda x: x["duration_sec"], reverse=True)
+        tool_metrics["shell_calls"] = all_shell_calls[:50]
         with open(os.path.join(task_dir, "tool-telemetry.json"), "w") as tf:
             json.dump(tool_metrics, tf, indent=2)
 except Exception:

--- a/factory/pkg/tasks/iterate.sh
+++ b/factory/pkg/tasks/iterate.sh
@@ -252,19 +252,22 @@ try:
     session_files = gb.glob("/root/.gemini/tmp/*/chats/session-*.jsonl") + gb.glob("/workspaces/.home/.gemini/tmp/*/chats/session-*.jsonl")
     if session_files:
         latest_session = max(session_files, key=os.path.getmtime)
-        tool_metrics = {"total_tool_calls": 0, "total_tool_duration_sec": 0, "tools": {}}
+        tool_metrics = {"total_tool_calls": 0, "total_tool_duration_sec": 0, "tools": {}, "shell_calls": []}
         pending = {}
+        all_shell_calls = []
         with open(latest_session, "r", errors="ignore") as f:
             for line in f:
                 try:
                     data = json.loads(line)
                     ts = parse_iso(data.get("timestamp"))
                     if not ts: continue
+                    ts_str = data.get("timestamp", "")
                     if "toolCalls" in data and isinstance(data["toolCalls"], list):
                         for fc in data["toolCalls"]:
-                            cmd = fc.get("args", {}).get("command", "") or fc.get("args", {}).get("CommandLine", "") or fc.get("args", {}).get("TargetFile", "") or str(fc.get("args", {}))
-                            if len(str(cmd)) > 120: cmd = str(cmd)[:120] + "..."
-                            pending[fc.get("id")] = {"name": fc.get("name", "unknown"), "start": ts, "cmd": cmd}
+                            tname = fc.get("name", "unknown")
+                            args = fc.get("args", {})
+                            cmd = args.get("command", "") or args.get("CommandLine", "") or args.get("TargetFile", "") or str(args)
+                            pending[fc.get("id")] = {"name": tname, "start": ts, "ts_str": ts_str, "cmd": str(cmd)}
                     c = data.get("content", "")
                     if isinstance(c, list):
                         for part in c:
@@ -275,16 +278,26 @@ try:
                                     sinfo = pending.pop(cid)
                                     dur = round((ts - sinfo["start"]).total_seconds(), 3)
                                     tname = sinfo["name"]
+                                    full_cmd = sinfo.get("cmd", "")
+                                    trunc_cmd = full_cmd[:300] + ("..." if len(full_cmd) > 300 else "")
                                     tstat = tool_metrics["tools"].setdefault(tname, {"count": 0, "total_sec": 0, "max_sec": 0, "slowest_cmd": ""})
                                     tstat["count"] += 1
                                     tstat["total_sec"] = round(tstat["total_sec"] + dur, 3)
                                     if dur >= tstat["max_sec"]:
                                         tstat["max_sec"] = dur
-                                        tstat["slowest_cmd"] = sinfo.get("cmd", "")
+                                        tstat["slowest_cmd"] = trunc_cmd[:120] + ("..." if len(trunc_cmd) > 120 else "")
                                     tool_metrics["total_tool_calls"] += 1
                                     tool_metrics["total_tool_duration_sec"] = round(tool_metrics["total_tool_duration_sec"] + dur, 3)
+                                    if tname == "run_shell_command":
+                                        all_shell_calls.append({
+                                            "cmd": trunc_cmd,
+                                            "duration_sec": dur,
+                                            "timestamp": sinfo.get("ts_str", ts.isoformat())
+                                        })
                 except Exception:
                     pass
+        all_shell_calls.sort(key=lambda x: x["duration_sec"], reverse=True)
+        tool_metrics["shell_calls"] = all_shell_calls[:50]
         with open(os.path.join(task_dir, "tool-telemetry.json"), "w") as tf:
             json.dump(tool_metrics, tf, indent=2)
 except Exception:

--- a/factory/pkg/tasks/review.sh
+++ b/factory/pkg/tasks/review.sh
@@ -213,19 +213,22 @@ try:
     session_files = gb.glob("/root/.gemini/tmp/*/chats/session-*.jsonl") + gb.glob("/workspaces/.home/.gemini/tmp/*/chats/session-*.jsonl")
     if session_files:
         latest_session = max(session_files, key=os.path.getmtime)
-        tool_metrics = {"total_tool_calls": 0, "total_tool_duration_sec": 0, "tools": {}}
+        tool_metrics = {"total_tool_calls": 0, "total_tool_duration_sec": 0, "tools": {}, "shell_calls": []}
         pending = {}
+        all_shell_calls = []
         with open(latest_session, "r", errors="ignore") as f:
             for line in f:
                 try:
                     data = json.loads(line)
                     ts = parse_iso(data.get("timestamp"))
                     if not ts: continue
+                    ts_str = data.get("timestamp", "")
                     if "toolCalls" in data and isinstance(data["toolCalls"], list):
                         for fc in data["toolCalls"]:
-                            cmd = fc.get("args", {}).get("command", "") or fc.get("args", {}).get("CommandLine", "") or fc.get("args", {}).get("TargetFile", "") or str(fc.get("args", {}))
-                            if len(str(cmd)) > 120: cmd = str(cmd)[:120] + "..."
-                            pending[fc.get("id")] = {"name": fc.get("name", "unknown"), "start": ts, "cmd": cmd}
+                            tname = fc.get("name", "unknown")
+                            args = fc.get("args", {})
+                            cmd = args.get("command", "") or args.get("CommandLine", "") or args.get("TargetFile", "") or str(args)
+                            pending[fc.get("id")] = {"name": tname, "start": ts, "ts_str": ts_str, "cmd": str(cmd)}
                     c = data.get("content", "")
                     if isinstance(c, list):
                         for part in c:
@@ -236,16 +239,26 @@ try:
                                     sinfo = pending.pop(cid)
                                     dur = round((ts - sinfo["start"]).total_seconds(), 3)
                                     tname = sinfo["name"]
+                                    full_cmd = sinfo.get("cmd", "")
+                                    trunc_cmd = full_cmd[:300] + ("..." if len(full_cmd) > 300 else "")
                                     tstat = tool_metrics["tools"].setdefault(tname, {"count": 0, "total_sec": 0, "max_sec": 0, "slowest_cmd": ""})
                                     tstat["count"] += 1
                                     tstat["total_sec"] = round(tstat["total_sec"] + dur, 3)
                                     if dur >= tstat["max_sec"]:
                                         tstat["max_sec"] = dur
-                                        tstat["slowest_cmd"] = sinfo.get("cmd", "")
+                                        tstat["slowest_cmd"] = trunc_cmd[:120] + ("..." if len(trunc_cmd) > 120 else "")
                                     tool_metrics["total_tool_calls"] += 1
                                     tool_metrics["total_tool_duration_sec"] = round(tool_metrics["total_tool_duration_sec"] + dur, 3)
+                                    if tname == "run_shell_command":
+                                        all_shell_calls.append({
+                                            "cmd": trunc_cmd,
+                                            "duration_sec": dur,
+                                            "timestamp": sinfo.get("ts_str", ts.isoformat())
+                                        })
                 except Exception:
                     pass
+        all_shell_calls.sort(key=lambda x: x["duration_sec"], reverse=True)
+        tool_metrics["shell_calls"] = all_shell_calls[:50]
         with open(os.path.join(task_dir, "tool-telemetry.json"), "w") as tf:
             json.dump(tool_metrics, tf, indent=2)
 except Exception:

--- a/factory/pkg/tasks/run_agent.sh
+++ b/factory/pkg/tasks/run_agent.sh
@@ -322,19 +322,22 @@ try:
     session_files = gb.glob("/root/.gemini/tmp/*/chats/session-*.jsonl") + gb.glob("/workspaces/.home/.gemini/tmp/*/chats/session-*.jsonl")
     if session_files:
         latest_session = max(session_files, key=os.path.getmtime)
-        tool_metrics = {"total_tool_calls": 0, "total_tool_duration_sec": 0, "tools": {}}
+        tool_metrics = {"total_tool_calls": 0, "total_tool_duration_sec": 0, "tools": {}, "shell_calls": []}
         pending = {}
+        all_shell_calls = []
         with open(latest_session, "r", errors="ignore") as f:
             for line in f:
                 try:
                     data = json.loads(line)
                     ts = parse_iso(data.get("timestamp"))
                     if not ts: continue
+                    ts_str = data.get("timestamp", "")
                     if "toolCalls" in data and isinstance(data["toolCalls"], list):
                         for fc in data["toolCalls"]:
-                            cmd = fc.get("args", {}).get("command", "") or fc.get("args", {}).get("CommandLine", "") or fc.get("args", {}).get("TargetFile", "") or str(fc.get("args", {}))
-                            if len(str(cmd)) > 120: cmd = str(cmd)[:120] + "..."
-                            pending[fc.get("id")] = {"name": fc.get("name", "unknown"), "start": ts, "cmd": cmd}
+                            tname = fc.get("name", "unknown")
+                            args = fc.get("args", {})
+                            cmd = args.get("command", "") or args.get("CommandLine", "") or args.get("TargetFile", "") or str(args)
+                            pending[fc.get("id")] = {"name": tname, "start": ts, "ts_str": ts_str, "cmd": str(cmd)}
                     c = data.get("content", "")
                     if isinstance(c, list):
                         for part in c:
@@ -345,16 +348,26 @@ try:
                                     sinfo = pending.pop(cid)
                                     dur = round((ts - sinfo["start"]).total_seconds(), 3)
                                     tname = sinfo["name"]
+                                    full_cmd = sinfo.get("cmd", "")
+                                    trunc_cmd = full_cmd[:300] + ("..." if len(full_cmd) > 300 else "")
                                     tstat = tool_metrics["tools"].setdefault(tname, {"count": 0, "total_sec": 0, "max_sec": 0, "slowest_cmd": ""})
                                     tstat["count"] += 1
                                     tstat["total_sec"] = round(tstat["total_sec"] + dur, 3)
                                     if dur >= tstat["max_sec"]:
                                         tstat["max_sec"] = dur
-                                        tstat["slowest_cmd"] = sinfo.get("cmd", "")
+                                        tstat["slowest_cmd"] = trunc_cmd[:120] + ("..." if len(trunc_cmd) > 120 else "")
                                     tool_metrics["total_tool_calls"] += 1
                                     tool_metrics["total_tool_duration_sec"] = round(tool_metrics["total_tool_duration_sec"] + dur, 3)
+                                    if tname == "run_shell_command":
+                                        all_shell_calls.append({
+                                            "cmd": trunc_cmd,
+                                            "duration_sec": dur,
+                                            "timestamp": sinfo.get("ts_str", ts.isoformat())
+                                        })
                 except Exception:
                     pass
+        all_shell_calls.sort(key=lambda x: x["duration_sec"], reverse=True)
+        tool_metrics["shell_calls"] = all_shell_calls[:50]
         with open(os.path.join(task_dir, "tool-telemetry.json"), "w") as tf:
             json.dump(tool_metrics, tf, indent=2)
 except Exception:

--- a/factory/pkg/tokenusage/server.go
+++ b/factory/pkg/tokenusage/server.go
@@ -45,10 +45,15 @@ func NewServer(storageRoot string) (*Server, error) {
 	s.mux.HandleFunc("GET /v1/usage/rollups/workflows", s.handleRollupWorkflows)
 	s.mux.HandleFunc("GET /v1/usage/rollups/workflows/{session}", s.handleWorkflowDetail)
 	s.mux.HandleFunc("POST /v1/workflows/{session}/mark-summarized", s.handleMarkSummarized)
+	s.mux.HandleFunc("GET /v1/usage/tools", s.handleUsageTools)
 	s.mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 	return s, nil
+}
+
+func (s *Server) handleUsageTools(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, s.store.SlowestShellCommands(r.URL.Query().Get("repo")))
 }
 
 func (s *Server) Handler() http.Handler { return s.mux }

--- a/factory/pkg/tokenusage/store.go
+++ b/factory/pkg/tokenusage/store.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 // Store persists usage records and subjects as JSONL append logs and keeps
@@ -560,4 +561,144 @@ func (s *Store) Close() error {
 		err = err2
 	}
 	return err
+}
+
+func parseTimeOrNow(tsStr string) time.Time {
+	if tsStr != "" {
+		if t, err := time.Parse(time.RFC3339, tsStr); err == nil {
+			return t
+		}
+		if t, err := time.Parse("2006-01-02T15:04:05Z07:00", tsStr); err == nil {
+			return t
+		}
+	}
+	return time.Now().UTC()
+}
+
+// SlowestShellCommands computes top 30 aggregated shell commands and top 5 slowest calls per period (day, week, month).
+func (s *Store) SlowestShellCommands(repoFilter string) SlowestCommandsResponse {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now().UTC()
+	dayLimit := now.Add(-24 * time.Hour)
+	weekLimit := now.Add(-7 * 24 * time.Hour)
+	monthLimit := now.Add(-30 * 24 * time.Hour)
+
+	type aggState struct {
+		count          int
+		totalSec       float64
+		maxSec         float64
+		lastExecutedAt string
+	}
+
+	aggMap := map[string]*aggState{}
+	var dayCalls []ShellCall
+	var weekCalls []ShellCall
+	var monthCalls []ShellCall
+
+	for _, rec := range s.records {
+		if repoFilter != "" && rec.Repo != repoFilter {
+			continue
+		}
+		if rec.ToolTelemetry == nil || len(rec.ToolTelemetry.ShellCalls) == 0 {
+			continue
+		}
+
+		for _, call := range rec.ToolTelemetry.ShellCalls {
+			c := call
+			if c.Repo == "" {
+				c.Repo = rec.Repo
+			}
+			if c.Sandbox == "" {
+				c.Sandbox = rec.Sandbox
+			}
+			if c.TaskType == "" {
+				c.TaskType = rec.TaskType
+			}
+			if c.TaskDir == "" {
+				c.TaskDir = rec.TaskDir
+			}
+			if c.Timestamp == "" {
+				c.Timestamp = rec.RecordedAt
+			}
+
+			st, exists := aggMap[c.Cmd]
+			if !exists {
+				st = &aggState{}
+				aggMap[c.Cmd] = st
+			}
+			st.count++
+			st.totalSec += c.DurationSec
+			if c.DurationSec > st.maxSec {
+				st.maxSec = c.DurationSec
+			}
+			if c.Timestamp > st.lastExecutedAt {
+				st.lastExecutedAt = c.Timestamp
+			}
+
+			t := parseTimeOrNow(c.Timestamp)
+			if t.After(dayLimit) {
+				dayCalls = append(dayCalls, c)
+			}
+			if t.After(weekLimit) {
+				weekCalls = append(weekCalls, c)
+			}
+			if t.After(monthLimit) {
+				monthCalls = append(monthCalls, c)
+			}
+		}
+	}
+
+	var topAgg []AggregatedCommand
+	for cmd, st := range aggMap {
+		avgSec := 0.0
+		if st.count > 0 {
+			avgSec = float64(int(st.totalSec/float64(st.count)*1000+0.5)) / 1000.0
+		}
+		topAgg = append(topAgg, AggregatedCommand{
+			Cmd:            cmd,
+			Count:          st.count,
+			TotalSec:       float64(int(st.totalSec*1000+0.5)) / 1000.0,
+			AvgSec:         avgSec,
+			MaxSec:         float64(int(st.maxSec*1000+0.5)) / 1000.0,
+			LastExecutedAt: st.lastExecutedAt,
+		})
+	}
+
+	sort.Slice(topAgg, func(i, j int) bool {
+		if topAgg[i].MaxSec != topAgg[j].MaxSec {
+			return topAgg[i].MaxSec > topAgg[j].MaxSec
+		}
+		return topAgg[i].Count > topAgg[j].Count
+	})
+	if len(topAgg) > 30 {
+		topAgg = topAgg[:30]
+	}
+
+	sortCalls := func(calls []ShellCall) []ShellCall {
+		sort.Slice(calls, func(i, j int) bool {
+			return calls[i].DurationSec > calls[j].DurationSec
+		})
+		if len(calls) > 5 {
+			return calls[:5]
+		}
+		if calls == nil {
+			return []ShellCall{}
+		}
+		return calls
+	}
+
+	resp := SlowestCommandsResponse{
+		TopSlowestCommands: topAgg,
+		SlowestByPeriod: PeriodSlowest{
+			Day:   sortCalls(dayCalls),
+			Week:  sortCalls(weekCalls),
+			Month: sortCalls(monthCalls),
+		},
+	}
+	if resp.TopSlowestCommands == nil {
+		resp.TopSlowestCommands = []AggregatedCommand{}
+	}
+	return resp
 }

--- a/factory/pkg/tokenusage/store_test.go
+++ b/factory/pkg/tokenusage/store_test.go
@@ -18,6 +18,7 @@ package tokenusage
 
 import (
 	"testing"
+	"time"
 )
 
 func statsFor(model string, input, output, total int64) Stats {
@@ -312,5 +313,62 @@ func mustPut(t *testing.T, s *Store, rec UsageRecord) {
 	t.Helper()
 	if err := s.Put(rec); err != nil {
 		t.Fatalf("Put %s: %v", rec.Key, err)
+	}
+}
+
+func TestSlowestShellCommands(t *testing.T) {
+	s, _ := newTestStore(t)
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	rec1 := UsageRecord{
+		Key:        "sb1:task1",
+		Repo:       "org/repo",
+		RecordedAt: now,
+		Stats:      statsFor("m", 1, 1, 2),
+		ToolTelemetry: &ToolTelemetry{
+			TotalCalls: 2,
+			ShellCalls: []ShellCall{
+				{Cmd: "go test ./...", DurationSec: 45.5, Timestamp: now},
+				{Cmd: "make build", DurationSec: 12.0, Timestamp: now},
+			},
+		},
+	}
+	rec2 := UsageRecord{
+		Key:        "sb2:task2",
+		Repo:       "org/repo",
+		RecordedAt: now,
+		Stats:      statsFor("m", 1, 1, 2),
+		ToolTelemetry: &ToolTelemetry{
+			TotalCalls: 1,
+			ShellCalls: []ShellCall{
+				{Cmd: "go test ./...", DurationSec: 55.5, Timestamp: now},
+			},
+		},
+	}
+
+	mustPut(t, s, rec1)
+	mustPut(t, s, rec2)
+
+	resp := s.SlowestShellCommands("org/repo")
+	if len(resp.TopSlowestCommands) != 2 {
+		t.Fatalf("expected 2 top aggregated commands, got %d", len(resp.TopSlowestCommands))
+	}
+	// "go test ./..." should be first with max 55.5s, count 2, total 101.0s, avg 50.5s
+	top := resp.TopSlowestCommands[0]
+	if top.Cmd != "go test ./..." {
+		t.Errorf("expected top command 'go test ./...', got %q", top.Cmd)
+	}
+	if top.Count != 2 {
+		t.Errorf("expected count 2, got %d", top.Count)
+	}
+	if top.MaxSec != 55.5 {
+		t.Errorf("expected maxSec 55.5, got %f", top.MaxSec)
+	}
+	if top.AvgSec != 50.5 {
+		t.Errorf("expected avgSec 50.5, got %f", top.AvgSec)
+	}
+
+	if len(resp.SlowestByPeriod.Day) != 3 {
+		t.Errorf("expected 3 day calls, got %d", len(resp.SlowestByPeriod.Day))
 	}
 }

--- a/factory/pkg/tokenusage/types.go
+++ b/factory/pkg/tokenusage/types.go
@@ -54,6 +54,58 @@ type TokenUsage struct {
 	Thoughts int64 `json:"thoughts"`
 }
 
+// ToolTelemetry captures accumulated tool execution statistics from task runs.
+type ToolTelemetry struct {
+	TotalCalls       int                 `json:"total_tool_calls"`
+	TotalDurationSec float64             `json:"total_tool_duration_sec"`
+	Tools            map[string]ToolStat `json:"tools,omitempty"`
+	ShellCalls       []ShellCall         `json:"shell_calls,omitempty"`
+}
+
+// ToolStat captures per-tool execution statistics.
+type ToolStat struct {
+	Count      int     `json:"count"`
+	TotalSec   float64 `json:"total_sec"`
+	MaxSec     float64 `json:"max_sec"`
+	SlowestCmd string  `json:"slowest_cmd"`
+}
+
+// ShellCall captures one run_shell_command invocation record.
+type ShellCall struct {
+	Cmd         string  `json:"cmd"`
+	DurationSec float64 `json:"duration_sec"`
+	Timestamp   string  `json:"timestamp"`
+
+	// Attributed context (filled during harvest)
+	Repo     string `json:"repo,omitempty"`
+	TaskType string `json:"taskType,omitempty"`
+	Sandbox  string `json:"sandbox,omitempty"`
+	TaskDir  string `json:"taskDir,omitempty"`
+}
+
+// AggregatedCommand captures aggregated statistics for a unique shell command pattern.
+type AggregatedCommand struct {
+	Cmd            string  `json:"cmd"`
+	Count          int     `json:"count"`
+	TotalSec       float64 `json:"total_sec"`
+	AvgSec         float64 `json:"avg_sec"`
+	MaxSec         float64 `json:"max_sec"`
+	LastExecutedAt string  `json:"last_executed_at"`
+}
+
+// PeriodSlowest contains the top 5 slowest shell command invocations for day, week, and month.
+type PeriodSlowest struct {
+	Day   []ShellCall `json:"day"`
+	Week  []ShellCall `json:"week"`
+	Month []ShellCall `json:"month"`
+}
+
+// SlowestCommandsResponse is returned by GET /v1/usage/tools.
+type SlowestCommandsResponse struct {
+	TopSlowestCommands []AggregatedCommand `json:"top_slowest_commands"`
+	SlowestByPeriod    PeriodSlowest       `json:"slowest_by_period"`
+}
+
 // UsageRecord is one harvested task's usage, with enough context to roll it
 // up by issue, PR, or workflow. Key is the idempotency key
 // "<sandbox>:<taskDir>"; re-posting the same key upserts the record.
@@ -73,8 +125,9 @@ type UsageRecord struct {
 	Workflow     string `json:"workflow,omitempty"`
 	WorkflowName string `json:"workflowName,omitempty"`
 
-	RecordedAt string `json:"recordedAt,omitempty"` // RFC3339
-	Stats      Stats  `json:"stats"`
+	RecordedAt    string         `json:"recordedAt,omitempty"` // RFC3339
+	Stats         Stats          `json:"stats"`
+	ToolTelemetry *ToolTelemetry `json:"toolTelemetry,omitempty"`
 }
 
 // Rollup is an aggregate of usage records grouped by some key

--- a/factory/pkg/usagereport/report.go
+++ b/factory/pkg/usagereport/report.go
@@ -169,6 +169,24 @@ func postJSON(ctx context.Context, path string, v any) error {
 	return nil
 }
 
+// ReadTaskToolTelemetry reads tool-telemetry.json from a task dir inside the sandbox.
+func ReadTaskToolTelemetry(ctx context.Context, client *envd.Client, taskDir string) (*ToolTelemetry, error) {
+	var stdout, stderr bytes.Buffer
+	catCmd := fmt.Sprintf("cat %s/tool-telemetry.json 2>/dev/null || true", taskDir)
+	if err := client.Exec(ctx, catCmd, "/workspaces", nil, nil, &stdout, &stderr); err != nil {
+		return nil, nil
+	}
+	data := strings.TrimSpace(stdout.String())
+	if data == "" {
+		return nil, nil
+	}
+	var telemetry ToolTelemetry
+	if err := json.Unmarshal([]byte(data), &telemetry); err != nil {
+		return nil, nil
+	}
+	return &telemetry, nil
+}
+
 // HarvestTask reads one task dir's usage and publishes it. Best-effort:
 // failures are logged, never returned.
 func HarvestTask(ctx context.Context, client *envd.Client, taskDir string, meta Meta) {
@@ -201,6 +219,25 @@ func HarvestTask(ctx context.Context, client *envd.Client, taskDir string, meta 
 		RecordedAt:   time.Now().UTC().Format(time.RFC3339),
 		Stats:        *stats,
 	}
+
+	if tt, err := ReadTaskToolTelemetry(ctx, client, taskDir); err == nil && tt != nil {
+		for i := range tt.ShellCalls {
+			if tt.ShellCalls[i].Repo == "" {
+				tt.ShellCalls[i].Repo = meta.Repo
+			}
+			if tt.ShellCalls[i].TaskType == "" {
+				tt.ShellCalls[i].TaskType = taskType
+			}
+			if tt.ShellCalls[i].Sandbox == "" {
+				tt.ShellCalls[i].Sandbox = meta.Sandbox
+			}
+			if tt.ShellCalls[i].TaskDir == "" {
+				tt.ShellCalls[i].TaskDir = taskDir
+			}
+		}
+		rec.ToolTelemetry = tt
+	}
+
 	if err := Publish(ctx, rec); err != nil {
 		klog.Warningf("usagereport: publishing usage for %s: %v", rec.Key, err)
 		return

--- a/factory/pkg/usagereport/types.go
+++ b/factory/pkg/usagereport/types.go
@@ -26,11 +26,17 @@ import (
 
 // Aliases to the canonical collector types defined in factory/pkg/tokenusage.
 type (
-	Stats       = tokenusage.Stats
-	ModelUsage  = tokenusage.ModelUsage
-	APIUsage    = tokenusage.APIUsage
-	TokenUsage  = tokenusage.TokenUsage
-	UsageRecord = tokenusage.UsageRecord
-	Rollup      = tokenusage.Rollup
-	Subject     = tokenusage.Subject
+	Stats         = tokenusage.Stats
+	ModelUsage    = tokenusage.ModelUsage
+	APIUsage      = tokenusage.APIUsage
+	TokenUsage    = tokenusage.TokenUsage
+	UsageRecord   = tokenusage.UsageRecord
+	Rollup        = tokenusage.Rollup
+	Subject       = tokenusage.Subject
+	ToolTelemetry           = tokenusage.ToolTelemetry
+	ToolStat                = tokenusage.ToolStat
+	ShellCall               = tokenusage.ShellCall
+	AggregatedCommand       = tokenusage.AggregatedCommand
+	PeriodSlowest           = tokenusage.PeriodSlowest
+	SlowestCommandsResponse = tokenusage.SlowestCommandsResponse
 )

--- a/factory/pkg/usagereport/types.go
+++ b/factory/pkg/usagereport/types.go
@@ -26,13 +26,13 @@ import (
 
 // Aliases to the canonical collector types defined in factory/pkg/tokenusage.
 type (
-	Stats         = tokenusage.Stats
-	ModelUsage    = tokenusage.ModelUsage
-	APIUsage      = tokenusage.APIUsage
-	TokenUsage    = tokenusage.TokenUsage
-	UsageRecord   = tokenusage.UsageRecord
-	Rollup        = tokenusage.Rollup
-	Subject       = tokenusage.Subject
+	Stats                   = tokenusage.Stats
+	ModelUsage              = tokenusage.ModelUsage
+	APIUsage                = tokenusage.APIUsage
+	TokenUsage              = tokenusage.TokenUsage
+	UsageRecord             = tokenusage.UsageRecord
+	Rollup                  = tokenusage.Rollup
+	Subject                 = tokenusage.Subject
 	ToolTelemetry           = tokenusage.ToolTelemetry
 	ToolStat                = tokenusage.ToolStat
 	ShellCall               = tokenusage.ShellCall

--- a/repo-agent/review-ui/ui/src/TokenUsage.js
+++ b/repo-agent/review-ui/ui/src/TokenUsage.js
@@ -128,11 +128,142 @@ const RollupTable = ({ title, subtitle, rollups, keyLabel, renderKey, showSubjec
 
 const prList = (prs) => (prs || []).map(n => `#${n}`).join(', ');
 
+const ToolTelemetrySection = ({ toolData }) => {
+    const [periodTab, setPeriodTab] = useState('day');
+    if (!toolData) return null;
+
+    const topCmds = toolData.top_slowest_commands || [];
+    const periodCalls = (toolData.slowest_by_period && toolData.slowest_by_period[periodTab]) || [];
+
+    const tabLabels = {
+        day: 'Past 24 Hours',
+        week: 'Past 7 Days',
+        month: 'Past 30 Days'
+    };
+
+    const formatTs = (ts) => {
+        if (!ts) return '-';
+        try {
+            const d = new Date(ts);
+            return isNaN(d.getTime()) ? ts : d.toLocaleString();
+        } catch (e) {
+            return ts;
+        }
+    };
+
+    return (
+        <div style={{ backgroundColor: 'var(--bg-card)', borderRadius: '8px', boxShadow: 'var(--shadow-card)', padding: '16px', marginBottom: '24px' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '12px' }}>
+                <div>
+                    <h3 style={{ margin: '0 0 2px 4px', color: 'var(--text-primary)' }}>⚡ Slowest Tool Execution Telemetry</h3>
+                    <p style={{ margin: '0 0 4px 4px', color: 'var(--text-secondary)', fontSize: '13px' }}>
+                        Tracking top shell command bottlenecks, average execution durations, and historical slowest commands over time.
+                    </p>
+                </div>
+            </div>
+
+            {/* Period Slowest Section */}
+            <div style={{ marginBottom: '20px', padding: '12px', backgroundColor: 'var(--bg-secondary)', borderRadius: '6px' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' }}>
+                    <h4 style={{ margin: 0, fontSize: '14px', color: '#58a6ff' }}>🏆 Top 5 Slowest Executions ({tabLabels[periodTab]})</h4>
+                    <div style={{ display: 'flex', gap: '8px' }}>
+                        {['day', 'week', 'month'].map(p => (
+                            <button
+                                key={p}
+                                className="btn"
+                                onClick={() => setPeriodTab(p)}
+                                style={{
+                                    padding: '4px 10px',
+                                    fontSize: '12px',
+                                    backgroundColor: periodTab === p ? '#1f6feb' : 'transparent',
+                                    color: periodTab === p ? '#fff' : 'var(--text-secondary)',
+                                    border: '1px solid var(--border-color)'
+                                }}
+                            >
+                                {tabLabels[p]}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+
+                {periodCalls.length === 0 ? (
+                    <p style={{ color: 'var(--text-secondary)', fontSize: '13px', margin: '4px' }}>No command executions recorded in this time window.</p>
+                ) : (
+                    <div style={{ overflowX: 'auto' }}>
+                        <table style={{ width: '100%', borderCollapse: 'collapse', textAlign: 'left', fontSize: '12px' }}>
+                            <thead>
+                                <tr style={{ borderBottom: '1px solid var(--border-color)', color: 'var(--text-secondary)' }}>
+                                    <th style={{ padding: '6px 10px', width: '40px' }}>Rank</th>
+                                    <th style={{ padding: '6px 10px' }}>Command</th>
+                                    <th style={{ padding: '6px 10px', textAlign: 'right' }}>Duration</th>
+                                    <th style={{ padding: '6px 10px' }}>Date / Time</th>
+                                    <th style={{ padding: '6px 10px' }}>Context</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {periodCalls.map((c, idx) => (
+                                    <tr key={idx} style={{ borderBottom: '1px solid var(--border-color)' }}>
+                                        <td style={{ padding: '6px 10px', fontWeight: 'bold', color: '#8b949e' }}>#{idx + 1}</td>
+                                        <td style={{ padding: '6px 10px', fontFamily: 'monospace', color: '#7ee787', wordBreak: 'break-all' }}>{c.cmd}</td>
+                                        <td style={{ padding: '6px 10px', textAlign: 'right', fontWeight: 'bold', color: c.duration_sec > 60 ? '#ff7b72' : '#e6edf3' }}>
+                                            {c.duration_sec}s
+                                        </td>
+                                        <td style={{ padding: '6px 10px', whiteSpace: 'nowrap', color: 'var(--text-secondary)' }}>{formatTs(c.timestamp)}</td>
+                                        <td style={{ padding: '6px 10px', color: 'var(--text-secondary)', fontSize: '11px', whiteSpace: 'nowrap' }}>
+                                            {c.sandbox || c.taskType || '-'} {c.repo ? `(${c.repo})` : ''}
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                )}
+            </div>
+
+            {/* Aggregated Commands Section */}
+            <div>
+                <h4 style={{ margin: '0 0 10px 4px', fontSize: '14px', color: 'var(--text-primary)' }}>📊 Top Slowest Aggregated Commands (Count & Avg Duration)</h4>
+                {topCmds.length === 0 ? (
+                    <p style={{ color: 'var(--text-secondary)', margin: '4px' }}>No shell commands recorded yet.</p>
+                ) : (
+                    <div style={{ overflowX: 'auto' }}>
+                        <table style={{ width: '100%', borderCollapse: 'collapse', textAlign: 'left' }}>
+                            <thead>
+                                <tr>
+                                    <th style={thStyle}>Command</th>
+                                    <th style={{ ...thStyle, textAlign: 'right' }}>Calls</th>
+                                    <th style={{ ...thStyle, textAlign: 'right' }}>Total Time</th>
+                                    <th style={{ ...thStyle, textAlign: 'right' }}>Avg Time</th>
+                                    <th style={{ ...thStyle, textAlign: 'right' }}>Max Time</th>
+                                    <th style={{ ...thStyle, textAlign: 'right' }}>Last Executed</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {topCmds.map((ac, idx) => (
+                                    <tr key={idx} className="table-row-hover">
+                                        <td style={{ ...tdStyle, fontFamily: 'monospace', color: '#7ee787', fontSize: '12px', wordBreak: 'break-all' }}>{ac.cmd}</td>
+                                        <td style={numStyle}>{fmt(ac.count)}</td>
+                                        <td style={numStyle}>{ac.total_sec}s</td>
+                                        <td style={{ ...numStyle, fontWeight: 'bold' }}>{ac.avg_sec}s</td>
+                                        <td style={{ ...numStyle, color: ac.max_sec > 60 ? '#ff7b72' : 'inherit', fontWeight: ac.max_sec > 60 ? 'bold' : 'normal' }}>{ac.max_sec}s</td>
+                                        <td style={{ ...numStyle, fontSize: '12px', color: 'var(--text-secondary)' }}>{formatTs(ac.last_executed_at)}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
 const TokenUsage = ({ onBack }) => {
     const [daily, setDaily] = useState([]);
     const [workflows, setWorkflows] = useState([]);
     const [issues, setIssues] = useState([]);
     const [prs, setPRs] = useState([]);
+    const [toolData, setToolData] = useState(null);
     const [error, setError] = useState(null);
 
     const fetchRollups = useCallback(() => {
@@ -151,7 +282,11 @@ const TokenUsage = ({ onBack }) => {
                 })
                 .then(data => {
                     setError(null);
-                    setter(data.rollups || []);
+                    if (path.includes('v1/usage/tools')) {
+                        setter(data);
+                    } else {
+                        setter(data.rollups || []);
+                    }
                 });
 
         Promise.all([
@@ -159,6 +294,7 @@ const TokenUsage = ({ onBack }) => {
             get('v1/usage/rollups/workflows', setWorkflows),
             get('v1/usage/rollups/issues', setIssues),
             get('v1/usage/rollups/prs', setPRs),
+            get('v1/usage/tools', setToolData),
         ]).catch(err => {
             console.error('Failed to fetch token usage:', err);
             setError(err.message);
@@ -174,7 +310,7 @@ const TokenUsage = ({ onBack }) => {
     return (
         <div style={{ padding: '24px', maxWidth: '1400px', margin: '0 auto' }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px' }}>
-                <h2 style={{ margin: 0, color: 'var(--text-primary)' }}>Gemini Token Usage</h2>
+                <h2 style={{ margin: 0, color: 'var(--text-primary)' }}>Gemini Token & Tool Telemetry Usage</h2>
                 <button className="btn" onClick={onBack} style={{ padding: '8px 16px', fontWeight: '500' }}>Back to Dashboard</button>
             </div>
 
@@ -183,6 +319,8 @@ const TokenUsage = ({ onBack }) => {
                     <strong>⚠️ Failed to load token usage:</strong> {error}
                 </div>
             )}
+
+            <ToolTelemetrySection toolData={toolData} />
 
             <RollupTable
                 title="Daily Usage"


### PR DESCRIPTION
## Summary
Extends the tool execution telemetry feature to collect all `run_shell_command` tool invocations per task and publish them to the central `token-usage` collector service, surfacing historical slowest commands and aggregated execution stats in the UI.

## Key Changes
1. **Task Shell Telemetry Collection**: Updated all task scripts (`address_feedback.sh`, `adopt.sh`, `fix_issue.sh`, `investigate_failures.sh`, `iterate.sh`, `review.sh`, `run_agent.sh`) to collect up to 50 `run_shell_command` calls sorted by duration, writing `cmd`, `duration_sec`, and `timestamp` into `tool-telemetry.json`.
2. **Collector Storage & Indexing**: Extended `factory/pkg/tokenusage` types (`ToolTelemetry`, `ShellCall`, `AggregatedCommand`, `SlowestCommandsResponse`) and `Store` to index shell command executions across tasks.
3. **Usage API Endpoint**: Registered `GET /v1/usage/tools` on the collector (proxied to `/api/usage/v1/usage/tools`), returning:
   - Top 30 aggregated slowest commands with total count, total duration, average duration (`avg_sec`), max duration (`max_sec`), and last executed timestamp.
   - Top 5 slowest individual shell command calls for **Past 24 Hours (Day)**, **Past 7 Days (Week)**, and **Past 30 Days (Month)** with recorded date/time and sandbox context.
4. **Harvest Engine**: Updated `factory/pkg/usagereport` to read `tool-telemetry.json` when completing or sweeping tasks and publish tool telemetry records alongside model token usage.
5. **UI Integration**: Updated `TokenUsage.js` in `review-ui` with a new **⚡ Slowest Tool Execution Telemetry** section featuring period tabs (Day, Week, Month) and an aggregated slowest command table.