### PR TITLE
ci: rename deploy-preview to deploy-autopush

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -129,11 +129,9 @@ jobs:
     needs: [build-and-publish, build-and-publish-overseer, build-and-publish-factory]
     permissions:
       contents: read
-    uses: ./.github/workflows/deploy-preview.yaml
+    uses: ./.github/workflows/deploy-autopush.yaml
     with:
       image_tag: ${{ github.sha }}
     secrets:
       GKE_SA_KEY: ${{ secrets.GKE_SA_KEY }}
-      GKE_PREVIEW_CLUSTER: ${{ secrets.GKE_PREVIEW_CLUSTER }}
-      GKE_PREVIEW_STD_CLUSTER: ${{ secrets.GKE_PREVIEW_STD_CLUSTER }}
       GKE_ZONE: ${{ secrets.GKE_ZONE }}

--- a/.github/workflows/deploy-autopush.yaml
+++ b/.github/workflows/deploy-autopush.yaml
@@ -1,4 +1,4 @@
-name: deploy to preview
+name: deploy to autopush
 
 on:
   workflow_call:
@@ -9,10 +9,6 @@ on:
         type: string
     secrets:
       GKE_SA_KEY:
-        required: true
-      GKE_PREVIEW_CLUSTER:
-        required: true
-      GKE_PREVIEW_STD_CLUSTER:
         required: true
       GKE_ZONE:
         required: true
@@ -27,7 +23,7 @@ permissions:
   contents: read
 
 jobs:
-  deploy-preview:
+  deploy-autopush:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -43,28 +39,28 @@ jobs:
       - name: Set up GKE credentials
         uses: google-github-actions/get-gke-credentials@3da1e46a907576cefaa90c484278bb5b259dd395 # v3
         with:
-          cluster_name: ${{ secrets.GKE_PREVIEW_CLUSTER }}
+          cluster_name: ${{ vars.GKE_AUTOPUSH_CLUSTER }}
           location: ${{ secrets.GKE_ZONE }}
 
-      - name: Deploy to Preview
+      - name: Deploy to Autopush
         run: |
           chmod +x ./repo-agent/scripts/upgrade.sh
           ./repo-agent/scripts/upgrade.sh
         env:
           IMAGE_TAG: ${{ inputs.image_tag || github.sha }}
           SKIP_PREQS: 'true'
-          CLUSTER_NAME: ${{ secrets.GKE_PREVIEW_CLUSTER }}
+          CLUSTER_NAME: ${{ vars.GKE_AUTOPUSH_CLUSTER }}
           GW_CLASS: 'gke-l7-regional-external-managed'
 
-      - name: Deploy Overseer to Preview
+      - name: Deploy Overseer to Autopush
         run: |
           chmod +x ./overseer/scripts/upgrade.sh
           ./overseer/scripts/upgrade.sh
         env:
           IMAGE_TAG: ${{ inputs.image_tag || github.sha }}
           SKIP_PREQS: 'true'
-          CLUSTER_NAME: ${{ secrets.GKE_PREVIEW_CLUSTER }}
-  deploy-preview-std:
+          CLUSTER_NAME: ${{ vars.GKE_AUTOPUSH_CLUSTER }}
+  deploy-autopush-std:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -80,24 +76,24 @@ jobs:
       - name: Set up GKE credentials
         uses: google-github-actions/get-gke-credentials@3da1e46a907576cefaa90c484278bb5b259dd395 # v3
         with:
-          cluster_name: ${{ secrets.GKE_PREVIEW_STD_CLUSTER }}
+          cluster_name: ${{ vars.GKE_AUTOPUSH_STD_CLUSTER }}
           location: ${{ secrets.GKE_ZONE }}
 
-      - name: Deploy to Preview Standard
+      - name: Deploy to Autopush Standard
         run: |
           chmod +x ./repo-agent/scripts/upgrade.sh
           ./repo-agent/scripts/upgrade.sh
         env:
           IMAGE_TAG: ${{ inputs.image_tag || github.sha }}
           SKIP_PREQS: 'true'
-          CLUSTER_NAME: ${{ secrets.GKE_PREVIEW_STD_CLUSTER }}
+          CLUSTER_NAME: ${{ vars.GKE_AUTOPUSH_STD_CLUSTER }}
           GW_CLASS: 'gke-l7-regional-external-managed'
 
-      - name: Deploy Overseer to Preview Standard
+      - name: Deploy Overseer to Autopush Standard
         run: |
           chmod +x ./overseer/scripts/upgrade.sh
           ./overseer/scripts/upgrade.sh
         env:
           IMAGE_TAG: ${{ inputs.image_tag || github.sha }}
           SKIP_PREQS: 'true'
-          CLUSTER_NAME: ${{ secrets.GKE_PREVIEW_STD_CLUSTER }}
+          CLUSTER_NAME: ${{ vars.GKE_AUTOPUSH_STD_CLUSTER }}


### PR DESCRIPTION
Renames the deploy-preview workflows to deploy-autopush to better convey the distinction between the autopush environment (that auto-deploys on every submission) versus the staging environment (that uses a manual deployment flow).

Also refactors the cluster name parameter from secrets to variables since it is not sensitive information. This makes the parameters easier to manage and understand.