### PR TITLE
feat: add PR staleness feature

### DIFF
--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -33,24 +33,25 @@ import (
 )
 
 type WatchFlags struct {
-	Repo               string
-	PollInterval       time.Duration
-	Assignee           string
-	Labels             []string
-	DryRun             bool
-	WatchTimeout       time.Duration
-	MaxActions         int
-	MaxPending         int
-	Mode               string
-	QueueDir           string
-	Once               bool
-	IssueMode          string
-	PRMode             string
-	ChoresMode         string
-	ScanLimit          int
-	TaskTimeout        time.Duration
-	SandboxEvictionAge string
-	SandboxIdleTimeout time.Duration
+	Repo                string
+	PollInterval        time.Duration
+	Assignee            string
+	Labels              []string
+	DryRun              bool
+	WatchTimeout        time.Duration
+	MaxActions          int
+	MaxPending          int
+	Mode                string
+	QueueDir            string
+	Once                bool
+	IssueMode           string
+	PRMode              string
+	ChoresMode          string
+	ScanLimit           int
+	TaskTimeout         time.Duration
+	SandboxEvictionAge  string
+	SandboxIdleTimeout  time.Duration
+	PRInactivityTimeout time.Duration
 }
 
 func NewWatchCommand(ctx context.Context) *cobra.Command {
@@ -106,7 +107,7 @@ func NewWatchCommand(ctx context.Context) *cobra.Command {
 				choresMode = "enabled"
 			}
 
-			return runWatch(ctx, parts[0], parts[1], flags.PollInterval, flags.Assignee, cmd.Flags().Changed("assignee"), flags.Labels, flags.DryRun, flags.WatchTimeout, flags.MaxActions, flags.MaxPending, flags.Mode, flags.QueueDir, flags.Once, issueMode, prMode, choresMode, rootFlags.EphemeralStorage, rootFlags.ResolvedSecrets, flags.ScanLimit, flags.TaskTimeout, flags.SandboxEvictionAge, flags.SandboxIdleTimeout)
+			return runWatch(ctx, parts[0], parts[1], flags.PollInterval, flags.Assignee, cmd.Flags().Changed("assignee"), flags.Labels, flags.DryRun, flags.WatchTimeout, flags.MaxActions, flags.MaxPending, flags.Mode, flags.QueueDir, flags.Once, issueMode, prMode, choresMode, rootFlags.EphemeralStorage, rootFlags.ResolvedSecrets, flags.ScanLimit, flags.TaskTimeout, flags.SandboxEvictionAge, flags.SandboxIdleTimeout, flags.PRInactivityTimeout)
 		},
 	}
 
@@ -128,6 +129,7 @@ func NewWatchCommand(ctx context.Context) *cobra.Command {
 	cmd.Flags().DurationVar(&flags.TaskTimeout, "task-timeout", 3*time.Hour, "Timeout for each task execution (default 3h)")
 	cmd.Flags().StringVar(&flags.SandboxEvictionAge, "sandbox-eviction-age", "7d", "Age threshold for idle sandbox eviction (e.g. '7d', '24h')")
 	cmd.Flags().DurationVar(&flags.SandboxIdleTimeout, "sandbox-idle-timeout", getEnvDuration("SANDBOX_IDLE_TIMEOUT", 0), "Idle timeout after which a sandbox that has not run any task is suspended by setting replicas to 0 (e.g. '30m', '1h')")
+	cmd.Flags().DurationVar(&flags.PRInactivityTimeout, "pr-inactivity-timeout", getEnvDuration("PR_INACTIVITY_TIMEOUT", 0), "Time of inactivity with no human comments before pausing automated processing on a PR (e.g. '24h', '168h')")
 
 	return cmd
 }
@@ -936,7 +938,7 @@ func writeTaskJournalEvent(queueDir string, taskFilename string, task *QueueTask
 	}
 }
 
-func runWatch(ctx context.Context, owner, repo string, interval time.Duration, assignee string, assigneeChanged bool, labels []string, dryRun bool, watchTimeout time.Duration, maxActions int, maxPending int, mode string, queueDir string, once bool, issueMode string, prMode string, choresMode string, ephemeralStorage string, secrets []factorysandbox.SecretMount, scanLimit int, taskTimeout time.Duration, sandboxEvictionAge string, sandboxIdleTimeout time.Duration) error {
+func runWatch(ctx context.Context, owner, repo string, interval time.Duration, assignee string, assigneeChanged bool, labels []string, dryRun bool, watchTimeout time.Duration, maxActions int, maxPending int, mode string, queueDir string, once bool, issueMode string, prMode string, choresMode string, ephemeralStorage string, secrets []factorysandbox.SecretMount, scanLimit int, taskTimeout time.Duration, sandboxEvictionAge string, sandboxIdleTimeout time.Duration, prInactivityTimeout time.Duration) error {
 	cfg, err := config.LoadConfig()
 	if err != nil {
 		klog.Warningf("Failed to load factory config: %v", err)
@@ -1242,7 +1244,45 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 				// Fetch all PR comments (handling pagination)
 				comments, listCommentsErr := github.ListAllIssueComments(ctx, ghClient, owner, repo, num)
 
+				var reviews []*githubv39.PullRequestReview
+				var listReviewsErr error
+				if listCommentsErr == nil {
+					reviews, listReviewsErr = github.ListAllReviews(ctx, ghClient, owner, repo, num)
+				}
+
+				revCommentsMap := make(map[int64][]*githubv39.PullRequestComment)
+				if listCommentsErr == nil && listReviewsErr == nil {
+					for _, r := range reviews {
+						if rc, err := github.ListAllReviewComments(ctx, ghClient, owner, repo, num, r.GetID()); err == nil {
+							revCommentsMap[r.GetID()] = rc
+						}
+					}
+				}
+
 				state := processedPRs[num]
+
+				// PR Inactivity check
+				if prInactivityTimeout > 0 && listCommentsErr == nil && listReviewsErr == nil {
+					var bots []string
+					if cfg != nil {
+						bots = cfg.AllowlistedBots
+					}
+					lastActivity := getLastPRActivityTime(pr, comments, reviews, revCommentsMap, githubLogin, bots)
+					if time.Since(lastActivity) > prInactivityTimeout {
+						stopLabel := getStopLabel(triggerLabel)
+						if dryRun {
+							fmt.Printf("[DRYRUN] Would pause automated processing on PR #%d and apply label '%s' due to inactivity since %v\n", num, stopLabel, lastActivity)
+						} else {
+							klog.Infof("Pausing automated processing on PR #%d and applying label '%s' due to inactivity since %v", num, stopLabel, lastActivity)
+							addGitHubComment(ctx, ghClient, owner, repo, num, fmt.Sprintf("🤖 AI Factory has paused automated processing on this pull request due to a period of inactivity with no human comments (inactive for %s). I have applied the `%s` label.\n\nTo resume automated processing, please remove the `%s` label from this pull request and add a new comment/review.", prInactivityTimeout, stopLabel, stopLabel))
+							if _, _, err := ghClient.Issues.AddLabelsToIssue(ctx, owner, repo, num, []string{stopLabel}); err != nil {
+								klog.Errorf("Failed to add stop label '%s' to PR #%d: %v", stopLabel, num, err)
+							}
+							removePendingTasksForNumber(incomingDir, num)
+						}
+						continue
+					}
+				}
 
 				// Check Phase 1: Rebase/Conflicts
 				isConflicting := pr.Mergeable != nil && !*pr.Mergeable
@@ -1449,11 +1489,6 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 				}
 
 				// Check review comments and approvals
-				var reviews []*githubv39.PullRequestReview
-				if listReviews, err := github.ListAllReviews(ctx, ghClient, owner, repo, num); err == nil {
-					reviews = listReviews
-				}
-
 				isApproved := isPRApprovedOrLGTM(pr, prIssue, reviews)
 
 				if listCommentsErr == nil {
@@ -1517,22 +1552,20 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 							hasNewComments = true
 						}
 
-						revComments, err := github.ListAllReviewComments(ctx, ghClient, owner, repo, num, r.GetID())
-						if err == nil {
-							for _, rc := range revComments {
-								if shouldIgnoreUser(rc.GetUser(), githubLogin, bots) {
-									if rc.GetCreatedAt().After(latestBotReplyTime) {
-										latestBotReplyTime = rc.GetCreatedAt()
-									}
-									continue
+						revComments := revCommentsMap[r.GetID()]
+						for _, rc := range revComments {
+							if shouldIgnoreUser(rc.GetUser(), githubLogin, bots) {
+								if rc.GetCreatedAt().After(latestBotReplyTime) {
+									latestBotReplyTime = rc.GetCreatedAt()
 								}
-								if strings.EqualFold(rc.GetUser().GetLogin(), pr.GetUser().GetLogin()) {
-									continue
-								}
-								if rc.GetCreatedAt().After(lastCommitTime) && rc.GetCreatedAt().After(state.lastCommentAddressedTime) && rc.GetCreatedAt().After(latestBotReplyTime) {
-									hasNewComments = true
-									unackPRCommentIDs = append(unackPRCommentIDs, rc.GetID())
-								}
+								continue
+							}
+							if strings.EqualFold(rc.GetUser().GetLogin(), pr.GetUser().GetLogin()) {
+								continue
+							}
+							if rc.GetCreatedAt().After(lastCommitTime) && rc.GetCreatedAt().After(state.lastCommentAddressedTime) && rc.GetCreatedAt().After(latestBotReplyTime) {
+								hasNewComments = true
+								unackPRCommentIDs = append(unackPRCommentIDs, rc.GetID())
 							}
 						}
 					}
@@ -3430,4 +3463,45 @@ func buildQueueResponse(queueDir string) map[string]interface{} {
 		"processing": processing,
 		"processed":  processed,
 	}
+}
+
+func getLastPRActivityTime(pr *githubv39.PullRequest, comments []*githubv39.IssueComment, reviews []*githubv39.PullRequestReview, revComments map[int64][]*githubv39.PullRequestComment, githubLogin string, bots []string) time.Time {
+	lastActivity := pr.GetCreatedAt()
+
+	// 1. Check issue comments
+	for _, c := range comments {
+		isBot := isBotReply(c.GetUser(), githubLogin, bots)
+		if !isBot {
+			if c.GetCreatedAt().After(lastActivity) {
+				lastActivity = c.GetCreatedAt()
+			}
+		} else {
+			if strings.Contains(c.GetBody(), "paused automated processing on this pull request due to a period of inactivity") {
+				if c.GetCreatedAt().After(lastActivity) {
+					lastActivity = c.GetCreatedAt()
+				}
+			}
+		}
+	}
+
+	// 2. Check reviews and review comments
+	for _, r := range reviews {
+		if !isBotReply(r.GetUser(), githubLogin, bots) {
+			if r.GetSubmittedAt().After(lastActivity) {
+				lastActivity = r.GetSubmittedAt()
+			}
+		}
+
+		if rcList, ok := revComments[r.GetID()]; ok {
+			for _, rc := range rcList {
+				if !isBotReply(rc.GetUser(), githubLogin, bots) {
+					if rc.GetCreatedAt().After(lastActivity) {
+						lastActivity = rc.GetCreatedAt()
+					}
+				}
+			}
+		}
+	}
+
+	return lastActivity
 }

--- a/factory/pkg/commands/watch_test.go
+++ b/factory/pkg/commands/watch_test.go
@@ -511,3 +511,100 @@ completedAt: "2026-07-23T14:00:00Z"
 		t.Errorf("expected lastIteratedSHA to be 'efgh456', got '%s'", state.lastIteratedSHA)
 	}
 }
+
+func TestGetLastPRActivityTime(t *testing.T) {
+	baseTime := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	pr := &githubv39.PullRequest{
+		CreatedAt: &baseTime,
+	}
+
+	githubLogin := "factory-bot"
+	bots := []string{"allowlisted-bot"}
+
+	// Case 1: No comments/reviews
+	got := getLastPRActivityTime(pr, nil, nil, nil, githubLogin, bots)
+	if !got.Equal(baseTime) {
+		t.Errorf("Case 1 failed: expected %v, got %v", baseTime, got)
+	}
+
+	// Case 2: Human comment on issue
+	humanTime := baseTime.Add(1 * time.Hour)
+	comments := []*githubv39.IssueComment{
+		{
+			User:      &githubv39.User{Login: stringPtr("human-user")},
+			CreatedAt: &humanTime,
+		},
+	}
+	got = getLastPRActivityTime(pr, comments, nil, nil, githubLogin, bots)
+	if !got.Equal(humanTime) {
+		t.Errorf("Case 2 failed: expected %v, got %v", humanTime, got)
+	}
+
+	// Case 3: Bot comment (ignored)
+	botTime := baseTime.Add(2 * time.Hour)
+	comments = []*githubv39.IssueComment{
+		{
+			User:      &githubv39.User{Login: stringPtr("allowlisted-bot")},
+			CreatedAt: &botTime,
+		},
+	}
+	got = getLastPRActivityTime(pr, comments, nil, nil, githubLogin, bots)
+	if !got.Equal(baseTime) {
+		t.Errorf("Case 3 failed: expected %v, got %v", baseTime, got)
+	}
+
+	// Case 4: Bot pause comment (resets timer)
+	pauseTime := baseTime.Add(3 * time.Hour)
+	comments = []*githubv39.IssueComment{
+		{
+			User:      &githubv39.User{Login: stringPtr("factory-bot")},
+			CreatedAt: &pauseTime,
+			Body:      stringPtr("🤖 AI Factory has paused automated processing on this pull request due to a period of inactivity"),
+		},
+	}
+	got = getLastPRActivityTime(pr, comments, nil, nil, githubLogin, bots)
+	if !got.Equal(pauseTime) {
+		t.Errorf("Case 4 failed: expected %v, got %v", pauseTime, got)
+	}
+
+	// Case 5: Human review
+	reviewTime := baseTime.Add(4 * time.Hour)
+	reviews := []*githubv39.PullRequestReview{
+		{
+			ID:          int64Ptr(1),
+			User:        &githubv39.User{Login: stringPtr("human-user2")},
+			SubmittedAt: &reviewTime,
+		},
+	}
+	got = getLastPRActivityTime(pr, nil, reviews, nil, githubLogin, bots)
+	if !got.Equal(reviewTime) {
+		t.Errorf("Case 5 failed: expected %v, got %v", reviewTime, got)
+	}
+
+	// Case 6: Review comment by human under a bot review
+	botReviewTime := baseTime.Add(5 * time.Hour)
+	humanReviewCommentTime := baseTime.Add(6 * time.Hour)
+	reviews = []*githubv39.PullRequestReview{
+		{
+			ID:          int64Ptr(2),
+			User:        &githubv39.User{Login: stringPtr("factory-bot")},
+			SubmittedAt: &botReviewTime,
+		},
+	}
+	revComments := map[int64][]*githubv39.PullRequestComment{
+		2: {
+			{
+				User:      &githubv39.User{Login: stringPtr("human-user3")},
+				CreatedAt: &humanReviewCommentTime,
+			},
+		},
+	}
+	got = getLastPRActivityTime(pr, nil, reviews, revComments, githubLogin, bots)
+	if !got.Equal(humanReviewCommentTime) {
+		t.Errorf("Case 6 failed: expected %v, got %v", humanReviewCommentTime, got)
+	}
+}
+
+func int64Ptr(i int64) *int64 {
+	return &i
+}

--- a/factory/pkg/config/config.go
+++ b/factory/pkg/config/config.go
@@ -44,6 +44,7 @@ type FactoryConfig struct {
 	Secrets              []SecretMount         `yaml:"secrets"`
 	Env                  []EnvVar              `yaml:"env"`
 	MinNumber            int                   `yaml:"minNumber"`
+	PRInactivityTimeout  string                `yaml:"prInactivityTimeout"`
 	Roles                map[string]RoleConfig `yaml:"roles"`
 }
 

--- a/overseer/images/overseer/run.sh
+++ b/overseer/images/overseer/run.sh
@@ -42,6 +42,9 @@ function writeFactoryConfig {
     if [ -n "$MIN_NUMBER" ]; then
         echo "minNumber: $MIN_NUMBER" >> "$CFG_FILE"
     fi
+    if [ -n "$PR_INACTIVITY_TIMEOUT" ]; then
+        echo "prInactivityTimeout: $PR_INACTIVITY_TIMEOUT" >> "$CFG_FILE"
+    fi
     
     # PR Labels configuration (defaulting to 'overseer' inside the overseer container)
     PR_LABEL_VAL=${PR_LABEL:-overseer}

--- a/overseer/k8s/crds/overseer.gemini.google.com_overseers.yaml
+++ b/overseer/k8s/crds/overseer.gemini.google.com_overseers.yaml
@@ -80,6 +80,8 @@ spec:
               pollInterval:
                 default: 30m
                 type: string
+              prInactivityTimeout:
+                type: string
               repo:
                 properties:
                   issueMode:

--- a/overseer/pkg/api/v1alpha1/overseer_types.go
+++ b/overseer/pkg/api/v1alpha1/overseer_types.go
@@ -152,6 +152,10 @@ type OverseerSpec struct {
 	// +kubebuilder:default="1h"
 	SandboxIdleTimeout string `json:"sandboxIdleTimeout,omitempty"`
 
+	// PRInactivityTimeout defines the time of inactivity with no human comments before pausing automated processing on a PR (defaults to 0, which disables staleness checks).
+	// +kubebuilder:validation:Optional
+	PRInactivityTimeout *metav1.Duration `json:"prInactivityTimeout,omitempty"`
+
 	// MinNumber specifies the minimum PR/issue number to process.
 	// +kubebuilder:validation:Optional
 	MinNumber *int32 `json:"minNumber,omitempty"`

--- a/overseer/pkg/api/v1alpha1/zz_generated.deepcopy.go
+++ b/overseer/pkg/api/v1alpha1/zz_generated.deepcopy.go
@@ -5,6 +5,7 @@
 package v1alpha1
 
 import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -129,6 +130,11 @@ func (in *OverseerSpec) DeepCopyInto(out *OverseerSpec) {
 	if in.MaxActiveIssues != nil {
 		in, out := &in.MaxActiveIssues, &out.MaxActiveIssues
 		*out = new(int32)
+		**out = **in
+	}
+	if in.PRInactivityTimeout != nil {
+		in, out := &in.PRInactivityTimeout, &out.PRInactivityTimeout
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	if in.MinNumber != nil {

--- a/overseer/pkg/overseer/overseer.go
+++ b/overseer/pkg/overseer/overseer.go
@@ -285,6 +285,12 @@ func newOverseerSandboxFromOverseer(o *overseerv1alpha1.Overseer, name, namespac
 			"value": o.Spec.SandboxIdleTimeout,
 		})
 	}
+	if o.Spec.PRInactivityTimeout != nil {
+		env = append(env, map[string]interface{}{
+			"name":  "PR_INACTIVITY_TIMEOUT",
+			"value": o.Spec.PRInactivityTimeout.Duration.String(),
+		})
+	}
 	if o.Spec.MinNumber != nil {
 		env = append(env, map[string]interface{}{
 			"name":  "MIN_NUMBER",


### PR DESCRIPTION
We have observed that overseer spends a lot cycles/tokens on stale pull requests, for example to periodically rebase. In order to minimize wasted tokens/cycles, this change introduces a staleness concept where a pull request without human action after a duration is treated as stale. A stale PR will have the overseer/stop label added, which can subsequently be removed by a human to resume overseer. This uses a default value of 1 week but can be configured on the overseer CR.