### PR TITLE
chore: run go mod tidy on factory module

### DIFF
--- a/factory/go.mod
+++ b/factory/go.mod
@@ -16,6 +16,7 @@ require (
 	k8s.io/apimachinery v0.35.4
 	k8s.io/client-go v0.35.4
 	k8s.io/klog/v2 v2.140.0
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -52,5 +53,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )


### PR DESCRIPTION
## Summary
Runs `go mod tidy` on the `factory/` Go module to keep module dependencies clean and formatted according to repository guidelines.