### PR TITLE
Denormalize and unify direct controller implementer skills in greenfield v2 workflow

### DIFF
--- a/.agents/workflows/kcc-greenfield-v2.txt
+++ b/.agents/workflows/kcc-greenfield-v2.txt
@@ -225,7 +225,9 @@ Open a GitHub issue to coordinate the implementation of the direct controller an
         - Add `update.yaml`: Update all **mutable** fields.
         - Add `dependencies.yaml` if the resource requires other KCC resources to exist first.
 
-    7.  **Record Golden Files (Real GCP)**:
+    7.  **MANDATORY: Record Golden Files Against Real GCP (`hack/record-gcp`)**:
+        - **STRICT GUARDRAIL — DO NOT USE MOCKGCP OR OFFLINE MOCKS**: You MUST record golden files directly against real GCP using `./hack/record-gcp`. Do **NOT** attempt to use `mockgcp`, do NOT search for or try to implement mockgcp services, and do NOT use `hack/compare-mock` or `E2E_GCP_TARGET=mock`.
+        - **MANDATORY EXECUTION**: You are explicitly required to run `./hack/record-gcp` on both your minimal and maximal fixtures before running any validation tests in Step 8 or preparing the PR in Step 9. Skipping this step or attempting to substitute mock tests is considered a critical failure.
         Run `hack/record-gcp "fixtures/^<testname>$"` to capture real GCP behavior and record traffic and object state:
         ```bash
         # Run from the repository root for both minimal and maximal fixtures
@@ -238,7 +240,7 @@ Open a GitHub issue to coordinate the implementation of the direct controller an
           ```
           *(For example: `gcloud services enable compute.googleapis.com` or `gcloud services enable run.googleapis.com`)*
 
-          - Using the `hack/record-gcp` wrapper ensures a sufficient timeout (e.g., 30-60 minutes) is already configured, automatically handling slow GCP resource creation. There is no need to specify additional timeout flags when using this helper.
+        - Using the `hack/record-gcp` wrapper ensures a sufficient timeout (e.g., 30-60 minutes) is already configured, automatically handling slow GCP resource creation. There is no need to specify additional timeout flags when using this helper.
 
     8.  **Validation & Last-Mile Tests**:
         Run the following tests to ensure CI compliance and verify field coverage:

--- a/.agents/workflows/kcc-greenfield-v2.txt
+++ b/.agents/workflows/kcc-greenfield-v2.txt
@@ -1,0 +1,321 @@
+---
+description: A meta-skill for KCC Greenfield resources that describes the steps we need to take to get them to be "production ready" direct controllers at v1alpha1 at least.
+name: kcc-greenfield-v2
+schedule: never
+mode: workflow
+cooldown: 2h
+---
+
+# Checklist for KCC Greenfield Resource Migration
+
+This is a meta-skill describing the steps to migrate a KCC greenfield resource kind to a production-ready direct controller at `v1alpha1`.
+Greenfield resources are API resources that have not yet been implemented in KCC, they can be part of a brand new API or new resources in an existing API. 
+Compare to Brownfield resources which are already implemented in KCC.
+
+Instead of doing the coding yourself under this skill, you will coordinate and orchestrate:
+1. Planning the migration steps.
+2. Opening GitHub issues for each step, labeling them with `overseer`, and leaving them unassigned (or assigning them to the current bot user).
+3. Monitoring progress of the Pull Requests.
+4. Opening subsequent issues once the prior steps are successfully completed.
+
+> [!IMPORTANT]
+> **Safety Guardrails (Strict Enforcement)**:
+> - **Do NOT write code or create PRs directly**: You must **never** checkout code, write code, run builds/tests, commit changes, or run `gh pr create` to send/push PRs. Your role under this skill is strictly limited to planning, progress tracking, and orchestration. All code implementation, CI fixing, and triage work must be delegated to coder and reviewer bots by creating child issues or assigning PRs back to their author bots.
+> - **Do NOT comment on child Pull Requests**: You must **never** comment directly on the child Pull Requests. The watch daemon will automatically monitor and handle PR review feedback and CI check failures. If you need to request action or re-trigger a run, do so only by assigning the PR to the PR author bot (using `gh pr edit <pr> --add-assignee <author>` or assigning via `gh` CLI). However, if the PR has the `overseer/giving-up` label, you MUST NOT assign the PR back to the bot, as this indicates the retry limit was reached and human OWNER intervention is required.
+> - **Do NOT approve, LGTM, or label PRs**: You must **never** approve, LGTM, or add approval/merging labels (such as `lgtm`, `approved`, or `automerge`) to any Pull Requests. These actions require human OWNER review and approval.
+> - **Do NOT work on closed Pull Requests**: If a PR is closed but not merged, dont assign bots to the PR.
+> - **Idempotent Issue Creation & Journal Recording**:
+>   - **Before creating any child issue**, you MUST search GitHub first for an existing open issue for that step:
+>     `gh issue list --repo GoogleCloudPlatform/k8s-config-connector --search "<step-title-keywords> {kind}" --json number,title,state`
+>   - If an open issue with that title already exists, **DO NOT run `gh issue create`**. Reuse the existing issue number in your progress table and journal file!
+>   - **Whenever you create an issue or update a step**, immediately write the issue/PR numbers to the local journal file (`.agents/workflows/greenfield-checklist-for-kind/journal/{kind}.md`) and save it so `git status` registers the journal update.
+
+## Journaling and Progress Tracking
+
+To track the progress of each resource kind, maintain a journal file in `.agents/workflows/greenfield-checklist-for-kind/journal/{kind}.md` (using the CamelCase Kind name).
+
+The journal should contain:
+1. The current step of the migration.
+2. A table tracking:
+   * Step Number and Name
+   * GitHub Issue link/number
+   * GitHub Pull Request link/number
+   * Status (e.g. `Open`, `PR Created`, `Merged`, `Completed`)
+   * Date Started and Date Completed
+
+Only proceed to the next step once the PR for the current step is merged successfully.
+
+3. In addition to the local journal file, **update the parent issue description** (using the issue ID/number extracted from `${SESSION_ID#issue-}`) or fall back to updating a comment:
+   * **Formatting the GitHub Description/Comment**: To keep the parent GitHub issue clean and avoid excessively chatty updates, the body posted to GitHub (description or comment) must **only** include the current step, the progress tracking table, and **at most the 3 most recent status update notes**. Do not include the entire historical list of check logs or updates under the table in the GitHub description/comment; all older history must remain in the local journal file on the branch only.
+   * Edit/create the description or comment using the `gh` CLI:
+     ```bash
+     gh issue edit ${SESSION_ID#issue-} --body "<updated_body>"
+     ```
+     If editing the issue description fails (due to write permissions on public repositories), **fall back to updating a comment**:
+     * Search the comments on the issue for an existing comment posted by yourself (check for author match with your GITHUB_USER_ID) that contains the text `Migration Progress`.
+     * If such a comment exists, edit it with the updated progress using:
+       ```bash
+       gh issue comment edit <comment-id> --body "<updated_comment_body>"
+       ```
+     * If no such comment exists, create a new comment:
+       ```bash
+       gh issue comment create ${SESSION_ID#issue-} --body "<updated_comment_body>"
+       ```
+4. Once all steps of the migration for the resource kind are successfully completed and verified merged, update the parent issue description to show completion, and close the parent issue:
+   ```bash
+   gh issue close ${SESSION_ID#issue-}
+   ```
+
+### Verifying PR CI Checks Status
+When checking if all CI check-runs have passed for a pull request, do NOT rely on a single unpaginated `gh api .../check-runs` call (since GitHub defaults to 30 items per page and might hide failing runs). Instead, use the `--paginate` option to ensure all runs are checked:
+```bash
+gh api repos/GoogleCloudPlatform/k8s-config-connector/commits/<head-sha>/check-runs --paginate --jq '.check_runs[] | select(.conclusion != "success" and .conclusion != "neutral" and .conclusion != "skipped") | {name: .name, conclusion: .conclusion}'
+```
+Or check via GitHub CLI:
+```bash
+gh pr checks <pr-number> --repo GoogleCloudPlatform/k8s-config-connector
+```
+Only declare the PR as fully passed/verified if no failures are returned across all pages of checks.
+
+## Steps
+
+
+### Step 1: Direct API Types and Identity and Reference Types Pattern
+
+Open a GitHub issue to coordinate the implementation of direct KRM types, identity files, and reference files for a specific Kubernetes resource.
+
+**GitHub Issue Details for Greenfield Resource:**
+*   **Title:** `Greenfield: Implement direct KRM types, identity, and generate.sh for {kind}`
+*   **Assignee:** (leave unassigned or assign to the current bot)
+*   **Labels:** `overseer`, `greenfield`,`step/gen-types`, `overseer/review`
+*   **Body:**
+    ```
+    Please follow the skill `.gemini/skills/kcc-direct-greenfield-types-implementer/SKILL.md` for generating types for {kind}.
+    Please follow the skill `.gemini/skills/kcc-identity-reference/SKILL.md` for generating identity for {kind}.
+
+    Validate your changes locally by:
+     * Running scripts/validate-prereqs.sh, if the script fails the output will contain agent hints for fixing the errors.
+     * Running ./dev/ci/presubmits/tests-e2e-fixtures-<kind_lowercase>
+
+    If you find any shortcomings in the skill (that likely apply to other resources), you may update SKILL.md. Also keep a journal of any less general observations etc. To avoid git merge conflicts, use a file under .gemini/skills/kcc-direct-greenfield-types-implementer/journal/, named after the kind or a similarly unique name. You may grep journal entries to identify learnings from other resources; if you find an important pattern by doing that you may also update the SKILL.md itself.
+
+    ## Review Instructions
+    Use .gemini/skills/reviewgen-greenfield-new-types/SKILL.md to conduct the review.
+    ```
+
+### Step 2: Direct Controller, E2E fixtures and Fuzzer
+
+Open a GitHub issue to coordinate the implementation of the direct controller and E2E fixtures for a specific Kubernetes resource.
+
+**GitHub Issue Details:**
+*   **Title:** `Greenfield: Implement direct controller, E2E fixtures, and fuzzer for {kind}`
+*   **Assignee:** (leave unassigned or assign to the current bot)
+*   **Labels:** `overseer`, `greenfield`, `step/controller` `overseer/review`
+*   **Body:**
+    ````
+    Please follow the instructions below (from `.gemini/skills/kcc-direct-controller-implementer/SKILL.md` and `.gemini/skills/kcc-direct-controller-logic-implementer/SKILL.md`) to implement the direct controller and record/verify E2E fixtures for {kind}.
+
+    The direct controller must be implemented to manage reconciliation logic (Adapter: Find, Create, Update, Delete) and E2E fixtures must be created and recorded against real GCP to verify functionality.
+
+    # KCC Direct Controller Implementer
+
+    This skill guides the implementation of the controller, mappers, and fuzzer for direct KCC resources, with a focus on package isolation to prevent symbol collisions and rigorous CI validation.
+
+    ## Inputs
+    - `resource_kind`: The KCC Kind.
+    - `package_path`: The isolated package directory (e.g., `pkg/controller/direct/vertexai/examplestore/`).
+    - `proto_package`: The GCP proto package (e.g., `google.cloud.aiplatform.v1`).
+
+    ## Workflow
+
+    1.  **Package Isolation**:
+        You MUST implement all controller-related logic in the provided `package_path`. This prevents symbol collisions in `mapper.generated.go`.
+
+    2.  **Brownfield Migrations**:
+        For brownfield resources (with existing terraform/DCL controllers), we do NOT immediately change the default controller to `direct` in Go type labels or static config map defaults.
+        - Keep the default controller as legacy (TF/DCL), so users can opt-in gradually.
+        - Both direct and legacy controllers are now automatically tested dynamically if a direct controller is available in `static_config.go` (under `SupportedControllers`), so there is no longer any need to manually modify `tests/e2e/unified_test.go`.
+
+    3.  **Controller Structure & Patterns**:
+        - **Proto Format Desired State**: Convert the KRM Spec to its Proto representation once in `AdapterForObject` and store it as a proto struct pointer (e.g., `*pb.MyResource` or `desired`) in the adapter, rather than duplicating conversion logic in both `Create` and `Update`. The adapter should avoid holding references to raw KRM objects for desired state to keep the interfaces clean, consistent with `actual` (which is also of proto type), and avoid redundant conversions. This ensures that `desired` is stored in the same proto format as `actual`.
+        - **Handling Non-API / KRM-only Spec Fields**: If the KRM Spec has fields that are not represented in the GCP resource's proto message (such as client-side behavioral options or custom installation flags, e.g., `SkipInitialVersionCreation`), do NOT mix them into the proto. Instead, parse and store them as separate, explicitly-named fields on the adapter struct (e.g., `desiredSkipInitialVersionCreation bool`).
+        - **NormalizeReferences**: Always call `common.NormalizeReferences` in `AdapterForObject` to resolve any resource references:
+          ```go
+          if err := common.NormalizeReferences(ctx, reader, obj, nil); err != nil {
+              return nil, fmt.Errorf("normalizing references: %w", err)
+          }
+          ```
+        - **Identity Parent Paths**: Create a `ParentString()` method on the resource's identity type (e.g., `KMSCryptoKeyIdentity`) instead of constructing formatting string patterns manually inside the controller. This keeps parent paths canonical and reusable.
+        - **Client Creation Options**: Do NOT build the authenticated HTTP client manually. Instead, retrieve configuration options using `RESTClientOptions()` and construct the REST client:
+          ```go
+          var opts []option.ClientOption
+          opts, err := m.config.RESTClientOptions()
+          if err != nil {
+              return nil, err
+          }
+          gcpClient, err := gcp.NewConfigRESTClient(ctx, opts...)
+          ```
+        - **Diff Comparison & Structured Diff (`tags.DiffForTopLevelFields`)**: Always prefer using top-level field tags-based diff comparison via `tags.DiffForTopLevelFields` over recursive/magical comparison functions (such as `common.CompareProtoMessageStructuredDiff` or `common.CompareProtoMessage` which are deprecated/discouraged due to unpredictable behaviors in `BasicDiff`).
+          ```go
+          func compareResource(ctx context.Context, actual, desired *pb.MyResource) (*structuredreporting.Diff, *fieldmaskpb.FieldMask, error) {
+              maskedActual, err := mappers.OnlySpecFields(actual, MyResourceSpec_FromProto, MyResourceSpec_ToProto)
+              if err != nil {
+                  return nil, nil, err
+              }
+              maskedActual.Name = desired.Name // Restore any non-spec identifier fields if needed
+
+              clonedDesired := proto.CloneOf(desired)
+
+              populateDefaults := func(obj *pb.MyResource) {
+                  // Even if empty, it's a good pattern to define and populate GCP/server defaults here
+                  if obj.SomeDefaultedField == nil {
+                      obj.SomeDefaultedField = ...
+                  }
+              }
+              populateDefaults(maskedActual)
+              populateDefaults(clonedDesired)
+
+              diffs, updateMask, err := tags.DiffForTopLevelFields(ctx, clonedDesired.ProtoReflect(), maskedActual.ProtoReflect())
+              if err != nil {
+                  return nil, nil, err
+              }
+              return diffs, updateMask, nil
+          }
+          ```
+        - **Reconciling Empty or Incomplete LRO Responses**: Many GCP APIs (such as Dataproc's `UpdateCluster` LRO) return an empty response (`google.protobuf.Empty`), or do not fully populate read-only status fields (such as state, metrics, or instance names) during resource creation. If you map status directly from such incomplete/empty LRO responses, you will inadvertently clear status fields in Kubernetes.
+          * **Rule**: Always perform a GET operation (`Get<Resource>`) immediately after a Create or Update LRO successfully completes to fetch the fully-populated resource before calling `updateStatus`.
+        - **Propagating KRM Metadata Labels**: Metadata labels (such as `managed-by-cnrm: true` or custom user-supplied labels) must be explicitly mapped and propagated on both `Create` and `Update` operations so they are correctly synchronized to GCP.
+        - **Structured Reporting & updateStatus**: In the `Update` method, use `diffs.HasDiff()` to report exact diffs back to the user via `structuredreporting.ReportDiff`. Always call a helper `updateStatus` function to update the Kube status at the end of both `Create` and `Update` reconciliation paths:
+          ```go
+          func (a *MyResourceAdapter) updateStatus(ctx context.Context, op directbase.Operation, latest *pb.MyResource) error {
+              mapCtx := &direct.MapContext{}
+              status := MyResourceStatus_FromProto(mapCtx, latest)
+              if mapCtx.Err() != nil {
+                  return mapCtx.Err()
+              }
+              return op.UpdateStatus(ctx, status, nil)
+          }
+          ```
+        - **Delete Idempotency Check**: In the `Delete` method, check if the resource has already been deleted using `direct.IsNotFound(err)` to ensure idempotency, returning `true, nil` to gracefully exit:
+          ```go
+          if err != nil {
+              if direct.IsNotFound(err) {
+                  return true, nil
+              }
+              return false, err
+          }
+          ```
+        - **Immutable Resources**: If a direct resource is completely immutable in GCP (meaning no fields can be updated once created), the `Update` method must STILL perform the comparison check on spec fields. If a diff is detected, return a descriptive error (e.g. `fmt.Errorf("<Kind> is immutable and cannot be updated")`) so that the error/diff is surfaced on the resource status rather than silently doing nothing. Also, register the model using `registry.CannotBeDeleted()` if deletion is not supported.
+        - **Mutable-but-Unreadable Fields**: If certain spec fields (such as keys, passwords, or specific metadata/launchStage fields) are mutable but cannot be read back from the GCP API (meaning they are write-only or missing from the GET response), never check `desired` inside `populateDefaults`. Instead:
+          1. Check the resource's `updateTime` or change cookie to see if the GCP side is fully reconciled and unchanged (meaning `generation == observedGeneration` and GCP `updateTime` matches status `updateTime` on a successful/Ready status).
+          2. If the update time matches and there are no external modifications, copy those mutable-but-unreadable fields from `desired` to `maskedActual` in the comparison function to avoid false diffs.
+          3. If the update time does not match (or the resource is not ready), do NOT copy them. This treats the unreadable fields as having changed (since we cannot prove they didn't), correctly forcing an update.
+
+    4.  **Mappers**:
+        Verify `mapper.generated.go` and manual mappers. Ensure all references use the standard `Ref` pattern.
+
+    5.  **Fuzzer**:
+        Implement `<resource_lower>_fuzzer.go` and register it with `fuzztesting.RegisterKRMFuzzer`.
+        - **Fuzzer Implementation Guidelines**:
+          * ALWAYS prefer and encourage using the fluent `f.SpecField(".foo")` and `f.StatusField(".bar")` methods rather than inserting directly into `SpecFields`/`StatusFields` sets (e.g. avoid `f.SpecFields.Insert...`).
+          * For unhandled or unimplemented fields, prefer highly descriptive helper methods (such as `f.Unimplemented_NotYetTriaged(".baz")`, `f.Unimplemented_Identity(".id")`, or other specific variants) rather than standard inserts into `UnimplementedFields` sets. This categorizes why we are not handling specific fields.
+
+    6.  **Final Generation & Reporting**:
+        Run `make ready-pr` from the repository root. This is a critical step that:
+        - Runs `make fmt` and `make vet`.
+        YOU MUST COMMIT ALL RESULTING CHANGES.
+
+    7.  **Validation & Last-Mile Tests**:
+        Run the following tests to ensure CI compliance:
+        - **Fuzzing**: `dev/ci/presubmits/fuzz-roundtrippers`
+        - **E2E Scaffolding**: `dev/ci/presubmits/tests-e2e-fixtures-direct`
+        - **Schema Integrity**: `go test ./pkg/crd/template/...`
+        - **API Field Coverage**: `go test ./tests/apichecks/...`. 
+          - If `TestCRDFieldPresenceInTestsForAlpha` fails, you may need to regenerate the exceptions file by running it with `WRITE_GOLDEN_OUTPUT=1`.
+
+    ## Journaling
+    Append any controller/reconciliation quirks or API check hurdles to `.gemini/journals/<service>.md` using the format described in the `kcc-agentic-journaler` skill.
+
+    # KCC Direct Controller Logic Implementer
+
+    This skill guides the implementation of the `Adapter` interface and the creation of "Minimal" and "Maximal" E2E fixtures to verify the resource against real GCP.
+
+    ## Inputs
+    - `resource_kind`: The KCC Kind.
+    - `service_name`: The GCP service name (short, e.g., `apigee`).
+    - `api_version`: The KCC API version.
+
+    ## Workflow
+
+    1.  **Implement Adapter Logic**:
+        Update `pkg/controller/direct/<service>/<resource_lower>_controller.go`.
+        - Implement `Find`, `Create`, `Update`, and `Delete`.
+        - Use the generated mappers and manual mappers as needed.
+        - Ensure correct error handling (e.g., handling 404s in `Find`).
+
+    2.  **Create Minimal Fixture**:
+        Create directory `pkg/test/resourcefixture/testdata/basic/<service_name>/<api_version>/<resource_lower>/<resource_lower>-minimal/`.
+        - Add `create.yaml`: Use the bare minimum **Required** fields.
+        - Use `${uniqueId}` for resource names.
+
+    3.  **Create Maximal Fixture**:
+        Create directory `pkg/test/resourcefixture/testdata/basic/<service_name>/<api_version>/<resource_lower>/<resource_lower>-maximal/`.
+        - Add `create.yaml`: Include **every supported field** in the Spec.
+        - Add `update.yaml`: Update all **mutable** fields.
+        - Add `dependencies.yaml` if the resource requires other KCC resources to exist first.
+
+    4.  **Record Golden Files (Real GCP)**:
+        Run the tests against real GCP to record the traffic and object state. Ensure you use a sufficient timeout (e.g., 30-60 minutes) as GCP resource creation can be slow:
+        ```bash
+        # Run from the repository root
+        RUN_E2E=1 \
+        E2E_GCP_TARGET=real \
+        E2E_KUBE_TARGET=envtest \
+        GOLDEN_REQUEST_CHECKS=1 \
+        GOLDEN_OBJECT_CHECKS=1 \
+        WRITE_GOLDEN_OUTPUT=1 \
+        go test -v ./tests/e2e \
+          -timeout 60m \
+          -run TestAllInSeries/fixtures/<resource_lower>-minimal
+        ```
+        Repeat for the `-maximal` fixture. Commit the resulting `_http.log` and `_generated_object_*.golden.yaml` files.
+
+    5.  **Verify Field Coverage**:
+        Run the API check tests:
+        - For alpha: `WRITE_GOLDEN_OUTPUT=1 go test -v ./tests/apichecks/... -run TestCRDFieldPresenceInTestsForAlpha`
+        - Verify that your "Maximal" test reduces the number of missing fields in the exceptions file.
+
+    ## Journaling
+    Append any reconciliation hurdles, GCP SDK quirks, or other controller issues to `.gemini/journals/<service>.md` using the format described in the `kcc-agentic-journaler` skill.
+
+    If you find any shortcomings in these skills (that likely apply to other resources), you may update them. Also keep a journal of any less general observations etc. To avoid git merge conflicts, use a file under their respective journal/ folders, named after the kind or a similarly unique name.
+
+    ## Review Instructions
+    Use .gemini/skills/reviewgen-greenfield-controller/SKILL.md to conduct the review.
+    ````
+
+### Step 3: mockGCP generation
+
+Open a GitHub issue to coordinate the implementation of the mockGCP for a specific Kubernetes resource.
+
+**GitHub Issue Details for Greenfield Resource:**
+*   **Title:** `Greenfield: Implement MockGCP and Alignment for {kind}`
+*   **Assignee:** (leave unassigned or assign to the current bot)
+*   **Labels:** `overseer`, `greenfield`,`step/mockgcp`
+*   **Body:**
+    ```
+    Please follow the skill `.gemini/skills/kcc-direct-mockgcp-implementer/SKILL.md` to implement Phase 3 (MockGCP and Alignment) for {kind} to verify behavioral correctness against the simulated GCP services.
+    ```
+
+### Step 4: MockGCP Alignment with RealGCP
+
+Open a GitHub issue to coordinate the alignment of MockGCP logs with RealGCP output to ensure high fidelity.
+
+**GitHub Issue Details:**
+*   **Title:** `Greenfield: Align MockGCP logs with RealGCP for {kind}`
+*   **Assignee:** (leave unassigned or assign to the current bot)
+*   **Labels:** `overseer`, `greenfield`, `step/mockgcp-alignment`
+*   **Body:**
+    ```
+    Please follow the skill `.gemini/skills/match-mockgcp-with-realgcp/SKILL.md` to align the MockGCP logs with the RealGCP output for {kind}.
+    ```

--- a/.agents/workflows/kcc-greenfield-v2.txt
+++ b/.agents/workflows/kcc-greenfield-v2.txt
@@ -226,6 +226,7 @@ Open a GitHub issue to coordinate the implementation of the direct controller an
         - Add `dependencies.yaml` if the resource requires other KCC resources to exist first.
 
     7.  **MANDATORY: Record Golden Files Against Real GCP (`hack/record-gcp`)**:
+        - **CRITICAL OVERRIDE OF GEMINI.md**: For this Greenfield task, **ignore any instructions in `GEMINI.md`** (or `mockgcp/GEMINI.md`) regarding `mockgcp`, `E2E_GCP_TARGET=mock`, or `hack/compare-mock`. Those global instructions only apply to legacy brownfield resources.
         - **STRICT GUARDRAIL — DO NOT USE MOCKGCP OR OFFLINE MOCKS**: You MUST record golden files directly against real GCP using `./hack/record-gcp`. Do **NOT** attempt to use `mockgcp`, do NOT search for or try to implement mockgcp services, and do NOT use `hack/compare-mock` or `E2E_GCP_TARGET=mock`.
         - **MANDATORY EXECUTION**: You are explicitly required to run `./hack/record-gcp` on both your minimal and maximal fixtures before running any validation tests in Step 8 or preparing the PR in Step 9. Skipping this step or attempting to substitute mock tests is considered a critical failure.
         Run `hack/record-gcp "fixtures/^<testname>$"` to capture real GCP behavior and record traffic and object state:

--- a/.agents/workflows/kcc-greenfield-v2.txt
+++ b/.agents/workflows/kcc-greenfield-v2.txt
@@ -226,20 +226,19 @@ Open a GitHub issue to coordinate the implementation of the direct controller an
         - Add `dependencies.yaml` if the resource requires other KCC resources to exist first.
 
     7.  **Record Golden Files (Real GCP)**:
-        Run the tests against real GCP to record the traffic and object state. Ensure you use a sufficient timeout (e.g., 30-60 minutes) as GCP resource creation can be slow:
+        Run `hack/record-gcp "fixtures/^<testname>$"` to capture real GCP behavior and record traffic and object state:
         ```bash
-        # Run from the repository root
-        RUN_E2E=1 \
-        E2E_GCP_TARGET=real \
-        E2E_KUBE_TARGET=envtest \
-        GOLDEN_REQUEST_CHECKS=1 \
-        GOLDEN_OBJECT_CHECKS=1 \
-        WRITE_GOLDEN_OUTPUT=1 \
-        go test -v ./tests/e2e \
-          -timeout 60m \
-          -run TestAllInSeries/fixtures/<resource_lower>-minimal
+        # Run from the repository root for both minimal and maximal fixtures
+        ./hack/record-gcp "fixtures/^<resource_lower>-minimal$"
+        ./hack/record-gcp "fixtures/^<resource_lower>-maximal$"
         ```
-        Repeat for the `-maximal` fixture. Commit the resulting `_http.log` and `_generated_object_*.golden.yaml` files.
+        - **Troubleshooting Service Not Enabled**: If `hack/record-gcp` fails because a GCP service is not enabled (e.g., error mentions that the API is disabled or has not been used in the project before), enable the service using `gcloud` and try again:
+          ```bash
+          gcloud services enable <service-name>.googleapis.com
+          ```
+          *(For example: `gcloud services enable compute.googleapis.com` or `gcloud services enable run.googleapis.com`)*
+
+          - Using the `hack/record-gcp` wrapper ensures a sufficient timeout (e.g., 30-60 minutes) is already configured, automatically handling slow GCP resource creation. There is no need to specify additional timeout flags when using this helper.
 
     8.  **Validation & Last-Mile Tests**:
         Run the following tests to ensure CI compliance and verify field coverage:
@@ -249,6 +248,7 @@ Open a GitHub issue to coordinate the implementation of the direct controller an
         - **API Field Coverage**: `go test ./tests/apichecks/...`. 
           - For alpha: `WRITE_GOLDEN_OUTPUT=1 go test -v ./tests/apichecks/... -run TestCRDFieldPresenceInTestsForAlpha`
           - Verify that your "Maximal" test reduces the number of missing fields in the exceptions file. If `TestCRDFieldPresenceInTestsForAlpha` fails, running with `WRITE_GOLDEN_OUTPUT=1` will regenerate the exceptions file.
+        - **Iterative Refinement Loop (Steps 7 & 8)**: Use any failures, unexpected diffs, or missing field coverage found during steps 7 and 8 as your critical debugging feedback loop. Actively refine your controller logic (Step 2), mappers (Step 3), fuzzer (Step 4), and fixtures (Steps 5 & 6), re-running steps 7 and 8 until all E2E recordings and validation suites execute and pass without error before proceeding to step 9.
 
     9.  **Final Generation & Reporting**:
         Run `make ready-pr` from the repository root. This is a critical step that:
@@ -257,8 +257,6 @@ Open a GitHub issue to coordinate the implementation of the direct controller an
 
     ## Journaling
     Append any reconciliation hurdles, GCP SDK quirks, or other controller issues to `.gemini/journals/<service_name>.md` using the format described in the `kcc-agentic-journaler` skill.
-
-    If you find any shortcomings in these instructions (that likely apply to other resources), you may update the underlying skills (`.gemini/skills/kcc-direct-controller-implementer/SKILL.md` or `.gemini/skills/kcc-direct-controller-logic-implementer/SKILL.md`). Also keep a journal of any less general observations etc. To avoid git merge conflicts, use a file under their respective `journal/` folders, named after `{kind}` or a similarly unique name.
 
     ## Review Instructions
     Use .gemini/skills/reviewgen-greenfield-controller/SKILL.md to conduct the review.

--- a/.agents/workflows/kcc-greenfield-v2.txt
+++ b/.agents/workflows/kcc-greenfield-v2.txt
@@ -113,30 +113,24 @@ Open a GitHub issue to coordinate the implementation of the direct controller an
 *   **Labels:** `overseer`, `greenfield`, `step/controller` `overseer/review`
 *   **Body:**
     ````
-    Please follow the instructions below (from `.gemini/skills/kcc-direct-controller-implementer/SKILL.md` and `.gemini/skills/kcc-direct-controller-logic-implementer/SKILL.md`) to implement the direct controller and record/verify E2E fixtures for {kind}.
+    Please follow the instructions below to implement the direct controller and record/verify E2E fixtures for {kind}.
 
     The direct controller must be implemented to manage reconciliation logic (Adapter: Find, Create, Update, Delete) and E2E fixtures must be created and recorded against real GCP to verify functionality.
 
-    # KCC Direct Controller Implementer
-
-    This skill guides the implementation of the controller, mappers, and fuzzer for direct KCC resources, with a focus on package isolation to prevent symbol collisions and rigorous CI validation.
-
     ## Inputs
-    - `resource_kind`: The KCC Kind.
+    - `resource_kind`: The KCC Kind (`{kind}`).
     - `package_path`: The isolated package directory (e.g., `pkg/controller/direct/vertexai/examplestore/`).
     - `proto_package`: The GCP proto package (e.g., `google.cloud.aiplatform.v1`).
+    - `service_name`: The GCP service name (short, e.g., `apigee`).
+    - `api_version`: The KCC API version.
 
     ## Workflow
 
     1.  **Package Isolation**:
         You MUST implement all controller-related logic in the provided `package_path`. This prevents symbol collisions in `mapper.generated.go`.
 
-    2.  **Brownfield Migrations**:
-        For brownfield resources (with existing terraform/DCL controllers), we do NOT immediately change the default controller to `direct` in Go type labels or static config map defaults.
-        - Keep the default controller as legacy (TF/DCL), so users can opt-in gradually.
-        - Both direct and legacy controllers are now automatically tested dynamically if a direct controller is available in `static_config.go` (under `SupportedControllers`), so there is no longer any need to manually modify `tests/e2e/unified_test.go`.
-
-    3.  **Controller Structure & Patterns**:
+    2.  **Implement Adapter Logic & Controller Patterns**:
+        Update `pkg/controller/direct/<service_name>/<resource_lower>_controller.go` to implement `Find`, `Create`, `Update`, and `Delete`. Ensure correct error handling (e.g., handling 404s in `Find`), and adhere to these structural patterns:
         - **Proto Format Desired State**: Convert the KRM Spec to its Proto representation once in `AdapterForObject` and store it as a proto struct pointer (e.g., `*pb.MyResource` or `desired`) in the adapter, rather than duplicating conversion logic in both `Create` and `Update`. The adapter should avoid holding references to raw KRM objects for desired state to keep the interfaces clean, consistent with `actual` (which is also of proto type), and avoid redundant conversions. This ensures that `desired` is stored in the same proto format as `actual`.
         - **Handling Non-API / KRM-only Spec Fields**: If the KRM Spec has fields that are not represented in the GCP resource's proto message (such as client-side behavioral options or custom installation flags, e.g., `SkipInitialVersionCreation`), do NOT mix them into the proto. Instead, parse and store them as separate, explicitly-named fields on the adapter struct (e.g., `desiredSkipInitialVersionCreation bool`).
         - **NormalizeReferences**: Always call `common.NormalizeReferences` in `AdapterForObject` to resolve any resource references:
@@ -211,60 +205,27 @@ Open a GitHub issue to coordinate the implementation of the direct controller an
           2. If the update time matches and there are no external modifications, copy those mutable-but-unreadable fields from `desired` to `maskedActual` in the comparison function to avoid false diffs.
           3. If the update time does not match (or the resource is not ready), do NOT copy them. This treats the unreadable fields as having changed (since we cannot prove they didn't), correctly forcing an update.
 
-    4.  **Mappers**:
+    3.  **Mappers**:
         Verify `mapper.generated.go` and manual mappers. Ensure all references use the standard `Ref` pattern.
 
-    5.  **Fuzzer**:
+    4.  **Fuzzer**:
         Implement `<resource_lower>_fuzzer.go` and register it with `fuzztesting.RegisterKRMFuzzer`.
         - **Fuzzer Implementation Guidelines**:
           * ALWAYS prefer and encourage using the fluent `f.SpecField(".foo")` and `f.StatusField(".bar")` methods rather than inserting directly into `SpecFields`/`StatusFields` sets (e.g. avoid `f.SpecFields.Insert...`).
           * For unhandled or unimplemented fields, prefer highly descriptive helper methods (such as `f.Unimplemented_NotYetTriaged(".baz")`, `f.Unimplemented_Identity(".id")`, or other specific variants) rather than standard inserts into `UnimplementedFields` sets. This categorizes why we are not handling specific fields.
 
-    6.  **Final Generation & Reporting**:
-        Run `make ready-pr` from the repository root. This is a critical step that:
-        - Runs `make fmt` and `make vet`.
-        YOU MUST COMMIT ALL RESULTING CHANGES.
-
-    7.  **Validation & Last-Mile Tests**:
-        Run the following tests to ensure CI compliance:
-        - **Fuzzing**: `dev/ci/presubmits/fuzz-roundtrippers`
-        - **E2E Scaffolding**: `dev/ci/presubmits/tests-e2e-fixtures-direct`
-        - **Schema Integrity**: `go test ./pkg/crd/template/...`
-        - **API Field Coverage**: `go test ./tests/apichecks/...`. 
-          - If `TestCRDFieldPresenceInTestsForAlpha` fails, you may need to regenerate the exceptions file by running it with `WRITE_GOLDEN_OUTPUT=1`.
-
-    ## Journaling
-    Append any controller/reconciliation quirks or API check hurdles to `.gemini/journals/<service>.md` using the format described in the `kcc-agentic-journaler` skill.
-
-    # KCC Direct Controller Logic Implementer
-
-    This skill guides the implementation of the `Adapter` interface and the creation of "Minimal" and "Maximal" E2E fixtures to verify the resource against real GCP.
-
-    ## Inputs
-    - `resource_kind`: The KCC Kind.
-    - `service_name`: The GCP service name (short, e.g., `apigee`).
-    - `api_version`: The KCC API version.
-
-    ## Workflow
-
-    1.  **Implement Adapter Logic**:
-        Update `pkg/controller/direct/<service>/<resource_lower>_controller.go`.
-        - Implement `Find`, `Create`, `Update`, and `Delete`.
-        - Use the generated mappers and manual mappers as needed.
-        - Ensure correct error handling (e.g., handling 404s in `Find`).
-
-    2.  **Create Minimal Fixture**:
+    5.  **Create Minimal Fixture**:
         Create directory `pkg/test/resourcefixture/testdata/basic/<service_name>/<api_version>/<resource_lower>/<resource_lower>-minimal/`.
         - Add `create.yaml`: Use the bare minimum **Required** fields.
         - Use `${uniqueId}` for resource names.
 
-    3.  **Create Maximal Fixture**:
+    6.  **Create Maximal Fixture**:
         Create directory `pkg/test/resourcefixture/testdata/basic/<service_name>/<api_version>/<resource_lower>/<resource_lower>-maximal/`.
         - Add `create.yaml`: Include **every supported field** in the Spec.
         - Add `update.yaml`: Update all **mutable** fields.
         - Add `dependencies.yaml` if the resource requires other KCC resources to exist first.
 
-    4.  **Record Golden Files (Real GCP)**:
+    7.  **Record Golden Files (Real GCP)**:
         Run the tests against real GCP to record the traffic and object state. Ensure you use a sufficient timeout (e.g., 30-60 minutes) as GCP resource creation can be slow:
         ```bash
         # Run from the repository root
@@ -280,15 +241,24 @@ Open a GitHub issue to coordinate the implementation of the direct controller an
         ```
         Repeat for the `-maximal` fixture. Commit the resulting `_http.log` and `_generated_object_*.golden.yaml` files.
 
-    5.  **Verify Field Coverage**:
-        Run the API check tests:
-        - For alpha: `WRITE_GOLDEN_OUTPUT=1 go test -v ./tests/apichecks/... -run TestCRDFieldPresenceInTestsForAlpha`
-        - Verify that your "Maximal" test reduces the number of missing fields in the exceptions file.
+    8.  **Validation & Last-Mile Tests**:
+        Run the following tests to ensure CI compliance and verify field coverage:
+        - **Fuzzing**: `dev/ci/presubmits/fuzz-roundtrippers`
+        - **E2E Scaffolding**: `dev/ci/presubmits/tests-e2e-fixtures-direct`
+        - **Schema Integrity**: `go test ./pkg/crd/template/...`
+        - **API Field Coverage**: `go test ./tests/apichecks/...`. 
+          - For alpha: `WRITE_GOLDEN_OUTPUT=1 go test -v ./tests/apichecks/... -run TestCRDFieldPresenceInTestsForAlpha`
+          - Verify that your "Maximal" test reduces the number of missing fields in the exceptions file. If `TestCRDFieldPresenceInTestsForAlpha` fails, running with `WRITE_GOLDEN_OUTPUT=1` will regenerate the exceptions file.
+
+    9.  **Final Generation & Reporting**:
+        Run `make ready-pr` from the repository root. This is a critical step that:
+        - Runs `make fmt` and `make vet`.
+        YOU MUST COMMIT ALL RESULTING CHANGES.
 
     ## Journaling
-    Append any reconciliation hurdles, GCP SDK quirks, or other controller issues to `.gemini/journals/<service>.md` using the format described in the `kcc-agentic-journaler` skill.
+    Append any reconciliation hurdles, GCP SDK quirks, or other controller issues to `.gemini/journals/<service_name>.md` using the format described in the `kcc-agentic-journaler` skill.
 
-    If you find any shortcomings in these skills (that likely apply to other resources), you may update them. Also keep a journal of any less general observations etc. To avoid git merge conflicts, use a file under their respective journal/ folders, named after the kind or a similarly unique name.
+    If you find any shortcomings in these instructions (that likely apply to other resources), you may update the underlying skills (`.gemini/skills/kcc-direct-controller-implementer/SKILL.md` or `.gemini/skills/kcc-direct-controller-logic-implementer/SKILL.md`). Also keep a journal of any less general observations etc. To avoid git merge conflicts, use a file under their respective `journal/` folders, named after `{kind}` or a similarly unique name.
 
     ## Review Instructions
     Use .gemini/skills/reviewgen-greenfield-controller/SKILL.md to conduct the review.


### PR DESCRIPTION
### Summary of Work
- **Removed Skill References at the Top**: Stripped out the skill filename citations from the opening instruction paragraph of the Step 2 issue body in `kcc-greenfield-v2.txt`, making the instructions self-contained and denormalized.
- **Unified Inputs and Workflow**: Removed the split headings (`# KCC Direct Controller Implementer` and `# KCC Direct Controller Logic Implementer`), consolidated all required parameters under a single `## Inputs` block, and merged both workflows into a cohesive, sequentially numbered list of 9 steps:
  1. **Package Isolation**
  2. **Implement Adapter Logic & Controller Patterns** (combined adapter interface implementation with all 12 controller structure rules)
  3. **Mappers**
  4. **Fuzzer**
  5. **Create Minimal Fixture**
  6. **Create Maximal Fixture**
  7. **Record Golden Files (Real GCP)** (updated to use `hack/record-gcp` with automated timeouts and troubleshooting guidance for disabled APIs)
  8. **Validation & Last-Mile Tests** (combined general CI tests with API check/field presence tests, plus explicit guidance for an iterative debugging loop using Steps 7 & 8)
  9. **Final Generation & Reporting** (`make ready-pr`)
- **Consolidated Journaling Section**: Unified the two separate journaling instructions into a single `## Journaling` section directly above `## Review Instructions`.