### PR TITLE
ci: fix secrets for reusable deploy workflows

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -135,4 +135,5 @@ jobs:
     secrets:
       GKE_SA_KEY: ${{ secrets.GKE_SA_KEY }}
       GKE_PREVIEW_CLUSTER: ${{ secrets.GKE_PREVIEW_CLUSTER }}
+      GKE_PREVIEW_STD_CLUSTER: ${{ secrets.GKE_PREVIEW_STD_CLUSTER }}
       GKE_ZONE: ${{ secrets.GKE_ZONE }}

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -7,6 +7,15 @@ on:
         description: 'Image tag to deploy'
         required: true
         type: string
+    secrets:
+      GKE_SA_KEY:
+        required: true
+      GKE_PREVIEW_CLUSTER:
+        required: true
+      GKE_PREVIEW_STD_CLUSTER:
+        required: true
+      GKE_ZONE:
+        required: true
   workflow_dispatch:
     inputs:
       image_tag:

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -7,6 +7,13 @@ on:
         description: 'Image tag to deploy'
         required: true
         type: string
+    secrets:
+      GKE_SA_KEY:
+        required: true
+      GKE_STAGING_CLUSTER:
+        required: true
+      GKE_ZONE:
+        required: true
   workflow_dispatch:
     inputs:
       image_tag:


### PR DESCRIPTION
When calling a reusable workflow with explicit secrets, rather than secrets: inherit, GitHub actions requires the called workflow to explicitly declare those secrets under on.workflow_call.secrets.