### PR TITLE
fix(overseer): prevent concurrent task execution in sandboxes & fix proc status parsing

### DIFF
--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -259,13 +259,19 @@ func isSandboxTaskRunning(ctx context.Context, kubeClient *clients.KubernetesCli
 					stat=$(ps -o stat= -p "$pid" 2>/dev/null | cut -c 1)
 					if ! kill -0 "$pid" 2>/dev/null || [ "$stat" = "Z" ]; then
 						echo "137" # Report SIGKILL/Crashed/Zombie fallback exit code
+					else
+						echo "RUNNING"
 					fi
+				else
+					echo "NOTASKS"
 				fi
 			fi`
 			if err := client.Exec(ctx, checkCmd, "/workspaces", nil, nil, &buf, nil); err == nil {
 				exitStr := strings.TrimSpace(buf.String())
 				if exitStr == "NOTASKS" {
 					return false, nil
+				} else if exitStr == "RUNNING" {
+					return true, nil
 				} else if exitStr != "" {
 					// Task has finished!
 					taskState := "Completed"

--- a/factory/pkg/envd/client.go
+++ b/factory/pkg/envd/client.go
@@ -401,6 +401,27 @@ func (c *Client) RunTaskResilient(ctx context.Context, cmdStr string, envs map[s
 	} else if isAlreadyRunning {
 		klog.Infof("Task in directory %s is already running. Reattaching...", taskDir)
 	} else {
+		// Verify no OTHER task in /workspaces/tasks is actively running before launching
+		var activeBuf bytes.Buffer
+		checkActiveCmd := fmt.Sprintf(`for d in /workspaces/tasks/*/; do
+  if [ -d "$d" ] && [ "$d" != "%s/" ] && [ ! -s "$d/exit_code" ] && [ -s "$d/pid" ]; then
+    pid=$(cat "$d/pid" 2>/dev/null)
+    if [ -n "$pid" ]; then
+      stat=$(ps -o stat= -p "$pid" 2>/dev/null | cut -c 1)
+      if kill -0 "$pid" 2>/dev/null && [ "$stat" != "Z" ]; then
+        echo "$d"
+        break
+      fi
+    fi
+  fi
+done`, strings.TrimSuffix(taskDir, "/"))
+		if err := c.Exec(ctx, checkActiveCmd, "/workspaces", nil, nil, &activeBuf, nil); err == nil {
+			activeTask := strings.TrimSpace(activeBuf.String())
+			if activeTask != "" {
+				return fmt.Errorf("cannot start task in %s: sandbox is currently running another task in %s", taskDir, activeTask)
+			}
+		}
+
 		// Ensure the task directory exists inside the pod before writing to it
 		if err := c.Exec(ctx, fmt.Sprintf("mkdir -p %s", taskDir), "/workspaces", nil, nil, nil, nil); err != nil {
 			return fmt.Errorf("failed to create task directory in pod: %w", err)

--- a/factory/pkg/envd/client.go
+++ b/factory/pkg/envd/client.go
@@ -401,27 +401,6 @@ func (c *Client) RunTaskResilient(ctx context.Context, cmdStr string, envs map[s
 	} else if isAlreadyRunning {
 		klog.Infof("Task in directory %s is already running. Reattaching...", taskDir)
 	} else {
-		// Verify no OTHER task in /workspaces/tasks is actively running before launching
-		var activeBuf bytes.Buffer
-		checkActiveCmd := fmt.Sprintf(`for d in /workspaces/tasks/*/; do
-  if [ -d "$d" ] && [ "$d" != "%s/" ] && [ ! -s "$d/exit_code" ] && [ -s "$d/pid" ]; then
-    pid=$(cat "$d/pid" 2>/dev/null)
-    if [ -n "$pid" ]; then
-      stat=$(ps -o stat= -p "$pid" 2>/dev/null | cut -c 1)
-      if kill -0 "$pid" 2>/dev/null && [ "$stat" != "Z" ]; then
-        echo "$d"
-        break
-      fi
-    fi
-  fi
-done`, strings.TrimSuffix(taskDir, "/"))
-		if err := c.Exec(ctx, checkActiveCmd, "/workspaces", nil, nil, &activeBuf, nil); err == nil {
-			activeTask := strings.TrimSpace(activeBuf.String())
-			if activeTask != "" {
-				return fmt.Errorf("cannot start task in %s: sandbox is currently running another task in %s", taskDir, activeTask)
-			}
-		}
-
 		// Ensure the task directory exists inside the pod before writing to it
 		if err := c.Exec(ctx, fmt.Sprintf("mkdir -p %s", taskDir), "/workspaces", nil, nil, nil, nil); err != nil {
 			return fmt.Errorf("failed to create task directory in pod: %w", err)

--- a/repo-agent/pkg/api/handlers_overseer.go
+++ b/repo-agent/pkg/api/handlers_overseer.go
@@ -459,7 +459,9 @@ if os.path.exists(tasks_dir):
                 with open(os.path.join(p, "pid")) as f: pid = int(f.read().strip())
                 stat = ""
                 if os.path.exists(f"/proc/{pid}/stat"):
-                    with open(f"/proc/{pid}/stat") as sf: stat = sf.read().split()[2] if len(sf.read().split()) > 2 else ""
+                    with open(f"/proc/{pid}/stat") as sf:
+                        cnt = sf.read().split()
+                        stat = cnt[2] if len(cnt) > 2 else ""
                 if stat.startswith("Z"): status = "Crashed"; ec = "137"
                 else:
                     try:


### PR DESCRIPTION
## Summary
Fixes an issue where Overseer could launch a second task into an active sandbox pod while a previous task was still running, and resolves a process status parsing bug in `handlers_overseer.go`.

## Root Cause
1. **False Idle Detection**: In `watch.go`, `isSandboxTaskRunning` previously returned `false` when a task had no `exit_code` file yet but its PID was alive (because `checkCmd` outputted an empty string `""` when the process was alive). Overseer interpreted the empty output as "sandbox is idle" and dispatched new tasks into active pods.
2. **Double-Read Stream Bug**: In `handlers_overseer.go`, `sf.read().split()[2] if len(sf.read().split()) > 2 else ""` read from `/proc/<pid>/stat` twice. The second read returned an empty string (`""`) at EOF, causing process status parsing to fail.

## Fixes
- **`watch.go`**: Updated `checkCmd` in `isSandboxTaskRunning` to explicitly output `"RUNNING"` when a PID is alive and not a zombie, returning `true, nil` so Overseer skips scheduling new tasks into busy sandboxes.
- **`handlers_overseer.go`**: Fixed the Python stream reading bug by assigning `cnt = sf.read().split()` once.


<img width="2256" height="840" alt="image" src="https://github.com/user-attachments/assets/3dd7c2b3-2213-4ed0-9d1f-2d9f5692ca9c" />
