### PR TITLE
refactor: create shared constants for factory

### DIFF
--- a/factory/pkg/commands/agent.go
+++ b/factory/pkg/commands/agent.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/clients"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/common"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/constants"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/envd"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/github"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/k8s"
@@ -221,8 +222,8 @@ func RunAgent(ctx context.Context, flags AgentFlags, ephemeralStorage string, se
 	if err != nil {
 		return fmt.Errorf("fetching %s secret in namespace %s: %w (make sure to run 'factory user onboard' first)", rootFlags.SecretName, rootFlags.Namespace, err)
 	}
-	githubLogin := string(secret.Data[KeyGithubLogin])
-	githubEmail := string(secret.Data[KeyGithubEmail])
+	githubLogin := string(secret.Data[constants.KeyGithubLogin])
+	githubEmail := string(secret.Data[constants.KeyGithubEmail])
 
 	fmt.Printf("Connecting to sandbox %s via envd...\n", sandboxName)
 	client, err := envd.Connect(ctx, rootFlags.Namespace, sandboxName)
@@ -297,7 +298,7 @@ func RunAgent(ctx context.Context, flags AgentFlags, ephemeralStorage string, se
 	envMap := map[string]string{
 		"HOME":                       "/workspaces/.home",
 		"FACTORY_CONFIG":             "/workspaces/.factory.cfg",
-		"GITHUB_TOKEN":               string(secret.Data[KeyGithubToken]),
+		"GITHUB_TOKEN":               string(secret.Data[constants.KeyGithubToken]),
 		"GEMINI_API_KEY":             getGeminiAPIKey(secret),
 		"GEMINI_CLI_TRUST_WORKSPACE": "true",
 		"REPO_OWNER":                 owner,

--- a/factory/pkg/commands/fix.go
+++ b/factory/pkg/commands/fix.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/clients"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/common"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/config"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/constants"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/envd"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/github"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/k8s"
@@ -200,8 +201,8 @@ func runFix(ctx context.Context, targetURL, prompt, name string, noPR, watch boo
 	if err != nil {
 		return fmt.Errorf("fetching %s secret in namespace %s: %w (make sure to run 'factory user onboard' first)", rootFlags.SecretName, rootFlags.Namespace, err)
 	}
-	githubLogin := string(secret.Data[KeyGithubLogin])
-	githubEmail := string(secret.Data[KeyGithubEmail])
+	githubLogin := string(secret.Data[constants.KeyGithubLogin])
+	githubEmail := string(secret.Data[constants.KeyGithubEmail])
 
 	var branchName string
 	var issueBody string
@@ -301,7 +302,7 @@ func runFix(ctx context.Context, targetURL, prompt, name string, noPR, watch boo
 	envMap := map[string]string{
 		"HOME":                       "/workspaces/.home",
 		"FACTORY_CONFIG":             "/workspaces/.factory.cfg",
-		"GITHUB_TOKEN":               string(secret.Data[KeyGithubToken]),
+		"GITHUB_TOKEN":               string(secret.Data[constants.KeyGithubToken]),
 		"GEMINI_API_KEY":             getGeminiAPIKey(secret),
 		"GEMINI_CLI_TRUST_WORKSPACE": "true",
 		"REPO_OWNER":                 owner,

--- a/factory/pkg/commands/pr.go
+++ b/factory/pkg/commands/pr.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/clients"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/common"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/config"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/constants"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/envd"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/github"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/k8s"
@@ -211,8 +212,8 @@ func runInvestigate(ctx context.Context, prURL, prompt string, continueSession b
 	if err != nil {
 		return fmt.Errorf("fetching %s secret in namespace %s: %w (make sure to run 'factory user onboard' first)", rootFlags.SecretName, rootFlags.Namespace, err)
 	}
-	githubLogin := string(secret.Data[KeyGithubLogin])
-	githubEmail := string(secret.Data[KeyGithubEmail])
+	githubLogin := string(secret.Data[constants.KeyGithubLogin])
+	githubEmail := string(secret.Data[constants.KeyGithubEmail])
 
 	triggerLabel := "factory"
 	if cfg != nil && cfg.TriggerLabel != "" {
@@ -262,7 +263,7 @@ func runInvestigate(ctx context.Context, prURL, prompt string, continueSession b
 	}
 
 	envMap := map[string]string{
-		"GITHUB_TOKEN":               string(secret.Data[KeyGithubToken]),
+		"GITHUB_TOKEN":               string(secret.Data[constants.KeyGithubToken]),
 		"GEMINI_API_KEY":             getGeminiAPIKey(secret),
 		"GEMINI_CLI_TRUST_WORKSPACE": "true",
 		"REPO_NAME":                  repo,
@@ -480,8 +481,8 @@ func runAddressComments(ctx context.Context, prURL, prompt string, continueSessi
 	if err != nil {
 		return fmt.Errorf("fetching %s secret in namespace %s: %w (make sure to run 'factory user onboard' first)", rootFlags.SecretName, rootFlags.Namespace, err)
 	}
-	githubLogin := string(secret.Data[KeyGithubLogin])
-	githubEmail := string(secret.Data[KeyGithubEmail])
+	githubLogin := string(secret.Data[constants.KeyGithubLogin])
+	githubEmail := string(secret.Data[constants.KeyGithubEmail])
 
 	triggerLabel := "factory"
 	if cfg != nil && cfg.TriggerLabel != "" {
@@ -534,7 +535,7 @@ func runAddressComments(ctx context.Context, prURL, prompt string, continueSessi
 	}
 
 	envMap := map[string]string{
-		"GITHUB_TOKEN":               string(secret.Data[KeyGithubToken]),
+		"GITHUB_TOKEN":               string(secret.Data[constants.KeyGithubToken]),
 		"GEMINI_API_KEY":             getGeminiAPIKey(secret),
 		"GEMINI_CLI_TRUST_WORKSPACE": "true",
 		"REPO_NAME":                  repo,
@@ -902,8 +903,8 @@ func runIterate(ctx context.Context, prURL, prompt string, continueSession bool,
 	if err != nil {
 		return fmt.Errorf("fetching %s secret in namespace %s: %w (make sure to run 'factory user onboard' first)", rootFlags.SecretName, rootFlags.Namespace, err)
 	}
-	githubLogin := string(secret.Data[KeyGithubLogin])
-	githubEmail := string(secret.Data[KeyGithubEmail])
+	githubLogin := string(secret.Data[constants.KeyGithubLogin])
+	githubEmail := string(secret.Data[constants.KeyGithubEmail])
 
 	params := tasks.IterateParams{
 		Repo: tasks.Repo{
@@ -945,7 +946,7 @@ func runIterate(ctx context.Context, prURL, prompt string, continueSession bool,
 	}
 
 	envMap := map[string]string{
-		"GITHUB_TOKEN":               string(secret.Data[KeyGithubToken]),
+		"GITHUB_TOKEN":               string(secret.Data[constants.KeyGithubToken]),
 		"GEMINI_API_KEY":             getGeminiAPIKey(secret),
 		"GEMINI_CLI_TRUST_WORKSPACE": "true",
 		"REPO_OWNER":                 owner,
@@ -1046,7 +1047,7 @@ func verifyPROwnership(ctx context.Context, prURL string) error {
 		user = prAuthor
 	}
 
-	if user != "" && rootFlags.SecretName == "factory-user" {
+	if user != "" && rootFlags.SecretName == constants.SecretFactoryUser {
 		secretName := fmt.Sprintf("user-%s", user)
 		_, err = kubeClient.Clientset.CoreV1().Secrets(rootFlags.Namespace).Get(ctx, secretName, metav1.GetOptions{})
 		if err == nil {
@@ -1064,7 +1065,7 @@ func verifyPROwnership(ctx context.Context, prURL string) error {
 	if err != nil {
 		return fmt.Errorf("fetching %s secret in namespace %s: %w (make sure to run 'factory user onboard' first)", rootFlags.SecretName, rootFlags.Namespace, err)
 	}
-	githubLogin := string(secret.Data[KeyGithubLogin])
+	githubLogin := string(secret.Data[constants.KeyGithubLogin])
 
 	if !strings.EqualFold(prAuthor, githubLogin) {
 		return fmt.Errorf("PR is not owned by the factory user (%s). It is owned by %s. Please run 'factory pr adopt <open|close> --pr-url %s' to adopt it first", githubLogin, prAuthor, prURL)
@@ -1153,8 +1154,8 @@ func runAdopt(ctx context.Context, prURL, adoptAction, strategy string, ephemera
 	if err != nil {
 		return fmt.Errorf("fetching %s secret in namespace %s: %w (make sure to run 'factory user onboard' first)", rootFlags.SecretName, rootFlags.Namespace, err)
 	}
-	githubLogin := string(secret.Data[KeyGithubLogin])
-	githubEmail := string(secret.Data[KeyGithubEmail])
+	githubLogin := string(secret.Data[constants.KeyGithubLogin])
+	githubEmail := string(secret.Data[constants.KeyGithubEmail])
 
 	prAuthor := pr.GetUser().GetLogin()
 	if strings.EqualFold(prAuthor, githubLogin) {
@@ -1191,7 +1192,7 @@ func runAdopt(ctx context.Context, prURL, adoptAction, strategy string, ephemera
 		if err != nil {
 			return fmt.Errorf("creating request for PR diff: %w", err)
 		}
-		req.Header.Set("Authorization", "Bearer "+string(secret.Data[KeyGithubToken]))
+		req.Header.Set("Authorization", "Bearer "+string(secret.Data[constants.KeyGithubToken]))
 
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
@@ -1241,7 +1242,7 @@ func runAdopt(ctx context.Context, prURL, adoptAction, strategy string, ephemera
 	}
 
 	envMap := map[string]string{
-		"GITHUB_TOKEN":               string(secret.Data[KeyGithubToken]),
+		"GITHUB_TOKEN":               string(secret.Data[constants.KeyGithubToken]),
 		"GEMINI_API_KEY":             getGeminiAPIKey(secret),
 		"GEMINI_CLI_TRUST_WORKSPACE": "true",
 		"REPO_OWNER":                 owner,

--- a/factory/pkg/commands/review.go
+++ b/factory/pkg/commands/review.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/clients"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/common"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/constants"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/envd"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/github"
 	factorysandbox "github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/sandbox"
@@ -233,9 +234,9 @@ func runReview(ctx context.Context, prURL string, publishPolicy string, instruct
 	if err != nil {
 		return fmt.Errorf("fetching %s secret in namespace %s: %w (make sure to run 'factory user onboard' first)", rootFlags.SecretName, rootFlags.Namespace, err)
 	}
-	githubLogin := string(secret.Data[KeyGithubLogin])
-	githubEmail := string(secret.Data[KeyGithubEmail])
-	userToken := string(secret.Data[KeyGithubToken])
+	githubLogin := string(secret.Data[constants.KeyGithubLogin])
+	githubEmail := string(secret.Data[constants.KeyGithubEmail])
+	userToken := string(secret.Data[constants.KeyGithubToken])
 	if userToken != "" {
 		ghClient = github.NewClientWithToken(ctx, userToken)
 	}
@@ -276,7 +277,7 @@ func runReview(ctx context.Context, prURL string, publishPolicy string, instruct
 	}
 
 	envMap := map[string]string{
-		"GITHUB_TOKEN":               string(secret.Data[KeyGithubToken]),
+		"GITHUB_TOKEN":               string(secret.Data[constants.KeyGithubToken]),
 		"GEMINI_API_KEY":             getGeminiAPIKey(secret),
 		"GEMINI_CLI_TRUST_WORKSPACE": "true",
 		"REPO_NAME":                  repo,

--- a/factory/pkg/commands/root.go
+++ b/factory/pkg/commands/root.go
@@ -11,18 +11,11 @@ import (
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/common"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/config"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/constants"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/geminitokens"
 	factorysandbox "github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/sandbox"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
-)
-
-const (
-	KeyGithubToken    = "GITHUB_TOKEN"
-	KeyGeminiAPIKey   = "GEMINI_API_KEY"
-	KeyGithubLogin    = "GITHUB_LOGIN"
-	KeyGithubEmail    = "GITHUB_EMAIL"
-	SecretFactoryUser = "factory-user"
 )
 
 var rootFlags common.RootFlags
@@ -71,7 +64,7 @@ coding tasks without local side effects or host dependencies.`,
 		if rootFlags.User != "" {
 			rootFlags.SecretName = fmt.Sprintf("user-%s", rootFlags.User)
 		} else {
-			rootFlags.SecretName = SecretFactoryUser
+			rootFlags.SecretName = constants.SecretFactoryUser
 		}
 	}
 

--- a/factory/pkg/commands/status.go
+++ b/factory/pkg/commands/status.go
@@ -8,6 +8,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/clients"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/constants"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/geminitokens"
 	"github.com/spf13/cobra"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -53,12 +54,12 @@ func NewStatusCommand(ctx context.Context) *cobra.Command {
 			if err != nil {
 				fmt.Fprintf(w, "User Secret\t[FAIL]\tSecret '%s' missing in namespace '%s' (run 'factory user onboard')\n", rootFlags.SecretName, rootFlags.Namespace)
 			} else {
-				if string(secret.Data[KeyGithubLogin]) == "" {
+				if string(secret.Data[constants.KeyGithubLogin]) == "" {
 					fmt.Fprintf(w, "GitHub Login\t[FAIL]\tGITHUB_LOGIN missing in secret '%s'\n", rootFlags.SecretName)
 				} else {
-					fmt.Fprintf(w, "GitHub Login\t[OK]\t%s\n", string(secret.Data[KeyGithubLogin]))
+					fmt.Fprintf(w, "GitHub Login\t[OK]\t%s\n", string(secret.Data[constants.KeyGithubLogin]))
 				}
-				if string(secret.Data[KeyGithubToken]) == "" {
+				if string(secret.Data[constants.KeyGithubToken]) == "" {
 					fmt.Fprintf(w, "GitHub Token\t[FAIL]\tGITHUB_TOKEN missing in secret '%s'\n", rootFlags.SecretName)
 				} else {
 					fmt.Fprintf(w, "GitHub Token\t[OK]\tConfigured in secret '%s'\n", rootFlags.SecretName)

--- a/factory/pkg/commands/user.go
+++ b/factory/pkg/commands/user.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/clients"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/constants"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/k8s"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -75,7 +76,7 @@ func RunUserOnboard(ctx context.Context, githubLogin, githubToken, githubEmail, 
 	}
 
 	if githubToken == "" {
-		if val := os.Getenv("GITHUB_TOKEN"); val != "" {
+		if val := os.Getenv(constants.KeyGithubToken); val != "" {
 			githubToken = val
 		} else if val := os.Getenv("GH_TOKEN"); val != "" {
 			githubToken = val
@@ -145,7 +146,7 @@ func RunUserOnboard(ctx context.Context, githubLogin, githubToken, githubEmail, 
 	}
 
 	if geminiKey == "" {
-		geminiKey = os.Getenv("GEMINI_API_KEY")
+		geminiKey = os.Getenv(constants.KeyGeminiAPIKey)
 		if geminiKey == "" {
 			return fmt.Errorf("GEMINI_API_KEY environment variable not set")
 		}
@@ -198,10 +199,10 @@ func RunUserOnboard(ctx context.Context, githubLogin, githubToken, githubEmail, 
 	}
 
 	data := map[string][]byte{
-		KeyGithubToken:  []byte(githubToken),
-		KeyGeminiAPIKey: []byte(geminiKey),
-		KeyGithubLogin:  []byte(githubLogin),
-		KeyGithubEmail:  []byte(githubEmail),
+		constants.KeyGithubToken:  []byte(githubToken),
+		constants.KeyGeminiAPIKey: []byte(geminiKey),
+		constants.KeyGithubLogin:  []byte(githubLogin),
+		constants.KeyGithubEmail:  []byte(githubEmail),
 	}
 
 	fmt.Printf("Creating secret '%s' in namespace '%s'...\n", rootFlags.SecretName, targetNamespace)

--- a/factory/pkg/commands/watch.go
+++ b/factory/pkg/commands/watch.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/clients"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/common"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/config"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/constants"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/envd"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/github"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/k8s"
@@ -1029,7 +1030,7 @@ func (w *Watcher) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("fetching %s secret in namespace %s: %w (make sure to run 'factory user onboard' first)", w.SecretName, w.Namespace, err)
 	}
-	githubLogin := string(secret.Data[KeyGithubLogin])
+	githubLogin := string(secret.Data[constants.KeyGithubLogin])
 
 	targetAssignee := w.Assignee
 	if !w.AssigneeChanged {

--- a/factory/pkg/constants/constants.go
+++ b/factory/pkg/constants/constants.go
@@ -1,0 +1,9 @@
+package constants
+
+const (
+	KeyGithubToken    = "GITHUB_TOKEN"
+	KeyGeminiAPIKey   = "GEMINI_API_KEY"
+	KeyGithubLogin    = "GITHUB_LOGIN"
+	KeyGithubEmail    = "GITHUB_EMAIL"
+	SecretFactoryUser = "factory-user"
+)

--- a/factory/pkg/envd/client.go
+++ b/factory/pkg/envd/client.go
@@ -20,6 +20,7 @@ import (
 	"syscall"
 
 	"connectrpc.com/connect"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/constants"
 	process "github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/envd/spec/process"
 	processconnect "github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/envd/spec/process/processconnect"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/geminitokens"
@@ -603,7 +604,7 @@ func (c *Client) RunTaskResilient(ctx context.Context, cmdStr string, envs map[s
 func handleQuotaOrSuspensionError(newData []byte, envs map[string]string) error {
 	key := geminitokens.ExtractAPIKeyFromError(newData)
 	if key == "" {
-		key = envs["GEMINI_API_KEY"]
+		key = envs[constants.KeyGeminiAPIKey]
 	}
 	if key != "" {
 		if geminitokens.IsSuspendedKeyError(newData) {

--- a/factory/pkg/geminitokens/geminitokens.go
+++ b/factory/pkg/geminitokens/geminitokens.go
@@ -12,11 +12,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 )
-
-const KeyGeminiAPIKey = "GEMINI_API_KEY"
 
 var (
 	listMutex      sync.Mutex
@@ -359,7 +358,7 @@ func GetGeminiAPIKey(secret *corev1.Secret) string {
 		return token
 	}
 	if secret != nil {
-		return string(secret.Data[KeyGeminiAPIKey])
+		return string(secret.Data[constants.KeyGeminiAPIKey])
 	}
 	return ""
 }

--- a/factory/pkg/github/github.go
+++ b/factory/pkg/github/github.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/constants"
 	githubv39 "github.com/google/go-github/v39/github"
 	"golang.org/x/oauth2"
 )
@@ -21,7 +22,7 @@ import (
 func GetGithubToken(ctx context.Context) (string, error) {
 	token := os.Getenv("MANUAL_PAT")
 	if token == "" {
-		token = os.Getenv("GITHUB_TOKEN")
+		token = os.Getenv(constants.KeyGithubToken)
 	}
 	if token == "" {
 		token = os.Getenv("OAUTH_PAT")


### PR DESCRIPTION
This consolidates shared constants to a common package so that they can
be shared instead of repeated/duplicated. This just starts with a few
constants but can be used as a starting point for other constants.