### PR TITLE
refactor: use custom flag type for parsing repo

### DIFF
--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -32,8 +32,34 @@ import (
 	"k8s.io/klog/v2"
 )
 
+type RepoFlag struct {
+	Owner string
+	Repo  string
+}
+
+func (r *RepoFlag) String() string {
+	if r == nil || (r.Owner == "" && r.Repo == "") {
+		return ""
+	}
+	return fmt.Sprintf("%s/%s", r.Owner, r.Repo)
+}
+
+func (r *RepoFlag) Set(val string) error {
+	parts := strings.Split(val, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return fmt.Errorf("invalid repo format, expected owner/repo, got %s", val)
+	}
+	r.Owner = parts[0]
+	r.Repo = parts[1]
+	return nil
+}
+
+func (r *RepoFlag) Type() string {
+	return "string"
+}
+
 type WatchFlags struct {
-	Repo                string
+	Repo                RepoFlag
 	PollInterval        time.Duration
 	Assignee            string
 	Labels              []string
@@ -71,14 +97,6 @@ func NewWatchCommand(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			if flags.Repo == "" {
-				return fmt.Errorf("--repo is required (e.g. owner/repo)")
-			}
-			parts := strings.Split(flags.Repo, "/")
-			if len(parts) != 2 {
-				return fmt.Errorf("invalid repo format, expected owner/repo, got %s", flags.Repo)
-			}
-
 			issueMode := os.Getenv("ISSUE_MODE")
 			if flags.IssueMode != "" {
 				issueMode = flags.IssueMode
@@ -107,11 +125,12 @@ func NewWatchCommand(ctx context.Context) *cobra.Command {
 				choresMode = "enabled"
 			}
 
-			return runWatch(ctx, parts[0], parts[1], flags.PollInterval, flags.Assignee, cmd.Flags().Changed("assignee"), flags.Labels, flags.DryRun, flags.WatchTimeout, flags.MaxActions, flags.MaxPending, flags.Mode, flags.QueueDir, flags.Once, issueMode, prMode, choresMode, rootFlags.EphemeralStorage, rootFlags.ResolvedSecrets, flags.ScanLimit, flags.TaskTimeout, flags.SandboxEvictionAge, flags.SandboxIdleTimeout, flags.PRInactivityTimeout)
+			return runWatch(ctx, flags.Repo.Owner, flags.Repo.Repo, flags.PollInterval, flags.Assignee, cmd.Flags().Changed("assignee"), flags.Labels, flags.DryRun, flags.WatchTimeout, flags.MaxActions, flags.MaxPending, flags.Mode, flags.QueueDir, flags.Once, issueMode, prMode, choresMode, rootFlags.EphemeralStorage, rootFlags.ResolvedSecrets, flags.ScanLimit, flags.TaskTimeout, flags.SandboxEvictionAge, flags.SandboxIdleTimeout, flags.PRInactivityTimeout)
 		},
 	}
 
-	cmd.Flags().StringVar(&flags.Repo, "repo", "", "GitHub repository (e.g. owner/repo)")
+	cmd.Flags().Var(&flags.Repo, "repo", "GitHub repository (e.g. owner/repo)")
+	_ = cmd.MarkFlagRequired("repo")
 	cmd.Flags().DurationVar(&flags.PollInterval, "poll-interval", 2*time.Minute, "Polling interval")
 	cmd.Flags().StringVar(&flags.Assignee, "assignee", "factory-bot", "GitHub username to watch for assigned issues (use empty string for unassigned issues)")
 	cmd.Flags().StringSliceVar(&flags.Labels, "labels", nil, "Comma-separated list of labels to filter issues by")

--- a/factory/pkg/commands/watch_test.go
+++ b/factory/pkg/commands/watch_test.go
@@ -1170,3 +1170,112 @@ status: Pending
 		}
 	})
 }
+
+func TestRepoFlag(t *testing.T) {
+	t.Run("Valid inputs", func(t *testing.T) {
+		tests := []struct {
+			input     string
+			wantOwner string
+			wantRepo  string
+			wantStr   string
+		}{
+			{
+				input:     "owner/repo",
+				wantOwner: "owner",
+				wantRepo:  "repo",
+				wantStr:   "owner/repo",
+			},
+			{
+				input:     "gke-labs/gemini-for-kubernetes-development",
+				wantOwner: "gke-labs",
+				wantRepo:  "gemini-for-kubernetes-development",
+				wantStr:   "gke-labs/gemini-for-kubernetes-development",
+			},
+			{
+				input:     "kubernetes/kubernetes",
+				wantOwner: "kubernetes",
+				wantRepo:  "kubernetes",
+				wantStr:   "kubernetes/kubernetes",
+			},
+		}
+
+		for _, tc := range tests {
+			var rf RepoFlag
+			if err := rf.Set(tc.input); err != nil {
+				t.Errorf("rf.Set(%q) unexpected error: %v", tc.input, err)
+			}
+			if rf.Owner != tc.wantOwner || rf.Repo != tc.wantRepo {
+				t.Errorf("rf.Set(%q) = Owner: %q, Repo: %q; want Owner: %q, Repo: %q", tc.input, rf.Owner, rf.Repo, tc.wantOwner, tc.wantRepo)
+			}
+			if rf.String() != tc.wantStr {
+				t.Errorf("rf.String() = %q; want %q", rf.String(), tc.wantStr)
+			}
+		}
+	})
+
+	t.Run("Invalid inputs", func(t *testing.T) {
+		invalidInputs := []string{
+			"",
+			"repo-only",
+			"owner/repo/extra",
+			"/repo",
+			"owner/",
+			"/",
+			"///",
+		}
+
+		for _, input := range invalidInputs {
+			var rf RepoFlag
+			if err := rf.Set(input); err == nil {
+				t.Errorf("rf.Set(%q) expected error, got nil (Owner: %q, Repo: %q)", input, rf.Owner, rf.Repo)
+			}
+		}
+	})
+
+	t.Run("Empty RepoFlag String and Type", func(t *testing.T) {
+		var rf RepoFlag
+		if rf.String() != "" {
+			t.Errorf("empty rf.String() = %q, want empty string", rf.String())
+		}
+		if rf.Type() != "string" {
+			t.Errorf("rf.Type() = %q, want \"string\"", rf.Type())
+		}
+
+		var nilRf *RepoFlag
+		if nilRf.String() != "" {
+			t.Errorf("nilRf.String() = %q, want empty string", nilRf.String())
+		}
+	})
+}
+
+func TestWatchCommand_RepoFlag(t *testing.T) {
+	t.Run("Valid repo flag parses into RepoFlag struct", func(t *testing.T) {
+		cmd := NewWatchCommand(context.Background())
+		cmd.SetArgs([]string{"--repo", "test-org/test-repo"})
+		if err := cmd.ParseFlags([]string{"--repo", "test-org/test-repo"}); err != nil {
+			t.Fatalf("cmd.ParseFlags failed: %v", err)
+		}
+		flagVal := cmd.Flag("repo").Value
+		if flagVal.String() != "test-org/test-repo" {
+			t.Errorf("flagVal.String() = %q, want %q", flagVal.String(), "test-org/test-repo")
+		}
+	})
+
+	t.Run("Invalid repo flag returns error during flag parsing", func(t *testing.T) {
+		cmd := NewWatchCommand(context.Background())
+		if err := cmd.ParseFlags([]string{"--repo", "invalid-repo-format"}); err == nil {
+			t.Errorf("expected error for invalid repo format, got nil")
+		}
+	})
+
+	t.Run("Missing repo flag fails required flag validation", func(t *testing.T) {
+		cmd := NewWatchCommand(context.Background())
+		cmd.SetArgs([]string{})
+		err := cmd.Execute()
+		if err == nil {
+			t.Errorf("expected error for missing repo flag, got nil")
+		} else if err.Error() != `required flag(s) "repo" not set` {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
This replaces the need for parsing the flag in the run function with a custom flag type. This is in preparation for a greater refactor to refactor the function signature of runWatch.