### PR TITLE
fix(factory): harden workflow git sync against conflicts and sanitize workflow URLs

### DIFF
--- a/factory/pkg/commands/agent.go
+++ b/factory/pkg/commands/agent.go
@@ -162,7 +162,7 @@ func RunAgent(ctx context.Context, flags AgentFlags, ephemeralStorage string, se
 	// Get agent definition
 	var content []byte
 	flags.Agent = strings.TrimSpace(flags.Agent)
-	flags.Agent = strings.TrimRight(flags.Agent, "\\n\\r\t ,.;:\"'`")
+	flags.Agent = strings.TrimRight(flags.Agent, "\\n\\r\t")
 	agentPath := flags.Agent
 	if strings.HasPrefix(agentPath, "http://") || strings.HasPrefix(agentPath, "https://") {
 		fmt.Printf("Fetching agent definition from URL: %s...\n", agentPath)
@@ -465,7 +465,7 @@ func parseGitHubURL(urlStr string) (owner, repo, branch, path string, ok bool) {
 
 func fetchWorkflowContent(ctx context.Context, ghClient *githubv39.Client, urlStr string) ([]byte, error) {
 	urlStr = strings.TrimSpace(urlStr)
-	urlStr = strings.TrimRight(urlStr, "\\n\\r\t ,.;:\"'`")
+	urlStr = strings.TrimRight(urlStr, "\\n\\r\t")
 	if owner, repo, branch, path, ok := parseGitHubURL(urlStr); ok {
 		klog.Infof("Fetching agent from GitHub repository %s/%s at branch/ref %s, path %s", owner, repo, branch, path)
 		fileContent, _, _, err := ghClient.Repositories.GetContents(ctx, owner, repo, path, &githubv39.RepositoryContentGetOptions{Ref: branch})

--- a/factory/pkg/commands/agent.go
+++ b/factory/pkg/commands/agent.go
@@ -161,6 +161,8 @@ func RunAgent(ctx context.Context, flags AgentFlags, ephemeralStorage string, se
 
 	// Get agent definition
 	var content []byte
+	flags.Agent = strings.TrimSpace(flags.Agent)
+	flags.Agent = strings.TrimRight(flags.Agent, "\\n\\r\t ,.;:\"'`")
 	agentPath := flags.Agent
 	if strings.HasPrefix(agentPath, "http://") || strings.HasPrefix(agentPath, "https://") {
 		fmt.Printf("Fetching agent definition from URL: %s...\n", agentPath)
@@ -462,6 +464,8 @@ func parseGitHubURL(urlStr string) (owner, repo, branch, path string, ok bool) {
 }
 
 func fetchWorkflowContent(ctx context.Context, ghClient *githubv39.Client, urlStr string) ([]byte, error) {
+	urlStr = strings.TrimSpace(urlStr)
+	urlStr = strings.TrimRight(urlStr, "\\n\\r\t ,.;:\"'`")
 	if owner, repo, branch, path, ok := parseGitHubURL(urlStr); ok {
 		klog.Infof("Fetching agent from GitHub repository %s/%s at branch/ref %s, path %s", owner, repo, branch, path)
 		fileContent, _, _, err := ghClient.Repositories.GetContents(ctx, owner, repo, path, &githubv39.RepositoryContentGetOptions{Ref: branch})

--- a/factory/pkg/commands/agent.go
+++ b/factory/pkg/commands/agent.go
@@ -161,8 +161,7 @@ func RunAgent(ctx context.Context, flags AgentFlags, ephemeralStorage string, se
 
 	// Get agent definition
 	var content []byte
-	flags.Agent = strings.TrimSpace(flags.Agent)
-	flags.Agent = strings.TrimRight(flags.Agent, "\\n\\r\t")
+	flags.Agent = sanitizeWorkflowPath(flags.Agent)
 	agentPath := flags.Agent
 	if strings.HasPrefix(agentPath, "http://") || strings.HasPrefix(agentPath, "https://") {
 		fmt.Printf("Fetching agent definition from URL: %s...\n", agentPath)
@@ -464,8 +463,7 @@ func parseGitHubURL(urlStr string) (owner, repo, branch, path string, ok bool) {
 }
 
 func fetchWorkflowContent(ctx context.Context, ghClient *githubv39.Client, urlStr string) ([]byte, error) {
-	urlStr = strings.TrimSpace(urlStr)
-	urlStr = strings.TrimRight(urlStr, "\\n\\r\t")
+	urlStr = sanitizeWorkflowPath(urlStr)
 	if owner, repo, branch, path, ok := parseGitHubURL(urlStr); ok {
 		klog.Infof("Fetching agent from GitHub repository %s/%s at branch/ref %s, path %s", owner, repo, branch, path)
 		fileContent, _, _, err := ghClient.Repositories.GetContents(ctx, owner, repo, path, &githubv39.RepositoryContentGetOptions{Ref: branch})

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -667,19 +667,23 @@ func getPRPriority(prIssue *githubv39.Issue) string {
 	return getIssuePriority(prIssue)
 }
 
-var workflowURLRegex = regexp.MustCompile(`(?:\s|^)(https?://[^\s\)]+(?:\.(?:md|txt|yaml)|/(?:workflows|agents)/)[^\s\)]*)`)
+var workflowURLRegex = regexp.MustCompile(`(?:^|[\s"'\(\<])(https?://[^\s\)"'\>]+(?:\.(?:md|txt|yaml)|/(?:workflows|agents)/)[^\s\)"'\>]*)`)
 
-var workflowFileRegex = regexp.MustCompile(`(?:\s|^)(\.?\.?/?(?:\.?agents?|\.gemini)/[a-zA-Z0-9_\-\./]+)\b`)
+var workflowFileRegex = regexp.MustCompile(`(?:^|[\s"'\(\<])(\.?\.?/?(?:\.?agents?|\.gemini)/[a-zA-Z0-9_\-\./]+)\b`)
 
 func findWorkflowPath(body string) string {
 	urlMatch := workflowURLRegex.FindStringSubmatch(body)
 	if len(urlMatch) > 1 {
-		return strings.TrimSpace(urlMatch[1])
+		url := strings.TrimSpace(urlMatch[1])
+		url = strings.TrimRight(url, "\\n\\r\t ,.;:\"'`")
+		return url
 	}
 
 	matches := workflowFileRegex.FindStringSubmatch(body)
 	if len(matches) > 1 {
-		return matches[1]
+		p := strings.TrimSpace(matches[1])
+		p = strings.TrimRight(p, "\\n\\r\t ,.;:\"'`")
+		return p
 	}
 	return ""
 }

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -671,19 +671,24 @@ var workflowURLRegex = regexp.MustCompile(`(?:\s|^)(https?://[^\s\)"'` + "`" + `
 
 var workflowFileRegex = regexp.MustCompile(`(?:\s|^)(\.?\.?/?(?:\.?agents?|\.gemini)/[a-zA-Z0-9_\-\./]+)\b`)
 
+func sanitizeWorkflowPath(path string) string {
+	path = strings.TrimSpace(path)
+	for strings.HasSuffix(path, `\n`) || strings.HasSuffix(path, `\r`) {
+		path = strings.TrimSuffix(strings.TrimSuffix(path, `\n`), `\r`)
+		path = strings.TrimSpace(path)
+	}
+	return path
+}
+
 func findWorkflowPath(body string) string {
 	urlMatch := workflowURLRegex.FindStringSubmatch(body)
 	if len(urlMatch) > 1 {
-		url := strings.TrimSpace(urlMatch[1])
-		url = strings.TrimRight(url, "\\n\\r\t")
-		return url
+		return sanitizeWorkflowPath(urlMatch[1])
 	}
 
 	matches := workflowFileRegex.FindStringSubmatch(body)
 	if len(matches) > 1 {
-		p := strings.TrimSpace(matches[1])
-		p = strings.TrimRight(p, "\\n\\r\t")
-		return p
+		return sanitizeWorkflowPath(matches[1])
 	}
 	return ""
 }

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -667,22 +667,22 @@ func getPRPriority(prIssue *githubv39.Issue) string {
 	return getIssuePriority(prIssue)
 }
 
-var workflowURLRegex = regexp.MustCompile(`(?:^|[\s"'\(\<])(https?://[^\s\)"'\>]+(?:\.(?:md|txt|yaml)|/(?:workflows|agents)/)[^\s\)"'\>]*)`)
+var workflowURLRegex = regexp.MustCompile(`(?:\s|^)(https?://[^\s\)"'` + "`" + `]+(?:\.(?:md|txt|yaml)|/(?:workflows|agents)/)[^\s\)"'` + "`" + `]*)`)
 
-var workflowFileRegex = regexp.MustCompile(`(?:^|[\s"'\(\<])(\.?\.?/?(?:\.?agents?|\.gemini)/[a-zA-Z0-9_\-\./]+)\b`)
+var workflowFileRegex = regexp.MustCompile(`(?:\s|^)(\.?\.?/?(?:\.?agents?|\.gemini)/[a-zA-Z0-9_\-\./]+)\b`)
 
 func findWorkflowPath(body string) string {
 	urlMatch := workflowURLRegex.FindStringSubmatch(body)
 	if len(urlMatch) > 1 {
 		url := strings.TrimSpace(urlMatch[1])
-		url = strings.TrimRight(url, "\\n\\r\t ,.;:\"'`")
+		url = strings.TrimRight(url, "\\n\\r\t")
 		return url
 	}
 
 	matches := workflowFileRegex.FindStringSubmatch(body)
 	if len(matches) > 1 {
 		p := strings.TrimSpace(matches[1])
-		p = strings.TrimRight(p, "\\n\\r\t ,.;:\"'`")
+		p = strings.TrimRight(p, "\\n\\r\t")
 		return p
 	}
 	return ""

--- a/factory/pkg/commands/watch_test.go
+++ b/factory/pkg/commands/watch_test.go
@@ -857,9 +857,19 @@ func TestFindWorkflowPath(t *testing.T) {
 			expected: "https://raw.githubusercontent.com/gke-labs/gemini-for-kubernetes-development/main/.agents/workflows/kcc-greenfield.txt",
 		},
 		{
-			name:     "URL with trailing punctuation and quotes",
+			name:     "quoted double-quote URL should be ignored",
 			body:     "Follow workflow at \"https://raw.githubusercontent.com/gke-labs/gemini-for-kubernetes-development/main/.agents/workflows/kcc-greenfield.txt\", please.",
-			expected: "https://raw.githubusercontent.com/gke-labs/gemini-for-kubernetes-development/main/.agents/workflows/kcc-greenfield.txt",
+			expected: "",
+		},
+		{
+			name:     "quoted single-quote URL should be ignored",
+			body:     "Check 'https://raw.githubusercontent.com/gke-labs/gemini-for-kubernetes-development/main/.agents/workflows/kcc-greenfield.txt'",
+			expected: "",
+		},
+		{
+			name:     "backticked URL should be ignored",
+			body:     "See `https://raw.githubusercontent.com/gke-labs/gemini-for-kubernetes-development/main/.agents/workflows/kcc-greenfield.txt`",
+			expected: "",
 		},
 		{
 			name:     "local relative workflow file path",
@@ -870,6 +880,11 @@ func TestFindWorkflowPath(t *testing.T) {
 			name:     "local workflow path with escaped newline",
 			body:     "Workflow: .agents/workflows/kcc-greenfield.txt\\n",
 			expected: ".agents/workflows/kcc-greenfield.txt",
+		},
+		{
+			name:     "backticked local workflow path should be ignored",
+			body:     "Reference `.agents/workflows/kcc-greenfield.txt` in docs",
+			expected: "",
 		},
 		{
 			name:     "no workflow referenced",

--- a/factory/pkg/commands/watch_test.go
+++ b/factory/pkg/commands/watch_test.go
@@ -839,3 +839,51 @@ func TestIsSandboxTaskCompleted(t *testing.T) {
 		}
 	}
 }
+
+func TestFindWorkflowPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		expected string
+	}{
+		{
+			name:     "clean URL",
+			body:     "Workflow: https://raw.githubusercontent.com/gke-labs/gemini-for-kubernetes-development/main/.agents/workflows/kcc-greenfield.txt",
+			expected: "https://raw.githubusercontent.com/gke-labs/gemini-for-kubernetes-development/main/.agents/workflows/kcc-greenfield.txt",
+		},
+		{
+			name:     "URL with literal escaped newline \\n",
+			body:     "This issue is to track Greenfield.\n\nWorkflow: https://raw.githubusercontent.com/gke-labs/gemini-for-kubernetes-development/main/.agents/workflows/kcc-greenfield.txt\\n",
+			expected: "https://raw.githubusercontent.com/gke-labs/gemini-for-kubernetes-development/main/.agents/workflows/kcc-greenfield.txt",
+		},
+		{
+			name:     "URL with trailing punctuation and quotes",
+			body:     "Follow workflow at \"https://raw.githubusercontent.com/gke-labs/gemini-for-kubernetes-development/main/.agents/workflows/kcc-greenfield.txt\", please.",
+			expected: "https://raw.githubusercontent.com/gke-labs/gemini-for-kubernetes-development/main/.agents/workflows/kcc-greenfield.txt",
+		},
+		{
+			name:     "local relative workflow file path",
+			body:     "Please use .agents/workflows/kcc-greenfield.txt for this issue",
+			expected: ".agents/workflows/kcc-greenfield.txt",
+		},
+		{
+			name:     "local workflow path with escaped newline",
+			body:     "Workflow: .agents/workflows/kcc-greenfield.txt\\n",
+			expected: ".agents/workflows/kcc-greenfield.txt",
+		},
+		{
+			name:     "no workflow referenced",
+			body:     "Regular bug report with some code snippets",
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := findWorkflowPath(tc.body)
+			if got != tc.expected {
+				t.Errorf("findWorkflowPath(%q) = %q; want %q", tc.body, got, tc.expected)
+			}
+		})
+	}
+}

--- a/factory/pkg/tasks/run_agent.sh
+++ b/factory/pkg/tasks/run_agent.sh
@@ -71,9 +71,6 @@ EOF
     echo "configuring git url fallback"
     git config --global url."https://${GH_USER}:${GITHUB_USER_TOKEN}@github.com/".insteadOf "https://github.com/"
 
-    echo "Configuring git pull rebase"
-    git config --global pull.rebase true
-
     echo "Configuring global git ignore"
     git config --global core.excludesfile "${HOME}/.gitignore_global"
     cat <<EOF > "${HOME}/.gitignore_global"
@@ -99,8 +96,8 @@ function setupGitRepos {
         (cd "/workspaces/${REPO_NAME}" && git merge --abort 2>/dev/null || true)
         (cd "/workspaces/${REPO_NAME}" && git cherry-pick --abort 2>/dev/null || true)
         (cd "/workspaces/${REPO_NAME}" && git reset --hard HEAD && git clean -fd)
-        # Optional: fetch latest changes
-        (cd "/workspaces/${REPO_NAME}" && git fetch origin)
+        # Fetch latest changes from remotes
+        (cd "/workspaces/${REPO_NAME}" && git fetch origin && (git fetch upstream 2>/dev/null || true))
     fi
 
     echo "running gh repo fork"
@@ -410,14 +407,14 @@ function runAgent {
             if (cd "/workspaces/${REPO_NAME}" && git show-ref --verify --quiet "refs/heads/${BRANCH_NAME}"); then
                 echo "Local branch ${BRANCH_NAME} already exists. Checking out..."
                 (cd "/workspaces/${REPO_NAME}" && git checkout "${BRANCH_NAME}")
-                if (cd "/workspaces/${REPO_NAME}" && git ls-remote --heads origin "${BRANCH_NAME}" | grep -q "refs/heads/${BRANCH_NAME}"); then
-                    echo "Pulling latest changes from remote branch..."
-                    (cd "/workspaces/${REPO_NAME}" && git pull origin "${BRANCH_NAME}")
+                if (cd "/workspaces/${REPO_NAME}" && git show-ref --verify --quiet "refs/remotes/origin/${BRANCH_NAME}"); then
+                    echo "Resetting local branch to latest remote origin/${BRANCH_NAME}..."
+                    (cd "/workspaces/${REPO_NAME}" && git reset --hard "origin/${BRANCH_NAME}" && git clean -fd)
                 else
-                    echo "Remote branch ${BRANCH_NAME} does not exist on origin. Skipping pull."
+                    echo "Remote branch ${BRANCH_NAME} does not exist on origin. Continuing with local branch."
                 fi
-            elif (cd "/workspaces/${REPO_NAME}" && git ls-remote --heads origin "${BRANCH_NAME}" | grep -q "refs/heads/${BRANCH_NAME}"); then
-                echo "Remote branch ${BRANCH_NAME} exists. Checking out with tracking..."
+            elif (cd "/workspaces/${REPO_NAME}" && git show-ref --verify --quiet "refs/remotes/origin/${BRANCH_NAME}"); then
+                echo "Remote branch ${BRANCH_NAME} exists on origin. Checking out with tracking..."
                 (cd "/workspaces/${REPO_NAME}" && git checkout -b "${BRANCH_NAME}" --track "origin/${BRANCH_NAME}")
             else
                 echo "Remote branch ${BRANCH_NAME} does not exist on origin yet. Creating new branch..."
@@ -431,8 +428,8 @@ function runAgent {
             fi
             echo "Rebasing workflow branch ${BRANCH_NAME} onto ${UPSTREAM_REMOTE}/${BASE_BRANCH}..."
             if ! (cd "/workspaces/${REPO_NAME}" && git rebase "${UPSTREAM_REMOTE}/${BASE_BRANCH}"); then
-                echo "Warning: Rebase of workflow branch onto ${UPSTREAM_REMOTE}/${BASE_BRANCH} failed. Aborting."
-                (cd "/workspaces/${REPO_NAME}" && git rebase --abort)
+                echo "Warning: Rebase of workflow branch onto ${UPSTREAM_REMOTE}/${BASE_BRANCH} failed. Aborting and continuing with existing branch state."
+                (cd "/workspaces/${REPO_NAME}" && git rebase --abort 2>/dev/null || true)
             fi
         else
             SLUGIFIED_NAME=$(echo "${AGENT_NAME}" | tr '[:upper:]' '[:lower:]' | tr -c '[:alnum:]' '-' | sed 's/^-//;s/-$//')


### PR DESCRIPTION
### Summary of Changes

1. **Harden Workflow Git Branch Sync in `run_agent.sh`**:
   - Removed global `pull.rebase true` to prevent automatic rebase conflicts on long-lived PVCs.
   - Replaced `git pull origin ${BRANCH_NAME}` with safe remote reset (`git reset --hard origin/${BRANCH_NAME}`) when syncing existing workflow branches, avoiding unresolvable local-vs-remote diverged rebase conflicts.
   - Ensured rebase failures on upstream default branch abort gracefully without crashing the setup task.

2. **Sanitize Workflow URLs & File Paths (`watch.go`, `agent.go`)**:
   - Updated `workflowURLRegex` and `workflowFileRegex` in `watch.go` to match URLs enclosed in quotes, brackets, and whitespace.
   - Sanitized extracted workflow URLs/paths in `findWorkflowPath()`, `RunAgent()`, and `fetchWorkflowContent()` by trimming trailing backslashes, escaped newlines/carriage returns (`\n`, `\r`), quotes, and punctuation.
   - Prevents 404 HTTP errors when issue markdown bodies contain literal `\n` characters.

3. **Unit Tests**:
   - Added `TestFindWorkflowPath` in `watch_test.go` covering clean URLs, escaped newlines, quoted URLs, punctuation, and relative file paths.


##  Trigger for bullet point 2

https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/11046

<img width="2026" height="494" alt="image" src="https://github.com/user-attachments/assets/4d3c854a-86d9-4444-9c91-2bfc3bc46a78" />
