### PR TITLE
fix(watch): ignore scaled-down sandboxes (replicas==0) in countRunningSandboxTasks

### DIFF
--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -346,6 +346,18 @@ func countRunningSandboxTasks(ctx context.Context, kubeClient *clients.Kubernete
 			continue
 		}
 
+		if spec, ok := item.Object["spec"].(map[string]interface{}); ok {
+			if r, ok := spec["replicas"].(int64); ok && r == 0 {
+				continue
+			}
+			if r, ok := spec["replicas"].(float64); ok && int64(r) == 0 {
+				continue
+			}
+			if r, ok := spec["replicas"].(int); ok && r == 0 {
+				continue
+			}
+		}
+
 		annotations := item.GetAnnotations()
 		if annotations == nil {
 			count++


### PR DESCRIPTION
## Summary
Fixes a critical bug where Overseer stopped scheduling incoming tasks because it calculated `runningCount = 120` and hit the `maxPending` limit (40).

## Root Cause
`countRunningSandboxTasks` in `factory/pkg/commands/watch.go` counted any sandbox object whose `sandbox.gemini.google.com/last-task-state` annotation was empty (`""`) as a running task.
In namespaces with retained/scaled-down sandboxes (`spec.replicas == 0`), these idle sandboxes were counted as active running tasks, permanently preventing Overseer from scheduling new incoming queue tasks.

## Fix
Check `spec.replicas == 0` in `countRunningSandboxTasks` and skip scaled-down sandboxes.