### PR TITLE
fix(factory): prioritize fatal quota error detection and enforce PR creation in fix tasks

### DIFF
--- a/factory/pkg/commands/fix.go
+++ b/factory/pkg/commands/fix.go
@@ -395,6 +395,10 @@ func runFix(ctx context.Context, targetURL, prompt, name string, noPR, watch boo
 		}
 	}
 
+	if prNum == 0 && !noPR {
+		return fmt.Errorf("task finished without creating a pull request")
+	}
+
 	return nil
 }
 

--- a/factory/pkg/envd/client.go
+++ b/factory/pkg/envd/client.go
@@ -474,15 +474,15 @@ func (c *Client) RunTaskResilient(ctx context.Context, cmdStr string, envs map[s
 					_, _ = os.Stdout.Write(newData)
 					offset += int64(len(newData))
 
-					if geminitokens.IsTransientRateLimit(newData) {
-						klog.V(2).Infof("Transient rate limit (RPM/TPM) detected in task output; allowing CLI to retry with backoff...")
-					} else if geminitokens.IsFatalQuotaError(newData) {
+					if geminitokens.IsFatalQuotaError(newData) {
 						klog.Warningf("Fatal quota/suspension error detected in task output. Terminating task process group in sandbox pod immediately...")
 						killCtx, killCancel := context.WithTimeout(context.Background(), 15*time.Second)
 						defer killCancel()
 						killCmd := fmt.Sprintf("if [ -f %s ]; then top_pid=$(cat %s); kill -9 -$(ps -o pgid= $top_pid 2>/dev/null | tr -d ' ') 2>/dev/null || pkill -9 -P $top_pid 2>/dev/null || kill -9 $top_pid 2>/dev/null || true; echo 137 > %s; fi", pidFile, pidFile, exitCodeFile)
 						_ = c.Exec(killCtx, killCmd, "/workspaces", nil, nil, nil, nil)
 						return handleQuotaOrSuspensionError(newData, envs)
+					} else if geminitokens.IsTransientRateLimit(newData) {
+						klog.V(2).Infof("Transient rate limit (RPM/TPM) detected in task output; allowing CLI to retry with backoff...")
 					}
 				}
 			} else {

--- a/factory/pkg/geminitokens/geminitokens.go
+++ b/factory/pkg/geminitokens/geminitokens.go
@@ -342,9 +342,12 @@ func IsFatalQuotaError(data []byte) bool {
 
 // IsTransientRateLimit checks if the output indicates a transient RPM/TPM rate limit spike being retried.
 func IsTransientRateLimit(data []byte) bool {
+	if IsFatalQuotaError(data) {
+		return false
+	}
 	str := string(data)
 	return strings.Contains(str, "Retrying with backoff") ||
-		(strings.Contains(str, "status: 429") && !IsFatalQuotaError(data))
+		strings.Contains(str, "status: 429")
 }
 
 func ContainsQuotaError(data []byte) bool {

--- a/factory/pkg/geminitokens/geminitokens_test.go
+++ b/factory/pkg/geminitokens/geminitokens_test.go
@@ -29,6 +29,11 @@ func TestIsFatalQuotaError(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "fatal billing quota during retry attempt",
+			input:    `Attempt 3 failed with status 429. Retrying with backoff... _ApiError: {"error":{"message":"You exceeded your current quota, please check your plan and billing details.","code":429,"status":"Too Many Requests"}}`,
+			expected: true,
+		},
+		{
 			name:     "normal output",
 			input:    `Generated code successfully`,
 			expected: false,
@@ -59,6 +64,11 @@ func TestIsTransientRateLimit(t *testing.T) {
 		{
 			name:     "fatal billing quota log",
 			input:    `You exceeded your current quota, please check your plan and billing details.`,
+			expected: false,
+		},
+		{
+			name:     "fatal billing quota during retry attempt",
+			input:    `Attempt 3 failed with status 429. Retrying with backoff... _ApiError: {"error":{"message":"You exceeded your current quota, please check your plan and billing details.","code":429,"status":"Too Many Requests"}}`,
 			expected: false,
 		},
 	}

--- a/factory/pkg/tasks/fix_issue.sh
+++ b/factory/pkg/tasks/fix_issue.sh
@@ -418,14 +418,14 @@ function recordPRLink {
     if [ -n "$pr_url" ] && [ "$pr_url" != "null" ]; then
         echo "Successfully found PR: ${pr_url}"
         echo "${pr_url}" > "$output_file"
+        popd > /dev/null
     else
         echo "Could not find PR link automatically."
-        # Don't overwrite if it already exists (unlikely here but safe)
-        if [ ! -s "$output_file" ]; then
-            echo "Could not find PR link automatically." > "$output_file"
-        fi
+        echo "Could not find PR link automatically." > "$output_file"
+        popd > /dev/null
+        echo "Task finished without creating a pull request." >&2
+        exit 1
     fi
-    popd > /dev/null
 }
 
 # Main execution

--- a/factory/pkg/tasks/fix_issue.sh
+++ b/factory/pkg/tasks/fix_issue.sh
@@ -420,8 +420,7 @@ function recordPRLink {
         echo "${pr_url}" > "$output_file"
         popd > /dev/null
     else
-        echo "Could not find PR link automatically."
-        echo "Could not find PR link automatically." > "$output_file"
+        echo "Could not find PR link automatically." | tee "$output_file"
         popd > /dev/null
         echo "Task finished without creating a pull request." >&2
         exit 1


### PR DESCRIPTION
### Summary of Changes

1. **Prioritize Fatal Quota Error Detection (`client.go` & `geminitokens.go`)**:
   - In `RunTaskResilient`, checked `IsFatalQuotaError(newData)` before `IsTransientRateLimit(newData)`.
   - Updated `IsTransientRateLimit` to explicitly return `false` if `IsFatalQuotaError(data)` is true, preventing logs that contain both `"Retrying with backoff"` and fatal quota messages (e.g. `"exceeded your current quota"`) from being falsely categorized as transient retries.
   - Added unit test cases verifying that retry attempts containing fatal quota errors are correctly identified as fatal and not transient.

2. **Enforce PR Creation in Fix Tasks (`fix.go` & `fix_issue.sh`)**:
   - In `recordPRLink` (`fix_issue.sh`), exit with code 1 (`exit 1`) if no PR URL is created/found and `NO_PR != true`.
   - In `runFix` (`fix.go`), return an error `task finished without creating a pull request` if `prNum == 0 && !noPR`, ensuring that unfinished/aborted runs are correctly marked as `Failed` in the queue rather than silently marked `Completed`.


## Triggering Issue
https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/12320#issuecomment-5245633647

the fix-issue task succeeded without creating a PR
<img width="2326" height="2124" alt="image" src="https://github.com/user-attachments/assets/f59d0201-7fd8-432c-b290-b79d152dcdf6" />
