### PR TITLE
ci: switch automated deploy to preview cluster

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -129,10 +129,10 @@ jobs:
     needs: [build-and-publish, build-and-publish-overseer, build-and-publish-factory]
     permissions:
       contents: read
-    uses: ./.github/workflows/deploy-staging.yaml
+    uses: ./.github/workflows/deploy-preview.yaml
     with:
       image_tag: ${{ github.sha }}
     secrets:
       GKE_SA_KEY: ${{ secrets.GKE_SA_KEY }}
-      GKE_STAGING_CLUSTER: ${{ secrets.GKE_STAGING_CLUSTER }}
+      GKE_PREVIEW_CLUSTER: ${{ secrets.GKE_PREVIEW_CLUSTER }}
       GKE_ZONE: ${{ secrets.GKE_ZONE }}

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -1,6 +1,12 @@
 name: deploy to preview
 
 on:
+  workflow_call:
+    inputs:
+      image_tag:
+        description: 'Image tag to deploy'
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       image_tag:


### PR DESCRIPTION
This switches the automated deployment mechanism to target the preview cluster instead of the staging cluster. We would like for the staging cluster to become more stable and have less frequent deployments.