### PR TITLE
fix(watch): paginate open PR list when populating referenced issues cache

### DIFF
--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -1671,11 +1671,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 		// Populate PR cache once on startup if needed by issue scan
 		if !hasPRs && runIssueScan {
 			klog.Infof("Populating open PRs cache for referenced issues...")
-			prOpts := &githubv39.PullRequestListOptions{
-				State:       "open",
-				ListOptions: githubv39.ListOptions{PerPage: 100},
-			}
-			prs, _, err := ghClient.PullRequests.List(ctx, owner, repo, prOpts)
+			prs, err := listAllOpenPRs(ctx, ghClient, owner, repo)
 			if err == nil {
 				state.mu.Lock()
 				state.openPRs = prs
@@ -1695,11 +1691,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 		// 1. Slow PR Scan Cycle
 		if runPRScan {
 			klog.Infof("Running slow PR scan cycle...")
-			prOpts := &githubv39.PullRequestListOptions{
-				State:       "open",
-				ListOptions: githubv39.ListOptions{PerPage: 100},
-			}
-			prs, _, err := ghClient.PullRequests.List(ctx, owner, repo, prOpts)
+			prs, err := listAllOpenPRs(ctx, ghClient, owner, repo)
 			if err == nil {
 				state.mu.Lock()
 				state.openPRs = prs
@@ -2419,6 +2411,26 @@ func getReferencedIssues(pr *githubv39.PullRequest) map[int]bool {
 	}
 
 	return referenced
+}
+
+func listAllOpenPRs(ctx context.Context, ghClient *githubv39.Client, owner, repo string) ([]*githubv39.PullRequest, error) {
+	var allPRs []*githubv39.PullRequest
+	opts := &githubv39.PullRequestListOptions{
+		State:       "open",
+		ListOptions: githubv39.ListOptions{PerPage: 100},
+	}
+	for {
+		prs, resp, err := ghClient.PullRequests.List(ctx, owner, repo, opts)
+		if err != nil {
+			return nil, err
+		}
+		allPRs = append(allPRs, prs...)
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return allPRs, nil
 }
 
 func syncReferencedIssueLabels(ctx context.Context, ghClient *githubv39.Client, owner, repo string, pr *githubv39.PullRequest, prIssue *githubv39.Issue) {


### PR DESCRIPTION
## Summary
Fixes an issue where duplicate PRs could be created for open issues when sandboxes are cleaned up or during upgrades.

## Root Cause
In repositories with more than 100 open PRs (such as `GoogleCloudPlatform/k8s-config-connector` which has 500+ open PRs), `watch.go` fetched open PRs using `ghClient.PullRequests.List(ctx, owner, repo, prOpts)` without paginating through results. As a result, only the first 100 open PRs were loaded into `state.referencedIssues`. Older open PRs (on pages 2, 3, etc.) were omitted from the referenced issues cache, causing Overseer to incorrectly conclude that no PR existed for the issue and schedule duplicate fix tasks.

## Fix
- Added `listAllOpenPRs` helper in `watch.go` to paginate through all open PR pages using `resp.NextPage`.
- Updated startup and slow PR scan cycles to use `listAllOpenPRs`, ensuring complete coverage of all open PRs in `state.referencedIssues`.

## Example failure:
https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/11153

<img width="2006" height="1134" alt="image" src="https://github.com/user-attachments/assets/22881142-dbb1-4f81-81c0-489a60f694b2" />
