### PR TITLE
fix(watch): prevent duplicate task runs by checking active sandbox and mapping PR task types on recovery

### DIFF
--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -324,10 +324,19 @@ func isSandboxTaskCompleted(ctx context.Context, kubeClient *clients.KubernetesC
 	tType := annotations["sandbox.gemini.google.com/last-task-type"]
 
 	sbTaskType := taskType
-	if taskType == "issue-fix" {
+	switch taskType {
+	case "issue-fix":
 		sbTaskType = "fix-issue"
-	} else if taskType == "agent-chore" {
+	case "agent-chore":
 		sbTaskType = "agent"
+	case "pr-comments":
+		sbTaskType = "address-comments"
+	case "pr-investigate":
+		sbTaskType = "investigate"
+	case "pr-iterate":
+		sbTaskType = "iterate"
+	case "pr-review":
+		sbTaskType = "review"
 	}
 
 	if strings.EqualFold(state, "Completed") && strings.EqualFold(tType, sbTaskType) {
@@ -1231,16 +1240,38 @@ func runWatch(ctx context.Context, owner, repo string, interval time.Duration, a
 		}
 	}
 
-	// Recovery: Move any stuck tasks from processingDir back to incomingDir on startup
+	// Recovery: Handle any leftover tasks in processingDir on startup
 	if files, err := os.ReadDir(processingDir); err == nil {
 		for _, f := range files {
 			if !f.IsDir() && strings.HasPrefix(f.Name(), "task-") && strings.HasSuffix(f.Name(), ".yaml") {
 				processingPath := filepath.Join(processingDir, f.Name())
 
-				// Read the task to reset its status to Pending
+				// Read the task
 				if data, err := os.ReadFile(processingPath); err == nil {
 					var t QueueTask
 					if err := yaml.Unmarshal(data, &t); err == nil {
+						sandboxName := resolveSandboxName(ctx, kubeClient, ghClient, t.Type, t.Number, owner, repo)
+						if kubeClient != nil && sandboxName != "" {
+							running, err := isSandboxTaskRunning(ctx, kubeClient, rootFlags.Namespace, sandboxName)
+							if err == nil && running {
+								klog.Infof("Task %s is still actively running in sandbox %s. Leaving in processing.", f.Name(), sandboxName)
+								continue
+							}
+							completed, err := isSandboxTaskCompleted(ctx, kubeClient, rootFlags.Namespace, sandboxName, t.Type)
+							if err == nil && completed {
+								klog.Infof("Task %s already completed in sandbox %s. Moving from processing to processed.", f.Name(), sandboxName)
+								t.Status = "Completed"
+								if t.CompletedAt.IsZero() {
+									t.CompletedAt = time.Now()
+								}
+								if err := writeTaskAtomically(processedDir, f.Name(), &t); err == nil {
+									_ = os.Remove(processingPath)
+									writeTaskJournalEvent(queueDir, f.Name(), &t, "Completed", 0)
+									continue
+								}
+							}
+						}
+
 						t.Status = "Pending"
 						t.Recovered = true
 						if err := writeTaskAtomically(incomingDir, f.Name(), &t); err == nil {

--- a/factory/pkg/commands/watch_test.go
+++ b/factory/pkg/commands/watch_test.go
@@ -1,14 +1,22 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/clients"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/config"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/k8s"
 	githubv39 "github.com/google/go-github/v39/github"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"sigs.k8s.io/yaml"
 )
 
@@ -770,3 +778,65 @@ func TestSortTasksFairly(t *testing.T) {
 		}
 	})
 }
+
+func TestIsSandboxTaskCompleted(t *testing.T) {
+	scheme := runtime.NewScheme()
+	ctx := context.Background()
+	ns := "test-ns"
+
+	tests := []struct {
+		taskType          string
+		annotatedTaskType string
+		state             string
+		expectedCompleted bool
+	}{
+		{"pr-comments", "address-comments", "Completed", true},
+		{"pr-comments", "address-comments", "Running", false},
+		{"pr-investigate", "investigate", "Completed", true},
+		{"pr-iterate", "iterate", "Completed", true},
+		{"pr-review", "review", "Completed", true},
+		{"issue-fix", "fix-issue", "Completed", true},
+		{"agent-chore", "agent", "Completed", true},
+		{"pr-comments", "wrong-type", "Completed", false},
+	}
+
+	for _, tc := range tests {
+		sbName := fmt.Sprintf("sb-%s-%s", tc.taskType, tc.state)
+		fakeDynamic := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{
+			k8s.SandboxGVR: "SandboxList",
+		})
+		kubeClient := &clients.KubernetesClient{
+			DynamicClient: fakeDynamic,
+		}
+
+		sb := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "agents.x-k8s.io/v1alpha1",
+				"kind":       "Sandbox",
+				"metadata": map[string]interface{}{
+					"name":      sbName,
+					"namespace": ns,
+					"annotations": map[string]interface{}{
+						"sandbox.gemini.google.com/last-task-state": tc.state,
+						"sandbox.gemini.google.com/last-task-type":  tc.annotatedTaskType,
+					},
+				},
+			},
+		}
+
+		_, err := fakeDynamic.Resource(k8s.SandboxGVR).Namespace(ns).Create(ctx, sb, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Failed to create mock sandbox: %v", err)
+		}
+
+		completed, err := isSandboxTaskCompleted(ctx, kubeClient, ns, sbName, tc.taskType)
+		if err != nil {
+			t.Errorf("Unexpected error for %s: %v", tc.taskType, err)
+		}
+		if completed != tc.expectedCompleted {
+			t.Errorf("For taskType=%s, annotatedTaskType=%s, state=%s: expected completed=%v, got %v",
+				tc.taskType, tc.annotatedTaskType, tc.state, tc.expectedCompleted, completed)
+		}
+	}
+}
+

--- a/factory/pkg/commands/watch_test.go
+++ b/factory/pkg/commands/watch_test.go
@@ -839,4 +839,3 @@ func TestIsSandboxTaskCompleted(t *testing.T) {
 		}
 	}
 }
-


### PR DESCRIPTION
### Summary of Changes
- **Map PR Task Types in `isSandboxTaskCompleted()`**: Added proper mapping from queue task types (`pr-comments`, `pr-investigate`, `pr-iterate`, `pr-review`) to their sandbox annotation types (`address-comments`, `investigate`, `iterate`, `review`).
- **Check Active and Completed Sandbox on Startup Recovery**: In the startup `processing/` recovery loop, check `isSandboxTaskRunning()` and `isSandboxTaskCompleted()`. If the sandbox is actively running the task, leave it in `processing/`. If the sandbox already finished the task, advance it to `processed/` rather than re-queueing for duplicate execution.
- **Unit Tests**: Added `TestIsSandboxTaskCompleted` in `watch_test.go` verifying all task type mappings against mock Kubernetes sandboxes.