### PR TITLE
feat: add enqueuedAt timestamp to Overseer task UI

### DIFF
--- a/.github/workflows/presubmit-repo-agent.yaml
+++ b/.github/workflows/presubmit-repo-agent.yaml
@@ -25,6 +25,14 @@ jobs:
         run: |
           ./dev/tools/test-unit --working-dir repo-agent/
           ./dev/tools/test-unit --working-dir overseer/
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 18
+      - name: Run UI Unit Tests
+        working-directory: repo-agent/review-ui/ui
+        run: |
+          npm ci || npm install
+          CI=true npm test
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -3536,14 +3536,45 @@ func startQueueHTTPServer(ctx context.Context, queueDir string, addr string) {
 	_ = server.Close()
 }
 
-func buildQueueResponse(queueDir string) map[string]interface{} {
-	readQueueDir := func(sub string) []map[string]interface{} {
+type QueueTaskItem struct {
+	FileName   string `json:"fileName"`
+	QueueState string `json:"queueState"`
+	Type       string `json:"type"`
+	URL        string `json:"url"`
+	Number     int    `json:"number"`
+	Priority   string `json:"priority"`
+	Phase      int    `json:"phase"`
+	CreatedAt  string `json:"createdAt"`
+	EnqueuedAt string `json:"enqueuedAt,omitempty"`
+	Assignee   string `json:"assignee"`
+	Status     string `json:"status"`
+	CommitSHA  string `json:"commitSHA"`
+	Rank       int    `json:"rank,omitempty"`
+}
+
+type QueueSummary struct {
+	TotalPending    int            `json:"totalPending"`
+	TotalProcessing int            `json:"totalProcessing"`
+	TotalCompleted  int            `json:"totalCompleted"`
+	ByPriority      map[string]int `json:"byPriority"`
+	ByType          map[string]int `json:"byType"`
+}
+
+type QueueResponse struct {
+	Summary    QueueSummary    `json:"summary"`
+	Incoming   []QueueTaskItem `json:"incoming"`
+	Processing []QueueTaskItem `json:"processing"`
+	Processed  []QueueTaskItem `json:"processed"`
+}
+
+func buildQueueResponse(queueDir string) QueueResponse {
+	readQueueDir := func(sub string) []taskItem {
 		d := filepath.Join(queueDir, sub)
 		entries, err := os.ReadDir(d)
 		if err != nil {
 			return nil
 		}
-		var tasks []map[string]interface{}
+		var items []taskItem
 		for _, e := range entries {
 			if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
 				continue
@@ -3552,118 +3583,101 @@ func buildQueueResponse(queueDir string) map[string]interface{} {
 			if err != nil {
 				continue
 			}
-			content := string(data)
-			extractField := func(key string) string {
-				for _, line := range strings.Split(content, "\n") {
-					line = strings.TrimSpace(line)
-					if strings.HasPrefix(line, key+":") {
-						val := strings.TrimPrefix(line, key+":")
-						val = strings.TrimSpace(val)
-						val = strings.Trim(val, "\"\r")
-						return val
-					}
+			var t QueueTask
+			if err := yaml.Unmarshal(data, &t); err != nil {
+				continue
+			}
+			if t.Priority == "" {
+				t.Priority = "medium"
+			}
+			if t.EnqueuedAt.IsZero() {
+				var modTime time.Time
+				if info, err := e.Info(); err == nil {
+					modTime = info.ModTime()
 				}
-				return ""
+				t.EnqueuedAt = getEnqueueTime(&t, modTime)
 			}
-
-			tType := extractField("type")
-			tURL := extractField("url")
-			tNumStr := extractField("number")
-			tPrio := strings.ToLower(extractField("priority"))
-			tPhaseStr := extractField("phase")
-			tCreated := extractField("createdAt")
-			tAssignee := extractField("assignee")
-			tStatus := extractField("status")
-			tSHA := extractField("commitSHA")
-
-			if tPrio == "" {
-				tPrio = "medium"
-			}
-			tNum, _ := strconv.Atoi(tNumStr)
-			tPhase, _ := strconv.Atoi(tPhaseStr)
-
-			tasks = append(tasks, map[string]interface{}{
-				"fileName":   e.Name(),
-				"queueState": sub,
-				"type":       tType,
-				"url":        tURL,
-				"number":     tNum,
-				"priority":   tPrio,
-				"phase":      tPhase,
-				"createdAt":  tCreated,
-				"assignee":   tAssignee,
-				"status":     tStatus,
-				"commitSHA":  tSHA,
+			items = append(items, taskItem{
+				filename: e.Name(),
+				task:     &t,
 			})
 		}
-		return tasks
+		return items
 	}
 
-	incoming := readQueueDir("incoming")
-	processing := readQueueDir("processing")
-	processed := readQueueDir("processed")
-
-	priorityRank := map[string]int{
-		"critical":  1,
-		"urgent":    2,
-		"important": 3,
-		"high":      4,
-		"medium":    5,
-		"low":       6,
+	taskToItem := func(item taskItem, sub string) QueueTaskItem {
+		t := item.task
+		tPrio := strings.ToLower(t.Priority)
+		if tPrio == "" {
+			tPrio = "medium"
+		}
+		var createdStr, enqueuedStr string
+		if !t.CreatedAt.IsZero() {
+			createdStr = t.CreatedAt.Format(time.RFC3339)
+		}
+		if !t.EnqueuedAt.IsZero() {
+			enqueuedStr = t.EnqueuedAt.Format(time.RFC3339)
+		}
+		return QueueTaskItem{
+			FileName:   item.filename,
+			QueueState: sub,
+			Type:       t.Type,
+			URL:        t.URL,
+			Number:     t.Number,
+			Priority:   tPrio,
+			Phase:      t.Phase,
+			CreatedAt:  createdStr,
+			EnqueuedAt: enqueuedStr,
+			Assignee:   t.Assignee,
+			Status:     t.Status,
+			CommitSHA:  t.CommitSHA,
+		}
 	}
-	getRankVal := func(p string) int {
-		if r, ok := priorityRank[strings.ToLower(p)]; ok {
-			return r
-		}
-		return 5
+
+	incomingItems := readQueueDir("incoming")
+	sortedIncoming := sortTasksFairly(incomingItems)
+
+	var incoming []QueueTaskItem
+	for i, item := range sortedIncoming {
+		m := taskToItem(item, "incoming")
+		m.Rank = i + 1
+		incoming = append(incoming, m)
 	}
 
-	sort.Slice(incoming, func(i, j int) bool {
-		pI, _ := incoming[i]["priority"].(string)
-		pJ, _ := incoming[j]["priority"].(string)
-		rI := getRankVal(pI)
-		rJ := getRankVal(pJ)
-		if rI != rJ {
-			return rI < rJ
-		}
-		phI, _ := incoming[i]["phase"].(int)
-		phJ, _ := incoming[j]["phase"].(int)
-		if phI != phJ {
-			return phI < phJ
-		}
-		cI, _ := incoming[i]["createdAt"].(string)
-		cJ, _ := incoming[j]["createdAt"].(string)
-		return cI < cJ
-	})
+	processingItems := readQueueDir("processing")
+	var processing []QueueTaskItem
+	for _, item := range processingItems {
+		processing = append(processing, taskToItem(item, "processing"))
+	}
 
-	for i := range incoming {
-		incoming[i]["rank"] = i + 1
+	processedItems := readQueueDir("processed")
+	var processed []QueueTaskItem
+	for _, item := range processedItems {
+		processed = append(processed, taskToItem(item, "processed"))
 	}
 
 	byPrio := make(map[string]int)
 	byType := make(map[string]int)
 	for _, item := range incoming {
-		p, _ := item["priority"].(string)
-		t, _ := item["type"].(string)
-		byPrio[p]++
-		byType[t]++
+		byPrio[item.Priority]++
+		byType[item.Type]++
 	}
 
 	if len(processed) > 20 {
 		processed = processed[:20]
 	}
 
-	return map[string]interface{}{
-		"summary": map[string]interface{}{
-			"totalPending":    len(incoming),
-			"totalProcessing": len(processing),
-			"totalCompleted":  len(processed),
-			"byPriority":      byPrio,
-			"byType":          byType,
+	return QueueResponse{
+		Summary: QueueSummary{
+			TotalPending:    len(incoming),
+			TotalProcessing: len(processing),
+			TotalCompleted:  len(processed),
+			ByPriority:      byPrio,
+			ByType:          byType,
 		},
-		"incoming":   incoming,
-		"processing": processing,
-		"processed":  processed,
+		Incoming:   incoming,
+		Processing: processing,
+		Processed:  processed,
 	}
 }
 

--- a/factory/pkg/commands/watch_test.go
+++ b/factory/pkg/commands/watch_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/clients"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/config"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/k8s"
+	"github.com/google/go-cmp/cmp"
 	githubv39 "github.com/google/go-github/v39/github"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -901,4 +902,271 @@ func TestFindWorkflowPath(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildQueueResponse(t *testing.T) {
+	t.Run("Empty and non-existent directories", func(t *testing.T) {
+		tempDir := t.TempDir()
+		resp := buildQueueResponse(tempDir)
+
+		if resp.Summary.TotalPending != 0 || resp.Summary.TotalProcessing != 0 || resp.Summary.TotalCompleted != 0 {
+			t.Errorf("expected 0 totals in summary, got %+v", resp.Summary)
+		}
+
+		if len(resp.Incoming) != 0 {
+			t.Errorf("expected 0 incoming tasks, got %d", len(resp.Incoming))
+		}
+	})
+
+	t.Run("Field extraction and defaults", func(t *testing.T) {
+		tempDir := t.TempDir()
+		incomingDir := filepath.Join(tempDir, "incoming")
+		if err := os.MkdirAll(incomingDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		// Task 1: Explicit fields
+		task1Content := `type: pr-review
+url: https://github.com/org/repo/pull/42
+number: 42
+priority: critical
+phase: 2
+createdAt: "2026-08-10T10:00:00Z"
+enqueuedAt: "2026-08-10T10:05:00Z"
+assignee: alice
+status: Pending
+commitSHA: abc123def
+`
+		if err := os.WriteFile(filepath.Join(incomingDir, "task1.yaml"), []byte(task1Content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Task 2: Defaults (no priority, no enqueuedAt)
+		task2Content := `type: issue-fix
+url: https://github.com/org/repo/issues/99
+number: 99
+createdAt: "2026-08-10T11:00:00Z"
+status: Pending
+`
+		if err := os.WriteFile(filepath.Join(incomingDir, "task2.yaml"), []byte(task2Content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Non-yaml file and directory should be ignored
+		if err := os.WriteFile(filepath.Join(incomingDir, "ignore.txt"), []byte("not yaml"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(incomingDir, "subfolder"), 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		resp := buildQueueResponse(tempDir)
+		if len(resp.Incoming) != 2 {
+			t.Fatalf("expected 2 incoming tasks, got %d", len(resp.Incoming))
+		}
+
+		if resp.Incoming[1].EnqueuedAt == "" {
+			t.Errorf("expected non-empty fallback enqueuedAt for task 2")
+		}
+
+		expectedIncoming := []QueueTaskItem{
+			{
+				FileName:   "task1.yaml",
+				QueueState: "incoming",
+				Type:       "pr-review",
+				URL:        "https://github.com/org/repo/pull/42",
+				Number:     42,
+				Priority:   "critical",
+				Phase:      2,
+				CreatedAt:  "2026-08-10T10:00:00Z",
+				EnqueuedAt: "2026-08-10T10:05:00Z",
+				Assignee:   "alice",
+				Status:     "Pending",
+				CommitSHA:  "abc123def",
+				Rank:       1,
+			},
+			{
+				FileName:   "task2.yaml",
+				QueueState: "incoming",
+				Type:       "issue-fix",
+				URL:        "https://github.com/org/repo/issues/99",
+				Number:     99,
+				Priority:   "medium",
+				Phase:      0,
+				CreatedAt:  "2026-08-10T11:00:00Z",
+				EnqueuedAt: resp.Incoming[1].EnqueuedAt,
+				Assignee:   "",
+				Status:     "Pending",
+				CommitSHA:  "",
+				Rank:       2,
+			},
+		}
+
+		if diff := cmp.Diff(expectedIncoming, resp.Incoming); diff != "" {
+			t.Errorf("incoming tasks mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("Sorting by priority, phase, and createdAt", func(t *testing.T) {
+		tempDir := t.TempDir()
+		incomingDir := filepath.Join(tempDir, "incoming")
+		if err := os.MkdirAll(incomingDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		tasks := []struct {
+			filename string
+			priority string
+			phase    int
+			created  string
+		}{
+			{"low.yaml", "low", 1, "2026-08-10T01:00:00Z"},
+			{"med_ph2.yaml", "medium", 2, "2026-08-10T01:00:00Z"},
+			{"crit_later.yaml", "critical", 1, "2026-08-10T02:00:00Z"},
+			{"urgent.yaml", "urgent", 1, "2026-08-10T01:00:00Z"},
+			{"med_ph1_earlier.yaml", "medium", 1, "2026-08-10T01:00:00Z"},
+			{"crit_earlier.yaml", "critical", 1, "2026-08-10T01:00:00Z"},
+			{"important.yaml", "important", 1, "2026-08-10T01:00:00Z"},
+			{"high.yaml", "high", 1, "2026-08-10T01:00:00Z"},
+			{"med_ph1_later.yaml", "medium", 1, "2026-08-10T02:00:00Z"},
+		}
+
+		for _, task := range tasks {
+			content := fmt.Sprintf("type: pr-review\npriority: %s\nphase: %d\ncreatedAt: %s\n", task.priority, task.phase, task.created)
+			if err := os.WriteFile(filepath.Join(incomingDir, task.filename), []byte(content), 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		resp := buildQueueResponse(tempDir)
+		if len(resp.Incoming) != len(tasks) {
+			t.Fatalf("expected %d tasks, got %d", len(tasks), len(resp.Incoming))
+		}
+
+		expectedOrder := []string{
+			"crit_earlier.yaml",
+			"crit_later.yaml",
+			"urgent.yaml",
+			"important.yaml",
+			"high.yaml",
+			"med_ph1_earlier.yaml",
+			"med_ph1_later.yaml",
+			"med_ph2.yaml",
+			"low.yaml",
+		}
+
+		for i, exp := range expectedOrder {
+			gotFile := resp.Incoming[i].FileName
+			gotRank := resp.Incoming[i].Rank
+			if gotFile != exp {
+				t.Errorf("at index %d: expected %s, got %v", i, exp, gotFile)
+			}
+			if gotRank != i+1 {
+				t.Errorf("at index %d: expected rank %d, got %v", i, i+1, gotRank)
+			}
+		}
+	})
+
+	t.Run("Fair round-robin across multiple entities matching watch loop", func(t *testing.T) {
+		tempDir := t.TempDir()
+		incomingDir := filepath.Join(tempDir, "incoming")
+		if err := os.MkdirAll(incomingDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		baseTime := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+
+		// 3 tasks for PR 10
+		_ = os.WriteFile(filepath.Join(incomingDir, "pr10_1.yaml"), []byte(fmt.Sprintf("number: 10\ntype: pr-comments\npriority: medium\nphase: 3\nenqueuedAt: %s\n", baseTime.Add(1*time.Minute).Format(time.RFC3339))), 0644)
+		_ = os.WriteFile(filepath.Join(incomingDir, "pr10_2.yaml"), []byte(fmt.Sprintf("number: 10\ntype: pr-comments\npriority: medium\nphase: 3\nenqueuedAt: %s\n", baseTime.Add(3*time.Minute).Format(time.RFC3339))), 0644)
+		_ = os.WriteFile(filepath.Join(incomingDir, "pr10_3.yaml"), []byte(fmt.Sprintf("number: 10\ntype: pr-comments\npriority: medium\nphase: 3\nenqueuedAt: %s\n", baseTime.Add(4*time.Minute).Format(time.RFC3339))), 0644)
+
+		// 2 tasks for PR 20
+		_ = os.WriteFile(filepath.Join(incomingDir, "pr20_1.yaml"), []byte(fmt.Sprintf("number: 20\ntype: pr-comments\npriority: medium\nphase: 3\nenqueuedAt: %s\n", baseTime.Add(5*time.Minute).Format(time.RFC3339))), 0644)
+		_ = os.WriteFile(filepath.Join(incomingDir, "pr20_2.yaml"), []byte(fmt.Sprintf("number: 20\ntype: pr-comments\npriority: medium\nphase: 3\nenqueuedAt: %s\n", baseTime.Add(6*time.Minute).Format(time.RFC3339))), 0644)
+
+		resp := buildQueueResponse(tempDir)
+		if len(resp.Incoming) != 5 {
+			t.Fatalf("expected 5 incoming tasks, got %d", len(resp.Incoming))
+		}
+
+		// Expected round-robin order between PR 10 and PR 20
+		expectedOrder := []string{"pr10_1.yaml", "pr20_1.yaml", "pr10_2.yaml", "pr20_2.yaml", "pr10_3.yaml"}
+		for i, exp := range expectedOrder {
+			if resp.Incoming[i].FileName != exp {
+				t.Errorf("at index %d: expected %s, got %v", i, exp, resp.Incoming[i].FileName)
+			}
+			if resp.Incoming[i].Rank != i+1 {
+				t.Errorf("at index %d: expected rank %d, got %v", i, i+1, resp.Incoming[i].Rank)
+			}
+		}
+	})
+
+	t.Run("Summary counts and breakdowns", func(t *testing.T) {
+		tempDir := t.TempDir()
+		incomingDir := filepath.Join(tempDir, "incoming")
+		processingDir := filepath.Join(tempDir, "processing")
+		processedDir := filepath.Join(tempDir, "processed")
+
+		for _, d := range []string{incomingDir, processingDir, processedDir} {
+			if err := os.MkdirAll(d, 0755); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// 3 incoming tasks (2 critical pr-review, 1 high issue-fix)
+		_ = os.WriteFile(filepath.Join(incomingDir, "task1.yaml"), []byte("type: pr-review\npriority: critical\n"), 0644)
+		_ = os.WriteFile(filepath.Join(incomingDir, "task2.yaml"), []byte("type: pr-review\npriority: critical\n"), 0644)
+		_ = os.WriteFile(filepath.Join(incomingDir, "task3.yaml"), []byte("type: issue-fix\npriority: high\n"), 0644)
+
+		// 2 processing tasks
+		_ = os.WriteFile(filepath.Join(processingDir, "proc1.yaml"), []byte("type: pr-review\npriority: critical\n"), 0644)
+		_ = os.WriteFile(filepath.Join(processingDir, "proc2.yaml"), []byte("type: agent-chore\npriority: low\n"), 0644)
+
+		// 1 processed task
+		_ = os.WriteFile(filepath.Join(processedDir, "done1.yaml"), []byte("type: pr-review\nstatus: Completed\n"), 0644)
+
+		resp := buildQueueResponse(tempDir)
+
+		if resp.Summary.TotalPending != 3 {
+			t.Errorf("expected totalPending 3, got %v", resp.Summary.TotalPending)
+		}
+		if resp.Summary.TotalProcessing != 2 {
+			t.Errorf("expected totalProcessing 2, got %v", resp.Summary.TotalProcessing)
+		}
+		if resp.Summary.TotalCompleted != 1 {
+			t.Errorf("expected totalCompleted 1, got %v", resp.Summary.TotalCompleted)
+		}
+
+		if resp.Summary.ByPriority["critical"] != 2 || resp.Summary.ByPriority["high"] != 1 {
+			t.Errorf("expected byPriority map [critical:2, high:1], got %+v", resp.Summary.ByPriority)
+		}
+
+		if resp.Summary.ByType["pr-review"] != 2 || resp.Summary.ByType["issue-fix"] != 1 {
+			t.Errorf("expected byType map [pr-review:2, issue-fix:1], got %+v", resp.Summary.ByType)
+		}
+	})
+
+	t.Run("Processed queue capping at 20", func(t *testing.T) {
+		tempDir := t.TempDir()
+		processedDir := filepath.Join(tempDir, "processed")
+		if err := os.MkdirAll(processedDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		for i := 1; i <= 30; i++ {
+			fn := fmt.Sprintf("task-%02d.yaml", i)
+			_ = os.WriteFile(filepath.Join(processedDir, fn), []byte("type: pr-review\nstatus: Completed\n"), 0644)
+		}
+
+		resp := buildQueueResponse(tempDir)
+
+		if len(resp.Processed) != 20 {
+			t.Errorf("expected processed capped at 20 items, got %d", len(resp.Processed))
+		}
+
+		if resp.Summary.TotalCompleted != 20 {
+			t.Errorf("expected totalCompleted 20 in summary, got %v", resp.Summary.TotalCompleted)
+		}
+	})
 }

--- a/repo-agent/pkg/api/handlers_overseer.go
+++ b/repo-agent/pkg/api/handlers_overseer.go
@@ -688,6 +688,7 @@ type QueueTaskItem struct {
 	Priority   string `json:"priority"`
 	Phase      int    `json:"phase"`
 	CreatedAt  string `json:"createdAt"`
+	EnqueuedAt string `json:"enqueuedAt,omitempty"`
 	Assignee   string `json:"assignee"`
 	Status     string `json:"status"`
 	CommitSHA  string `json:"commitSHA"`

--- a/repo-agent/review-ui/ui/src/Overseer.js
+++ b/repo-agent/review-ui/ui/src/Overseer.js
@@ -2,7 +2,45 @@ import React, { useState, useEffect, useCallback, useRef } from 'react';
 import './App.css';
 import SandboxTerminal from './Terminal';
 
-
+export const formatQueueTimestamp = (ts) => {
+    if (!ts) return '-';
+    try {
+        const d = new Date(ts);
+        if (isNaN(d.getTime())) return ts;
+        const exact = d.toLocaleString();
+        const diffMs = Date.now() - d.getTime();
+        let rel = '';
+        if (diffMs >= 0) {
+            const seconds = Math.floor(diffMs / 1000);
+            if (seconds < 60) {
+                rel = `${seconds}s ago`;
+            } else {
+                const minutes = Math.floor(seconds / 60);
+                if (minutes < 60) {
+                    rel = `${minutes}m ago`;
+                } else {
+                    const hours = Math.floor(minutes / 60);
+                    if (hours < 24) {
+                        rel = `${hours}h ${minutes % 60}m ago`;
+                    } else {
+                        const days = Math.floor(hours / 24);
+                        rel = `${days}d ${hours % 24}h ago`;
+                    }
+                }
+            }
+        } else {
+            rel = 'just now';
+        }
+        return (
+            <div>
+                <div>{exact}</div>
+                {rel && <div style={{ fontSize: '0.75rem', color: 'var(--text-muted)', marginTop: '2px' }}>{`(${rel})`}</div>}
+            </div>
+        );
+    } catch (e) {
+        return ts;
+    }
+};
 
 const Overseer = ({ onBack, namespace: userNamespace }) => {
     const [overseers, setOverseers] = useState([]);
@@ -661,6 +699,7 @@ const Overseer = ({ onBack, namespace: userNamespace }) => {
                                         <th style={{ padding: '12px 16px', textAlign: 'left' }}>Priority</th>
                                         <th style={{ padding: '12px 16px', textAlign: 'left' }}>Assignee</th>
                                         <th style={{ padding: '12px 16px', textAlign: 'left' }}>Created At</th>
+                                        <th style={{ padding: '12px 16px', textAlign: 'left' }}>Enqueued At</th>
                                         <th style={{ padding: '12px 16px', textAlign: 'right' }}>Actions</th>
                                     </tr>
                                 </thead>
@@ -690,6 +729,9 @@ const Overseer = ({ onBack, namespace: userNamespace }) => {
                                             </td>
                                             <td style={{ padding: '12px 16px', fontSize: '0.85rem' }}>{t.assignee || '-'}</td>
                                             <td style={{ padding: '12px 16px', fontSize: '0.85rem', color: 'var(--text-secondary)' }}>-</td>
+                                            <td style={{ padding: '12px 16px', fontSize: '0.85rem', color: 'var(--text-secondary)' }}>
+                                                {formatQueueTimestamp(t.enqueuedAt)}
+                                            </td>
                                             <td style={{ padding: '12px 16px', textAlign: 'right' }}>-</td>
                                         </tr>
                                     ))}
@@ -703,6 +745,7 @@ const Overseer = ({ onBack, namespace: userNamespace }) => {
                                                    (t.type || '').toLowerCase().includes(q) ||
                                                    (t.priority || '').toLowerCase().includes(q) ||
                                                    (t.assignee || '').toLowerCase().includes(q) ||
+                                                   (t.enqueuedAt || '').toLowerCase().includes(q) ||
                                                    String(t.number).includes(q) ||
                                                    (t.url || '').toLowerCase().includes(q);
                                         });
@@ -710,7 +753,7 @@ const Overseer = ({ onBack, namespace: userNamespace }) => {
                                         if (filtered.length === 0) {
                                             return (
                                                 <tr>
-                                                    <td colSpan="7" style={{ padding: '30px', textAlign: 'center', color: 'var(--text-secondary)' }}>
+                                                    <td colSpan="8" style={{ padding: '30px', textAlign: 'center', color: 'var(--text-secondary)' }}>
                                                         {queueData ? 'No pending tasks match the current filter.' : 'Loading task queue...'}
                                                     </td>
                                                 </tr>
@@ -744,6 +787,9 @@ const Overseer = ({ onBack, namespace: userNamespace }) => {
                                                 <td style={{ padding: '12px 16px', fontSize: '0.85rem' }}>{t.assignee || '-'}</td>
                                                 <td style={{ padding: '12px 16px', fontSize: '0.85rem', color: 'var(--text-secondary)' }}>
                                                     {t.createdAt ? t.createdAt.split('T')[0] : '-'}
+                                                </td>
+                                                <td style={{ padding: '12px 16px', fontSize: '0.85rem', color: 'var(--text-secondary)' }} title={t.enqueuedAt || ''}>
+                                                    {formatQueueTimestamp(t.enqueuedAt)}
                                                 </td>
                                                 <td style={{ padding: '12px 16px', textAlign: 'right' }}>
                                                     <button 

--- a/repo-agent/review-ui/ui/src/Overseer.test.js
+++ b/repo-agent/review-ui/ui/src/Overseer.test.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import { formatQueueTimestamp } from './Overseer';
+
+jest.mock('./Terminal', () => () => null);
+
+describe('formatQueueTimestamp', () => {
+    test('returns "-" for falsy/empty values', () => {
+        expect(formatQueueTimestamp(null)).toBe('-');
+        expect(formatQueueTimestamp(undefined)).toBe('-');
+        expect(formatQueueTimestamp('')).toBe('-');
+    });
+
+    test('returns raw string for invalid dates', () => {
+        expect(formatQueueTimestamp('not-a-valid-date')).toBe('not-a-valid-date');
+    });
+
+    test('formats valid timestamps with exact date and relative time', () => {
+        const now = 1750000000000; // Fixed timestamp in ms
+        const originalDateNow = Date.now;
+        Date.now = jest.fn(() => now);
+
+        const getText = (node) => {
+            if (!node || !node.props) return '';
+            const c = node.props.children;
+            return Array.isArray(c) ? c.join('') : String(c || '');
+        };
+
+        try {
+            // 1. Future / just now
+            const futureDate = new Date(now + 5000).toISOString();
+            const futureRes = formatQueueTimestamp(futureDate);
+            expect(futureRes).toBeTruthy();
+            expect(getText(futureRes.props.children[1])).toBe('(just now)');
+
+            // 2. Seconds ago (< 60s)
+            const secondsAgoDate = new Date(now - 25 * 1000).toISOString();
+            const secondsRes = formatQueueTimestamp(secondsAgoDate);
+            expect(getText(secondsRes.props.children[1])).toBe('(25s ago)');
+
+            // 3. Minutes ago (< 60m)
+            const minutesAgoDate = new Date(now - 12 * 60 * 1000).toISOString();
+            const minutesRes = formatQueueTimestamp(minutesAgoDate);
+            expect(getText(minutesRes.props.children[1])).toBe('(12m ago)');
+
+            // 4. Hours ago (< 24h)
+            const hoursAgoDate = new Date(now - (3 * 3600 * 1000 + 45 * 60 * 1000)).toISOString();
+            const hoursRes = formatQueueTimestamp(hoursAgoDate);
+            expect(getText(hoursRes.props.children[1])).toBe('(3h 45m ago)');
+
+            // 5. Days ago (>= 24h)
+            const daysAgoDate = new Date(now - (2 * 24 * 3600 * 1000 + 5 * 3600 * 1000)).toISOString();
+            const daysRes = formatQueueTimestamp(daysAgoDate);
+            expect(getText(daysRes.props.children[1])).toBe('(2d 5h ago)');
+
+            // Check that exact localized date string is rendered as first child
+            const exactExpected = new Date(daysAgoDate).toLocaleString();
+            expect(getText(daysRes.props.children[0])).toBe(exactExpected);
+        } finally {
+            Date.now = originalDateNow;
+        }
+    });
+});


### PR DESCRIPTION
This change adds a new column to the incoming task queue UI for overseer which surfaces the enqueuedAt timestamp. This shows when each task entered the queue, making it easier to identify tasks which have been starved in the queued.

Also refactors the sorting logic for the queue backend to re-use the same sorting function as the watcher, so that the UI reflects the same task prioritization as the watcher.