### PR TITLE
ci: rename non-sensitive parameters to variables

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -134,4 +134,3 @@ jobs:
       image_tag: ${{ github.sha }}
     secrets:
       GKE_SA_KEY: ${{ secrets.GKE_SA_KEY }}
-      GKE_ZONE: ${{ secrets.GKE_ZONE }}

--- a/.github/workflows/deploy-autopush.yaml
+++ b/.github/workflows/deploy-autopush.yaml
@@ -10,8 +10,6 @@ on:
     secrets:
       GKE_SA_KEY:
         required: true
-      GKE_ZONE:
-        required: true
   workflow_dispatch:
     inputs:
       image_tag:
@@ -40,7 +38,7 @@ jobs:
         uses: google-github-actions/get-gke-credentials@3da1e46a907576cefaa90c484278bb5b259dd395 # v3
         with:
           cluster_name: ${{ vars.GKE_AUTOPUSH_CLUSTER }}
-          location: ${{ secrets.GKE_ZONE }}
+          location: ${{ vars.GKE_ZONE }}
 
       - name: Deploy to Autopush
         run: |
@@ -77,7 +75,7 @@ jobs:
         uses: google-github-actions/get-gke-credentials@3da1e46a907576cefaa90c484278bb5b259dd395 # v3
         with:
           cluster_name: ${{ vars.GKE_AUTOPUSH_STD_CLUSTER }}
-          location: ${{ secrets.GKE_ZONE }}
+          location: ${{ vars.GKE_ZONE }}
 
       - name: Deploy to Autopush Standard
         run: |

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -10,10 +10,6 @@ on:
     secrets:
       GKE_SA_KEY:
         required: true
-      GKE_STAGING_CLUSTER:
-        required: true
-      GKE_ZONE:
-        required: true
   workflow_dispatch:
     inputs:
       image_tag:
@@ -41,8 +37,8 @@ jobs:
       - name: Set up GKE credentials
         uses: google-github-actions/get-gke-credentials@3da1e46a907576cefaa90c484278bb5b259dd395 # v3
         with:
-          cluster_name: ${{ secrets.GKE_STAGING_CLUSTER }}
-          location: ${{ secrets.GKE_ZONE }}
+          cluster_name: ${{ vars.GKE_STAGING_CLUSTER }}
+          location: ${{ vars.GKE_ZONE }}
 
       - name: Deploy to Staging
         run: |
@@ -51,7 +47,7 @@ jobs:
         env:
           IMAGE_TAG: ${{ inputs.image_tag || github.sha }}
           SKIP_PREQS: 'true'
-          CLUSTER_NAME: ${{ secrets.GKE_STAGING_CLUSTER }}
+          CLUSTER_NAME: ${{ vars.GKE_STAGING_CLUSTER }}
           GW_CLASS: 'gke-l7-regional-external-managed'
 
       - name: Deploy Overseer to Staging
@@ -61,4 +57,4 @@ jobs:
         env:
           IMAGE_TAG: ${{ inputs.image_tag || github.sha }}
           SKIP_PREQS: 'true'
-          CLUSTER_NAME: ${{ secrets.GKE_STAGING_CLUSTER }}
+          CLUSTER_NAME: ${{ vars.GKE_STAGING_CLUSTER }}


### PR DESCRIPTION
This renames the non-sensitive parameters like GKE zone and staging cluster name to use variables so that they are easier to manage.