### PR TITLE
fix: overseer-controller error loops on overseer spec update

### DIFF
--- a/overseer/pkg/overseer/overseer.go
+++ b/overseer/pkg/overseer/overseer.go
@@ -105,18 +105,8 @@ func ReconcileOverseer(ctx context.Context, c client.Client, o *overseerv1alpha1
 		if err := c.Update(ctx, sandbox); err != nil {
 			return fmt.Errorf("updating sandbox spec: %w", err)
 		}
-
-		// Delete the sandbox pod to force a restart/recreation with the new spec
-		pod := &corev1.Pod{}
-		err = c.Get(ctx, types.NamespacedName{Name: overseerName, Namespace: namespace}, pod)
-		if err == nil {
-			log.Info("Deleting Overseer sandbox pod to force restart", "name", overseerName, "namespace", namespace)
-			if err := c.Delete(ctx, pod); err != nil {
-				log.Error(err, "Failed to delete sandbox pod to force restart", "name", overseerName, "namespace", namespace)
-			}
-		} else if !errors.IsNotFound(err) {
-			log.Error(err, "Failed to find sandbox pod for deletion", "name", overseerName, "namespace", namespace)
-		}
+		// TODO: At this point the sandbox Pod may be stale (using old PodSpec). Ideally this should
+		// implement a safe update which allows the sandbox to gracefully restart (e.g. draining its task queue).
 	}
 
 	o.Status.OverseerStatus = overseerv1alpha1.OverseerStatusActive


### PR DESCRIPTION
The overseer controller lacked sufficient permissions to actually perform the Pod restart, so this code path was not successful. It turns out this is preferred behavior over restarting the sandbox on every overseer spec update.

The preferred behavior would be a graceful restart that allows the sandbox to drain its task queue.


Note: This is a follow-up on https://github.com/gke-labs/gemini-for-kubernetes-development/pull/1282 without the RBAC changes. The RBAC is currently needed so that overseer-controller can create the namespaced RBAC for child overseer Pods