### PR TITLE
fix(api): select target overseer pod IP matching overseer-<name> instead of pods.Items[0]

### DIFF
--- a/repo-agent/pkg/api/handlers_overseer.go
+++ b/repo-agent/pkg/api/handlers_overseer.go
@@ -691,7 +691,20 @@ func (s *Server) getOverseerQueue(c *gin.Context) {
 		return
 	}
 
-	podIP := pods.Items[0].Status.PodIP
+	var targetPod *corev1.Pod
+	expectedName := fmt.Sprintf("overseer-%s", overseerName)
+	for i := range pods.Items {
+		p := &pods.Items[i]
+		if p.Name == expectedName || strings.HasPrefix(p.Name, "overseer-") {
+			targetPod = p
+			break
+		}
+	}
+	if targetPod == nil {
+		targetPod = &pods.Items[0]
+	}
+
+	podIP := targetPod.Status.PodIP
 	if podIP == "" {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Overseer pod has no IP address allocated yet"})
 		return
@@ -738,7 +751,20 @@ func (s *Server) updateOverseerQueueTaskPriority(c *gin.Context) {
 		return
 	}
 
-	podIP := pods.Items[0].Status.PodIP
+	var targetPod *corev1.Pod
+	expectedName := fmt.Sprintf("overseer-%s", overseerName)
+	for i := range pods.Items {
+		p := &pods.Items[i]
+		if p.Name == expectedName || strings.HasPrefix(p.Name, "overseer-") {
+			targetPod = p
+			break
+		}
+	}
+	if targetPod == nil {
+		targetPod = &pods.Items[0]
+	}
+
+	podIP := targetPod.Status.PodIP
 	if podIP == "" {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Overseer pod has no IP address allocated yet"})
 		return


### PR DESCRIPTION
## Summary
Fixes an issue where `getOverseerQueue` and `updateOverseerQueueTaskPriority` in `repo-agent/pkg/api/handlers_overseer.go` selected `pods.Items[0]` when listing pods in the `overseer-kcc` namespace.

Because the namespace contains 30+ sandbox pods (e.g. `agent-k8s-config-connector-pr-review-assigner`), `pods.Items[0]` returned the first alphabetical sandbox pod rather than `pod/overseer-kcc`. The sandbox pod does not expose port 13338, causing connections to fail and triggering the fallback banner continuously.

## Fix
Filter `pods.Items` for the pod whose name matches `overseer-<name>` or starts with `overseer-` to ensure port 13338 queries hit the controller daemon pod.