### PR TITLE
refactor: move watch into its own package

### DIFF
--- a/factory/pkg/commands/watch/watch.go
+++ b/factory/pkg/commands/watch/watch.go
@@ -1,4 +1,4 @@
-package commands
+package watch
 
 import (
 	"bytes"
@@ -27,7 +27,6 @@ import (
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/usagereport"
 	githubv39 "github.com/google/go-github/v39/github"
 	"github.com/robfig/cron/v3"
-	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,7 +59,7 @@ func (r *RepoFlag) Type() string {
 	return "string"
 }
 
-type WatchFlags struct {
+type Flags struct {
 	Repo                RepoFlag
 	PollInterval        time.Duration
 	Assignee            string
@@ -85,87 +84,14 @@ type WatchFlags struct {
 
 type Watcher struct {
 	common.RootFlags
-	WatchFlags
+	Flags
 }
 
-func NewWatcher(rootFlags common.RootFlags, flags WatchFlags) *Watcher {
+func NewWatcher(rootFlags common.RootFlags, flags Flags) *Watcher {
 	return &Watcher{
-		RootFlags:  rootFlags,
-		WatchFlags: flags,
+		RootFlags: rootFlags,
+		Flags:     flags,
 	}
-}
-
-func NewWatchCommand(ctx context.Context) *cobra.Command {
-	var flags WatchFlags
-
-	cmd := &cobra.Command{
-		Use:   "watch",
-		Short: "Watch a GitHub repo for test failures and assigned issues to automatically fix and review",
-		Example: `  # Watch for unassigned issues with specific labels
-  factory watch --repo owner/repo --assignee "" --labels "bug,help wanted"
-
-  # Watch for assigned issues with labels
-  factory watch --repo owner/repo --assignee "factory-bot" --labels "p0,urgent"`,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			_, err := ResolveRootFlags(cmd)
-			if err != nil {
-				return err
-			}
-
-			flags.AssigneeChanged = cmd.Flags().Changed("assignee")
-
-			if flags.IssueMode == "" {
-				flags.IssueMode = os.Getenv("ISSUE_MODE")
-			}
-			if flags.IssueMode == "" {
-				flags.IssueMode = "enabled"
-			}
-
-			if flags.PRMode == "" {
-				flags.PRMode = os.Getenv("PR_MODE")
-			}
-			if flags.PRMode == "" {
-				flags.PRMode = "enabled"
-			}
-
-			if flags.ChoresMode == "" {
-				flags.ChoresMode = os.Getenv("CHORES_MODE")
-			}
-			cfg, _ := config.LoadConfig()
-			if cfg != nil && cfg.Chores.Mode == "disabled" {
-				flags.ChoresMode = "disabled"
-			}
-			if flags.ChoresMode == "" {
-				flags.ChoresMode = "enabled"
-			}
-
-			watcher := NewWatcher(rootFlags, flags)
-			return watcher.Run(ctx)
-		},
-	}
-
-	cmd.Flags().Var(&flags.Repo, "repo", "GitHub repository (e.g. owner/repo)")
-	_ = cmd.MarkFlagRequired("repo")
-	cmd.Flags().DurationVar(&flags.PollInterval, "poll-interval", 2*time.Minute, "Polling interval")
-	cmd.Flags().StringVar(&flags.Assignee, "assignee", "factory-bot", "GitHub username to watch for assigned issues (use empty string for unassigned issues)")
-	cmd.Flags().StringSliceVar(&flags.Labels, "labels", nil, "Comma-separated list of labels to filter issues by")
-	cmd.Flags().BoolVar(&flags.DryRun, "dryrun", false, "Print actions without creating sandboxes or executing tasks")
-	cmd.Flags().DurationVar(&flags.WatchTimeout, "watch-timeout", 0, "Timeout for watching (default forever)")
-	cmd.Flags().IntVar(&flags.MaxActions, "max-actions", 40, "Maximum number of actions to take in a single watch loop")
-	cmd.Flags().IntVar(&flags.MaxPending, "max-pending", 40, "Maximum number of pending/running sandboxes allowed before skipping actions")
-	cmd.Flags().StringVar(&flags.Mode, "mode", "all", "Watch mode: all (scan & run), scan (only scan & queue), run (only process queue)")
-	cmd.Flags().StringVar(&flags.QueueDir, "queue-dir", "/workspaces/queues", "Directory path for the task queues")
-	cmd.Flags().BoolVar(&flags.Once, "once", false, "Run watch once and exit (waits for active tasks to complete)")
-	cmd.Flags().StringVar(&flags.IssueMode, "issue-mode", "", "Issue mode: enabled or disabled (defaults to ISSUE_MODE env or enabled)")
-	cmd.Flags().StringVar(&flags.PRMode, "pr-mode", "", "PR mode: enabled or disabled (defaults to PR_MODE env or enabled)")
-	cmd.Flags().StringVar(&flags.ChoresMode, "chores-mode", "", "Chores mode: enabled or disabled (defaults to CHORES_MODE env or enabled)")
-	cmd.Flags().IntVar(&flags.ScanLimit, "scan-limit", 100, "Maximum number of issues/PRs to fetch from GitHub API in a scan cycle")
-	cmd.Flags().DurationVar(&flags.TaskTimeout, "task-timeout", 3*time.Hour, "Timeout for each task execution (default 3h)")
-	cmd.Flags().StringVar(&flags.SandboxEvictionAge, "sandbox-eviction-age", "7d", "Age threshold for idle sandbox eviction (e.g. '7d', '24h')")
-	cmd.Flags().DurationVar(&flags.SandboxIdleTimeout, "sandbox-idle-timeout", common.GetEnvDuration("SANDBOX_IDLE_TIMEOUT", 0), "Idle timeout after which a sandbox that has not run any task is suspended by setting replicas to 0 (e.g. '30m', '1h')")
-	cmd.Flags().DurationVar(&flags.PRInactivityTimeout, "pr-inactivity-timeout", common.GetEnvDuration("PR_INACTIVITY_TIMEOUT", 0), "Time of inactivity with no human comments before pausing automated processing on a PR (e.g. '24h', '168h')")
-
-	return cmd
 }
 
 func assignedBotUser(issue *githubv39.Issue, botUsers []string) string {

--- a/factory/pkg/commands/watch/watch_test.go
+++ b/factory/pkg/commands/watch/watch_test.go
@@ -1,4 +1,4 @@
-package commands
+package watch
 
 import (
 	"context"
@@ -13,6 +13,7 @@ import (
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/k8s"
 	"github.com/google/go-cmp/cmp"
 	githubv39 "github.com/google/go-github/v39/github"
+	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -20,6 +21,10 @@ import (
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"sigs.k8s.io/yaml"
 )
+
+func stringPtr(s string) *string {
+	return &s
+}
 
 func TestShouldRunChoreAt(t *testing.T) {
 	// Base mock "now" time: Wednesday, July 1st, 2026 at 9:55 AM UTC
@@ -1118,8 +1123,21 @@ func TestRepoFlag(t *testing.T) {
 }
 
 func TestWatchCommand_RepoFlag(t *testing.T) {
+	newCmd := func() *cobra.Command {
+		var flags Flags
+		cmd := &cobra.Command{
+			Use: "watch",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return nil
+			},
+		}
+		cmd.Flags().Var(&flags.Repo, "repo", "GitHub repository (e.g. owner/repo)")
+		_ = cmd.MarkFlagRequired("repo")
+		return cmd
+	}
+
 	t.Run("Valid repo flag parses into RepoFlag struct", func(t *testing.T) {
-		cmd := NewWatchCommand(context.Background())
+		cmd := newCmd()
 		cmd.SetArgs([]string{"--repo", "test-org/test-repo"})
 		if err := cmd.ParseFlags([]string{"--repo", "test-org/test-repo"}); err != nil {
 			t.Fatalf("cmd.ParseFlags failed: %v", err)
@@ -1131,14 +1149,14 @@ func TestWatchCommand_RepoFlag(t *testing.T) {
 	})
 
 	t.Run("Invalid repo flag returns error during flag parsing", func(t *testing.T) {
-		cmd := NewWatchCommand(context.Background())
+		cmd := newCmd()
 		if err := cmd.ParseFlags([]string{"--repo", "invalid-repo-format"}); err == nil {
 			t.Errorf("expected error for invalid repo format, got nil")
 		}
 	})
 
 	t.Run("Missing repo flag fails required flag validation", func(t *testing.T) {
-		cmd := NewWatchCommand(context.Background())
+		cmd := newCmd()
 		cmd.SetArgs([]string{})
 		err := cmd.Execute()
 		if err == nil {

--- a/factory/pkg/commands/watch_cmd.go
+++ b/factory/pkg/commands/watch_cmd.go
@@ -1,0 +1,85 @@
+package commands
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/common"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/watch"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+func NewWatchCommand(ctx context.Context) *cobra.Command {
+	var flags watch.Flags
+
+	cmd := &cobra.Command{
+		Use:   "watch",
+		Short: "Watch a GitHub repo for test failures and assigned issues to automatically fix and review",
+		Example: `  # Watch for unassigned issues with specific labels
+  factory watch --repo owner/repo --assignee "" --labels "bug,help wanted"
+
+  # Watch for assigned issues with labels
+  factory watch --repo owner/repo --assignee "factory-bot" --labels "p0,urgent"`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			_, err := ResolveRootFlags(cmd)
+			if err != nil {
+				return err
+			}
+
+			flags.AssigneeChanged = cmd.Flags().Changed("assignee")
+
+			if flags.IssueMode == "" {
+				flags.IssueMode = os.Getenv("ISSUE_MODE")
+			}
+			if flags.IssueMode == "" {
+				flags.IssueMode = "enabled"
+			}
+
+			if flags.PRMode == "" {
+				flags.PRMode = os.Getenv("PR_MODE")
+			}
+			if flags.PRMode == "" {
+				flags.PRMode = "enabled"
+			}
+
+			if flags.ChoresMode == "" {
+				flags.ChoresMode = os.Getenv("CHORES_MODE")
+			}
+			cfg, _ := config.LoadConfig()
+			if cfg != nil && cfg.Chores.Mode == "disabled" {
+				flags.ChoresMode = "disabled"
+			}
+			if flags.ChoresMode == "" {
+				flags.ChoresMode = "enabled"
+			}
+
+			watcher := watch.NewWatcher(rootFlags, flags)
+			return watcher.Run(ctx)
+		},
+	}
+
+	cmd.Flags().Var(&flags.Repo, "repo", "GitHub repository (e.g. owner/repo)")
+	_ = cmd.MarkFlagRequired("repo")
+	cmd.Flags().DurationVar(&flags.PollInterval, "poll-interval", 2*time.Minute, "Polling interval")
+	cmd.Flags().StringVar(&flags.Assignee, "assignee", "factory-bot", "GitHub username to watch for assigned issues (use empty string for unassigned issues)")
+	cmd.Flags().StringSliceVar(&flags.Labels, "labels", nil, "Comma-separated list of labels to filter issues by")
+	cmd.Flags().BoolVar(&flags.DryRun, "dryrun", false, "Print actions without creating sandboxes or executing tasks")
+	cmd.Flags().DurationVar(&flags.WatchTimeout, "watch-timeout", 0, "Timeout for watching (default forever)")
+	cmd.Flags().IntVar(&flags.MaxActions, "max-actions", 40, "Maximum number of actions to take in a single watch loop")
+	cmd.Flags().IntVar(&flags.MaxPending, "max-pending", 40, "Maximum number of pending/running sandboxes allowed before skipping actions")
+	cmd.Flags().StringVar(&flags.Mode, "mode", "all", "Watch mode: all (scan & run), scan (only scan & queue), run (only process queue)")
+	cmd.Flags().StringVar(&flags.QueueDir, "queue-dir", "/workspaces/queues", "Directory path for the task queues")
+	cmd.Flags().BoolVar(&flags.Once, "once", false, "Run watch once and exit (waits for active tasks to complete)")
+	cmd.Flags().StringVar(&flags.IssueMode, "issue-mode", "", "Issue mode: enabled or disabled (defaults to ISSUE_MODE env or enabled)")
+	cmd.Flags().StringVar(&flags.PRMode, "pr-mode", "", "PR mode: enabled or disabled (defaults to PR_MODE env or enabled)")
+	cmd.Flags().StringVar(&flags.ChoresMode, "chores-mode", "", "Chores mode: enabled or disabled (defaults to CHORES_MODE env or enabled)")
+	cmd.Flags().IntVar(&flags.ScanLimit, "scan-limit", 100, "Maximum number of issues/PRs to fetch from GitHub API in a scan cycle")
+	cmd.Flags().DurationVar(&flags.TaskTimeout, "task-timeout", 3*time.Hour, "Timeout for each task execution (default 3h)")
+	cmd.Flags().StringVar(&flags.SandboxEvictionAge, "sandbox-eviction-age", "7d", "Age threshold for idle sandbox eviction (e.g. '7d', '24h')")
+	cmd.Flags().DurationVar(&flags.SandboxIdleTimeout, "sandbox-idle-timeout", common.GetEnvDuration("SANDBOX_IDLE_TIMEOUT", 0), "Idle timeout after which a sandbox that has not run any task is suspended by setting replicas to 0 (e.g. '30m', '1h')")
+	cmd.Flags().DurationVar(&flags.PRInactivityTimeout, "pr-inactivity-timeout", common.GetEnvDuration("PR_INACTIVITY_TIMEOUT", 0), "Time of inactivity with no human comments before pausing automated processing on a PR (e.g. '24h', '168h')")
+
+	return cmd
+}


### PR DESCRIPTION
This relocates the majority of code for the factory watch command into its own subdirectory/package.