### PR TITLE
fix(tasks): add automated commitAndPush fallback to address_feedback.sh and investigate_failures.sh

### DIFF
--- a/factory/pkg/tasks/address_feedback.sh
+++ b/factory/pkg/tasks/address_feedback.sh
@@ -113,6 +113,7 @@ function checkoutPRBranch {
     (cd "/workspaces/${REPO_NAME}" && git merge --abort 2>/dev/null || true)
     (cd "/workspaces/${REPO_NAME}" && git cherry-pick --abort 2>/dev/null || true)
     (cd "/workspaces/${REPO_NAME}" && git reset --hard HEAD && git clean -fd && /usr/bin/gh pr checkout ${PR_NUMBER} --force && (git reset --hard @{u} 2>/dev/null || git reset --hard FETCH_HEAD))
+    OLD_HEAD=$(cd "/workspaces/${REPO_NAME}" && git rev-parse HEAD)
 }
 
 function configureGemini {
@@ -317,6 +318,34 @@ function runGemini {
     fi
 }
 
+function commitAndPush {
+    echo "Running commitAndPush..."
+    pushd "/workspaces/${REPO_NAME}" > /dev/null
+    
+    NEW_HEAD=$(git rev-parse HEAD)
+
+    # check if there are changes
+    if [ -z "$(git status --porcelain)" ]; then 
+        if [ "$OLD_HEAD" != "$NEW_HEAD" ]; then
+            echo "HEAD has changed (committed or rebased by agent). Pushing changes..."
+            git push --force origin HEAD
+        else
+            echo "No changes to commit."
+        fi
+    else
+        echo "Changes detected in working directory, committing..."
+        git add .
+        git commit -m "Address review feedback: Apply changes"
+        if [ "$OLD_HEAD" != "$NEW_HEAD" ]; then
+            echo "HEAD has changed and working directory has changes. Pushing changes..."
+            git push --force origin HEAD
+        else
+            git push origin HEAD
+        fi
+    fi
+    popd > /dev/null
+}
+
 # Main execution
 setupGit
 setupGitRepos
@@ -326,3 +355,5 @@ checkoutPRBranch
 configureGemini
 installExtensions
 runGemini
+commitAndPush
+

--- a/factory/pkg/tasks/investigate_failures.sh
+++ b/factory/pkg/tasks/investigate_failures.sh
@@ -114,6 +114,7 @@ function checkoutPRBranch {
     (cd "/workspaces/${REPO_NAME}" && git merge --abort 2>/dev/null || true)
     (cd "/workspaces/${REPO_NAME}" && git cherry-pick --abort 2>/dev/null || true)
     (cd "/workspaces/${REPO_NAME}" && git reset --hard HEAD && git clean -fd && /usr/bin/gh pr checkout ${PR_NUMBER} --force && (git reset --hard @{u} 2>/dev/null || git reset --hard FETCH_HEAD))
+    OLD_HEAD=$(cd "/workspaces/${REPO_NAME}" && git rev-parse HEAD)
 }
 
 function fetchLogs {
@@ -341,6 +342,34 @@ function runGemini {
     fi
 }
 
+function commitAndPush {
+    echo "Running commitAndPush..."
+    pushd "/workspaces/${REPO_NAME}" > /dev/null
+    
+    NEW_HEAD=$(git rev-parse HEAD)
+
+    # check if there are changes
+    if [ -z "$(git status --porcelain)" ]; then 
+        if [ "$OLD_HEAD" != "$NEW_HEAD" ]; then
+            echo "HEAD has changed (committed or rebased by agent). Pushing changes..."
+            git push --force origin HEAD
+        else
+            echo "No changes to commit."
+        fi
+    else
+        echo "Changes detected in working directory, committing..."
+        git add .
+        git commit -m "Fix CI failures: Apply changes"
+        if [ "$OLD_HEAD" != "$NEW_HEAD" ]; then
+            echo "HEAD has changed and working directory has changes. Pushing changes..."
+            git push --force origin HEAD
+        else
+            git push origin HEAD
+        fi
+    fi
+    popd > /dev/null
+}
+
 # Main execution
 setupGit
 setupGitRepos
@@ -351,3 +380,5 @@ fetchLogs
 configureGemini
 installExtensions
 runGemini
+commitAndPush
+


### PR DESCRIPTION
### Summary of Changes

1. **Automated `commitAndPush` Fallback**:
   - Added `OLD_HEAD` recording in `checkoutPRBranch` across both `address_feedback.sh` and `investigate_failures.sh`.
   - Added `commitAndPush` function that runs after `runGemini`:
     - If the working directory has uncommitted/unstaged edits (`git status --porcelain` non-empty), it automatically stages (`git add .`), commits, and pushes them upstream.
     - If the agent committed or rebased locally but did not push (`OLD_HEAD != NEW_HEAD`), it pushes the commits upstream (`git push origin HEAD` or `--force`).
     - If no changes were made or committed (`git status --porcelain` empty and `OLD_HEAD == NEW_HEAD`), it exits cleanly without attempting git push (`No changes to commit.`).

2. **Parity with `iterate.sh`**:
   - Matches the battle-tested pattern in `iterate.sh` and `fix_issue.sh`, preventing changes from remaining stranded in the sandbox if the LLM finishes its turn before executing git commands.


## Root cause

Address comment task was triggered but commit was not pushed. 
we need a fallback if the model doesnt push.

https://github.com/GoogleCloudPlatform/k8s-config-connector/pull/12301#issuecomment-5236814465

<img width="2154" height="968" alt="image" src="https://github.com/user-attachments/assets/3b322bca-584a-4abd-947c-289f15855500" />
