### PR TITLE
fix(watch): process queued tasks in FIFO order by CreatedAt time

### DIFF
--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -2019,7 +2019,7 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 						if tI.Phase > tJ.Phase {
 							swap = true
 						} else if tI.Phase == tJ.Phase {
-							if tI.CreatedAt.Before(tJ.CreatedAt) {
+							if tI.CreatedAt.After(tJ.CreatedAt) {
 								swap = true
 							}
 						}


### PR DESCRIPTION
## Summary
Fixes a queue sorting bug where older queued tasks were sorted *after* newer tasks within the same priority rank, causing older workflow tasks to starve at the end of the queue.

## Root Cause
In `watch.go` queue sorting, when tasks shared equal priority, `tI.CreatedAt.Before(tJ.CreatedAt)` caused newer tasks to take precedence over older tasks. In queues with hundreds of items (500+ items in `incoming/`) and a `maxPending` active sandbox limit, older tasks (such as workflow tasks created earlier) were continuously pushed to the end of the queue and starved.

## Fix
Updated task sorting in `watch.go` to compare `tI.CreatedAt.After(tJ.CreatedAt)` so tasks are executed in true FIFO order.


## Failing workflow

starved workflow: https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/10975
did not go to the next step for 5 hrs

<img width="1036" height="952" alt="image" src="https://github.com/user-attachments/assets/cbf97294-537c-4667-8310-a3de0b439d4a" />
