### PR TITLE
fix: overseer-controller error loops on overseer spec update

### DIFF
--- a/overseer/k8s/overseer-controller.yaml
+++ b/overseer/k8s/overseer-controller.yaml
@@ -44,12 +44,6 @@ rules:
 - apiGroups: ["agents.x-k8s.io"]
   resources: ["sandboxes"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-- apiGroups: [""]
-  resources: ["pods", "events"]
-  verbs: ["get", "list"]
-- apiGroups: [""]
-  resources: ["pods/portforward"]
-  verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/overseer/pkg/controllers/overseer_controller.go
+++ b/overseer/pkg/controllers/overseer_controller.go
@@ -50,8 +50,6 @@ type OverseerReconciler struct {
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups="",resources=pods;events,verbs=get;list
-//+kubebuilder:rbac:groups="",resources=pods/portforward,verbs=create
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes,verbs=get;list;watch;create;update;patch;delete
 

--- a/overseer/pkg/overseer/overseer.go
+++ b/overseer/pkg/overseer/overseer.go
@@ -105,18 +105,8 @@ func ReconcileOverseer(ctx context.Context, c client.Client, o *overseerv1alpha1
 		if err := c.Update(ctx, sandbox); err != nil {
 			return fmt.Errorf("updating sandbox spec: %w", err)
 		}
-
-		// Delete the sandbox pod to force a restart/recreation with the new spec
-		pod := &corev1.Pod{}
-		err = c.Get(ctx, types.NamespacedName{Name: overseerName, Namespace: namespace}, pod)
-		if err == nil {
-			log.Info("Deleting Overseer sandbox pod to force restart", "name", overseerName, "namespace", namespace)
-			if err := c.Delete(ctx, pod); err != nil {
-				log.Error(err, "Failed to delete sandbox pod to force restart", "name", overseerName, "namespace", namespace)
-			}
-		} else if !errors.IsNotFound(err) {
-			log.Error(err, "Failed to find sandbox pod for deletion", "name", overseerName, "namespace", namespace)
-		}
+		// TODO: At this point the sandbox Pod may be stale (using old PodSpec). Ideally this should
+		// implement a safe update which allows the sandbox to gracefully restart (e.g. draining its task queue).
 	}
 
 	o.Status.OverseerStatus = overseerv1alpha1.OverseerStatusActive


### PR DESCRIPTION
The overseer controller lacked sufficient permissions to actually perform the Pod restart, so this code path was not successful. It turns out this is preferred behavior over restarting the sandbox on every overseer spec update.

Eventually (long term) the preferred behavior would be a graceful restart that allows the sandbox to drain its task queue.