### PR TITLE
Revert "fix: overseer-controller error loops on overseer spec update"

### DIFF
--- a/overseer/k8s/overseer-controller.yaml
+++ b/overseer/k8s/overseer-controller.yaml
@@ -44,6 +44,12 @@ rules:
 - apiGroups: ["agents.x-k8s.io"]
   resources: ["sandboxes"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["pods", "events"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods/portforward"]
+  verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/overseer/pkg/controllers/overseer_controller.go
+++ b/overseer/pkg/controllers/overseer_controller.go
@@ -50,6 +50,8 @@ type OverseerReconciler struct {
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=pods;events,verbs=get;list
+//+kubebuilder:rbac:groups="",resources=pods/portforward,verbs=create
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes,verbs=get;list;watch;create;update;patch;delete
 

--- a/overseer/pkg/overseer/overseer.go
+++ b/overseer/pkg/overseer/overseer.go
@@ -105,8 +105,18 @@ func ReconcileOverseer(ctx context.Context, c client.Client, o *overseerv1alpha1
 		if err := c.Update(ctx, sandbox); err != nil {
 			return fmt.Errorf("updating sandbox spec: %w", err)
 		}
-		// TODO: At this point the sandbox Pod may be stale (using old PodSpec). Ideally this should
-		// implement a safe update which allows the sandbox to gracefully restart (e.g. draining its task queue).
+
+		// Delete the sandbox pod to force a restart/recreation with the new spec
+		pod := &corev1.Pod{}
+		err = c.Get(ctx, types.NamespacedName{Name: overseerName, Namespace: namespace}, pod)
+		if err == nil {
+			log.Info("Deleting Overseer sandbox pod to force restart", "name", overseerName, "namespace", namespace)
+			if err := c.Delete(ctx, pod); err != nil {
+				log.Error(err, "Failed to delete sandbox pod to force restart", "name", overseerName, "namespace", namespace)
+			}
+		} else if !errors.IsNotFound(err) {
+			log.Error(err, "Failed to find sandbox pod for deletion", "name", overseerName, "namespace", namespace)
+		}
 	}
 
 	o.Status.OverseerStatus = overseerv1alpha1.OverseerStatusActive


### PR DESCRIPTION
Reverts gke-labs/gemini-for-kubernetes-development#1282

prevents:
```
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:313
2026-08-14T23:59:13Z    INFO    Adding ServiceAccount to overseer-binding ClusterRoleBinding    {"controller": "overseer", "controllerGroup": "overseer.gemini.google.com", "controllerKind": "Overseer", "Overseer": {"name":"overseer"}, "namespace": "", "name": "overseer", "reconcileID": "36d43705-fca9-49c9-90fe-6bd2da42b643", "namespace": "overseer-overseer"}
2026-08-14T23:59:13Z    ERROR   Reconciler error        {"controller": "overseer", "controllerGroup": "overseer.gemini.google.com", "controllerKind": "Overseer", "Overseer": {"name":"overseer"}, "namespace": "", "name": "overseer", "reconcileID": "36d43705-fca9-49c9-90fe-6bd2da42b643", "error": "clusterrolebindings.rbac.authorization.k8s.io \"overseer-binding\" is forbidden: user \"system:serviceaccount:overseer-system:overseer-controller\" (groups=[\"system:serviceaccounts\" \"system:serviceaccounts:overseer-system\" \"system:authenticated\"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:[\"\"], Resources:[\"events\"], Verbs:[\"get\" \"list\"]}\n{APIGroups:[\"\"], Resources:[\"pods\"], Verbs:[\"get\" \"list\"]}\n{APIGroups:[\"\"], Resources:[\"pods/portforward\"], Verbs:[\"create\"]}"}
```