### PR TITLE
fix(watch): ignore tasks with status Failed when scanning processed queue directory

### DIFF
--- a/factory/pkg/commands/watch/watch.go
+++ b/factory/pkg/commands/watch/watch.go
@@ -1042,6 +1042,9 @@ func (w *Watcher) Run(ctx context.Context) error {
 							hasTask = true
 						}
 					}
+					if hasTask && strings.EqualFold(t.Status, "Failed") {
+						continue
+					}
 					if info, err := f.Info(); err == nil {
 						tTime := info.ModTime()
 						if hasTask && !t.CompletedAt.IsZero() {
@@ -2715,6 +2718,9 @@ func parseProcessedPRTask(filePath string, name string, fInfo os.FileInfo, state
 	if data, err := os.ReadFile(filePath); err == nil {
 		if err := yaml.Unmarshal(data, &t); err == nil {
 			hasTask = true
+			if strings.EqualFold(t.Status, "Failed") {
+				return state
+			}
 			if t.CommitSHA != "" {
 				state.lastSHA = t.CommitSHA
 			}

--- a/factory/pkg/commands/watch/watch_test.go
+++ b/factory/pkg/commands/watch/watch_test.go
@@ -461,6 +461,20 @@ completedAt: "2026-07-23T14:00:00Z"
 	if state.lastIteratedSHA != "efgh456" {
 		t.Errorf("expected lastIteratedSHA to be 'efgh456', got '%s'", state.lastIteratedSHA)
 	}
+
+	// 5. Test that a Failed task is ignored
+	failedTaskPath := filepath.Join(tempDir, "task-pr-123-comments-failed.yaml")
+	failedTaskData := []byte(`
+type: pr-comments
+status: Failed
+completedAt: "2026-07-23T20:00:00Z"
+`)
+	_ = os.WriteFile(failedTaskPath, failedTaskData, 0644)
+	fInfoFailed, _ := os.Stat(failedTaskPath)
+	state = parseProcessedPRTask(failedTaskPath, "task-pr-123-comments", fInfoFailed, state)
+	if !state.lastCommentAddressedTime.Equal(expectedCommentTime) {
+		t.Errorf("expected lastCommentAddressedTime to remain unchanged when task is Failed, got %v", state.lastCommentAddressedTime)
+	}
 }
 
 func TestGetLastPRActivityTime(t *testing.T) {


### PR DESCRIPTION
### Summary of Changes

1. **Ignore Failed Tasks in `processedIssues` and `processedPRs`**:
   - When scanning `processedDir` on startup or during queue scans, check if the processed task file has `status: Failed` (`strings.EqualFold(t.Status, "Failed")`).
   - If a task failed, do not record its timestamp in `processedIssues[num]` or update `prWatchState` timestamps in `parseProcessedPRTask`.
   - This ensures that if a task fails (such as hitting a 429 quota limit or crashing), Overseer will treat the target issue/PR as unprocessed and automatically re-queue a retry on subsequent watch cycles rather than waiting for the issue/PR on GitHub to be updated.

2. **Added Unit Tests**:
   - Added test assertions in `TestParseProcessedPRTask` verifying that files with `status: Failed` do not suppress subsequent retries or modify last-processed timestamps.


## Trigger
https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/12416#issuecomment-5303333577

this issue was not scheduled for 9 hrs. required a manual comment to nudge.
issue was the first fix task failed and new one was not scheduled.