### PR TITLE
fix: handle pid recycling for sandbox tasks

### DIFF
--- a/factory/design/resilient-task-execution.md
+++ b/factory/design/resilient-task-execution.md
@@ -50,13 +50,14 @@ sequenceDiagram
 ### 1. Detached Launch Command
 Instead of executing the bash command directly, the client executes a wrapper command that detaches the process:
 ```bash
-nohup sh -c "echo \$\$ > {taskDir}/pid; {cmdStr} > {taskDir}/execution.log 2>&1; echo \$? > {taskDir}/exit_code" >/dev/null 2>&1 &
+nohup sh -c "echo \$\$ > {taskDir}/pid; ps -p \$\$ -o lstart= > {taskDir}/start_time; {cmdStr} > {taskDir}/execution.log 2>&1; echo \$? > {taskDir}/exit_code" >/dev/null 2>&1 &
 ```
 This command:
 1. Records the background PID to `{taskDir}/pid`.
-2. Runs the script `{cmdStr}`, piping all output to `execution.log`.
-3. Writes the status exit code to `exit_code` file upon completion.
-4. Exits immediately, allowing the Connect-RPC request to finish with code `0`.
+2. Records the process start time to `{taskDir}/start_time` to prevent PID reuse hazards.
+3. Runs the script `{cmdStr}`, piping all output to `execution.log`.
+4. Writes the status exit code to `exit_code` file upon completion.
+5. Exits immediately, allowing the Connect-RPC request to finish with code `0`.
 
 ### 2. Client Tailing Loop (Interactive Mode)
 In interactive (default) mode, the client performs the following loop:
@@ -86,6 +87,7 @@ In interactive (default) mode, the client performs the following loop:
 | Pitfall | Impact | Mitigation |
 | :--- | :--- | :--- |
 | **Tmux Compatibility** | Tmux can fail in containers with restricted PTY or socket permissions. | Used `nohup` (standard POSIX fork) which has zero socket/PTY dependencies. |
+| **PID Recycling / Collision** | A dead task's PID might be re-assigned to an unrelated new process. | Recorded `start_time` via `ps -o lstart=` and validated against live process start time before signaling or status reporting. |
 | **Log Polling Overhead** | Downloading the entire log file recursively wastes CPU/bandwidth. | Used `tail -c +<offset>` to retrieve only the delta bytes since the last read. |
 | **Log Truncation** | The process might exit, but the client breaks the loop before reading final log lines. | Perform one final `tail -c +<offset>` check after detecting the `exit_code` file. |
 | **Orphaned Processes** | Forgotten tasks run forever. | Deleting the sandbox pod via standard controller methods cleans up all resources. |

--- a/factory/pkg/envd/client.go
+++ b/factory/pkg/envd/client.go
@@ -387,7 +387,7 @@ func (c *Client) RunTaskResilient(ctx context.Context, cmdStr string, envs map[s
 	isAlreadyRunning := false
 	if !isCompleted {
 		var pidBuf bytes.Buffer
-		checkPidCmd := BuildCheckPidCmd(taskFiles.PIDFile)
+		checkPidCmd := BuildCheckPidCmd(taskFiles.PIDFile, taskFiles.StartTimeFile)
 		if err := c.Exec(ctx, checkPidCmd, "/workspaces", nil, nil, &pidBuf, nil); err == nil {
 			if strings.TrimSpace(pidBuf.String()) == "alive" {
 				isAlreadyRunning = true
@@ -456,7 +456,7 @@ func (c *Client) RunTaskResilient(ctx context.Context, cmdStr string, envs map[s
 				defer killCancel()
 
 				fmt.Printf("Terminating process in pod...\n")
-				killCmd := BuildAbortKillCmd(taskFiles.PIDFile, taskFiles.ExitCodeFile)
+				killCmd := BuildAbortKillCmd(taskFiles.PIDFile, taskFiles.StartTimeFile, taskFiles.ExitCodeFile)
 				_ = c.Exec(killCtx, killCmd, "/workspaces", nil, nil, nil, nil)
 			}
 			return loopCtx.Err()
@@ -477,7 +477,7 @@ func (c *Client) RunTaskResilient(ctx context.Context, cmdStr string, envs map[s
 						klog.Warningf("Fatal quota/suspension error detected in task output. Terminating task process group in sandbox pod immediately...")
 						killCtx, killCancel := context.WithTimeout(context.Background(), 15*time.Second)
 						defer killCancel()
-						killCmd := BuildQuotaKillCmd(taskFiles.PIDFile, taskFiles.ExitCodeFile)
+						killCmd := BuildQuotaKillCmd(taskFiles.PIDFile, taskFiles.StartTimeFile, taskFiles.ExitCodeFile)
 						_ = c.Exec(killCtx, killCmd, "/workspaces", nil, nil, nil, nil)
 						return handleQuotaOrSuspensionError(newData, envs)
 					} else if geminitokens.IsTransientRateLimit(newData) {
@@ -493,7 +493,7 @@ func (c *Client) RunTaskResilient(ctx context.Context, cmdStr string, envs map[s
 
 			// Check if process is still alive
 			var pidBuf bytes.Buffer
-			checkPidCmd := BuildCheckPidCmd(taskFiles.PIDFile)
+			checkPidCmd := BuildCheckPidCmd(taskFiles.PIDFile, taskFiles.StartTimeFile)
 			processAlive := false
 			if err := c.Exec(loopCtx, checkPidCmd, "/workspaces", nil, nil, &pidBuf, nil); err == nil {
 				if strings.TrimSpace(pidBuf.String()) == "alive" {

--- a/factory/pkg/envd/scripts.go
+++ b/factory/pkg/envd/scripts.go
@@ -6,45 +6,49 @@ const DefaultTasksDir = "/workspaces/tasks"
 
 // TaskFiles represents standard file paths for a resilient background task.
 type TaskFiles struct {
-	TaskDir      string
-	PIDFile      string
-	LogFile      string
-	ExitCodeFile string
+	TaskDir       string
+	PIDFile       string
+	StartTimeFile string
+	LogFile       string
+	ExitCodeFile  string
 }
 
 // NewTaskFiles creates a TaskFiles struct for a given task directory.
 func NewTaskFiles(taskDir string) TaskFiles {
 	return TaskFiles{
-		TaskDir:      taskDir,
-		PIDFile:      fmt.Sprintf("%s/pid", taskDir),
-		LogFile:      fmt.Sprintf("%s/execution.log", taskDir),
-		ExitCodeFile: fmt.Sprintf("%s/exit_code", taskDir),
+		TaskDir:       taskDir,
+		PIDFile:       fmt.Sprintf("%s/pid", taskDir),
+		StartTimeFile: fmt.Sprintf("%s/start_time", taskDir),
+		LogFile:       fmt.Sprintf("%s/execution.log", taskDir),
+		ExitCodeFile:  fmt.Sprintf("%s/exit_code", taskDir),
 	}
 }
 
 // BuildDetachedLaunchCmd generates the shell command to launch a detached task in the sandbox pod.
 func BuildDetachedLaunchCmd(files TaskFiles, cmdStr string) string {
-	return fmt.Sprintf("nohup sh -c \"echo \\$\\$ > %s; %s > %s 2>&1; echo \\$? > %s\" >/dev/null 2>&1 &",
-		files.PIDFile, cmdStr, files.LogFile, files.ExitCodeFile)
+	return fmt.Sprintf("nohup sh -c \"echo \\$\\$ > %s; ps -p \\$\\$ -o lstart= > %s; %s > %s 2>&1; echo \\$? > %s\" >/dev/null 2>&1 &",
+		files.PIDFile, files.StartTimeFile, cmdStr, files.LogFile, files.ExitCodeFile)
 }
 
-// BuildCheckPidCmd generates the shell command to check if a task process is alive and not a zombie.
-// Outputs "alive" if the process is currently running.
-func BuildCheckPidCmd(pidFile string) string {
-	return fmt.Sprintf("if [ -s %s ]; then pid=$(cat %s 2>/dev/null); if [ -n \"$pid\" ]; then stat=$(ps -o stat= -p \"$pid\" 2>/dev/null | cut -c 1); if kill -0 \"$pid\" 2>/dev/null && [ \"$stat\" != \"Z\" ]; then echo \"alive\"; fi; fi; fi",
-		pidFile, pidFile)
+// BuildCheckPidCmd generates the shell command to check if a task process is alive, not a zombie, and matches start_time.
+// Outputs "alive" if the process is currently running and start time matches.
+func BuildCheckPidCmd(pidFile, startTimeFile string) string {
+	return fmt.Sprintf("if [ -s %s ]; then pid=$(cat %s 2>/dev/null); if [ -n \"$pid\" ]; then stat=$(ps -o stat= -p \"$pid\" 2>/dev/null | cut -c 1); expected_start=$(cat %s 2>/dev/null | xargs); current_start=$(ps -p \"$pid\" -o lstart= 2>/dev/null | xargs); if kill -0 \"$pid\" 2>/dev/null && [ \"$stat\" != \"Z\" ] && { [ -z \"$expected_start\" ] || [ \"$expected_start\" = \"$current_start\" ]; }; then echo \"alive\"; fi; fi; fi",
+		pidFile, pidFile, startTimeFile)
 }
 
 // BuildAbortKillCmd generates the shell command to terminate a task process tree on abort/cancel.
-func BuildAbortKillCmd(pidFile, exitCodeFile string) string {
-	return fmt.Sprintf("if [ -f %s ]; then pids=\"$(cat %s 2>/dev/null) $(pgrep -P $(cat %s 2>/dev/null) 2>/dev/null)\"; kill $pids 2>/dev/null || true; if [ ! -f %s ]; then echo 143 > %s; fi; fi",
-		pidFile, pidFile, pidFile, exitCodeFile, exitCodeFile)
+// Kills PID and its children if PID and start_time match, and writes exit code 143 if exit_code does not exist.
+func BuildAbortKillCmd(pidFile, startTimeFile, exitCodeFile string) string {
+	return fmt.Sprintf("if [ -f %s ]; then pid=$(cat %s 2>/dev/null); expected_start=$(cat %s 2>/dev/null | xargs); current_start=$(ps -p \"$pid\" -o lstart= 2>/dev/null | xargs); if [ -z \"$expected_start\" ] || [ \"$expected_start\" = \"$current_start\" ]; then pids=\"$pid $(pgrep -P $pid 2>/dev/null)\"; kill $pids 2>/dev/null || true; fi; if [ ! -f %s ]; then echo 143 > %s; fi; fi",
+		pidFile, pidFile, startTimeFile, exitCodeFile, exitCodeFile)
 }
 
 // BuildQuotaKillCmd generates the shell command to terminate a task process group on quota/fatal error.
-func BuildQuotaKillCmd(pidFile, exitCodeFile string) string {
-	return fmt.Sprintf("if [ -f %s ]; then top_pid=$(cat %s 2>/dev/null); kill -9 -$(ps -o pgid= $top_pid 2>/dev/null | tr -d ' ') 2>/dev/null || pkill -9 -P $top_pid 2>/dev/null || kill -9 $top_pid 2>/dev/null || true; echo 137 > %s; fi",
-		pidFile, pidFile, exitCodeFile)
+// Kills process group, children, or top PID if start_time matches, and writes exit code 137.
+func BuildQuotaKillCmd(pidFile, startTimeFile, exitCodeFile string) string {
+	return fmt.Sprintf("if [ -f %s ]; then top_pid=$(cat %s 2>/dev/null); expected_start=$(cat %s 2>/dev/null | xargs); current_start=$(ps -p \"$top_pid\" -o lstart= 2>/dev/null | xargs); if [ -z \"$expected_start\" ] || [ \"$expected_start\" = \"$current_start\" ]; then kill -9 -$(ps -o pgid= $top_pid 2>/dev/null | tr -d ' ') 2>/dev/null || pkill -9 -P $top_pid 2>/dev/null || kill -9 $top_pid 2>/dev/null || true; fi; echo 137 > %s; fi",
+		pidFile, pidFile, startTimeFile, exitCodeFile)
 }
 
 // BuildTailLogCmd generates the shell command to read delta logs starting from offset.
@@ -78,8 +82,10 @@ else
 	pid=$(cat "$task_dir/pid" 2>/dev/null)
 	if [ -n "$pid" ]; then
 		stat=$(ps -o stat= -p "$pid" 2>/dev/null | cut -c 1)
-		if ! kill -0 "$pid" 2>/dev/null || [ "$stat" = "Z" ]; then
-			echo "137" # Report SIGKILL/Crashed/Zombie fallback exit code
+		expected_start=$(cat "$task_dir/start_time" 2>/dev/null | xargs)
+		current_start=$(ps -p "$pid" -o lstart= 2>/dev/null | xargs)
+		if ! kill -0 "$pid" 2>/dev/null || [ "$stat" = "Z" ] || { [ -n "$expected_start" ] && [ "$expected_start" != "$current_start" ]; }; then
+			echo "137" # Report SIGKILL/Crashed/Zombie/PID-recycled fallback exit code
 		else
 			echo "RUNNING"
 		fi

--- a/factory/pkg/envd/scripts_test.go
+++ b/factory/pkg/envd/scripts_test.go
@@ -21,6 +21,15 @@ func runShell(t *testing.T, script string) (string, error) {
 	return strings.TrimSpace(stdout.String()), err
 }
 
+func getLiveProcessStartTime(t *testing.T, pid int) string {
+	t.Helper()
+	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "lstart=").Output()
+	if err != nil {
+		t.Fatalf("failed to get start time for pid %d: %v", pid, err)
+	}
+	return strings.Join(strings.Fields(string(out)), " ")
+}
+
 func TestBuildDetachedLaunchCmd(t *testing.T) {
 	tmpDir := t.TempDir()
 	taskDir := filepath.Join(tmpDir, "task-123")
@@ -65,6 +74,12 @@ func TestBuildDetachedLaunchCmd(t *testing.T) {
 		t.Errorf("invalid pid written: %q", string(pidBytes))
 	}
 
+	// Check start time file
+	startBytes, err := os.ReadFile(files.StartTimeFile)
+	if err != nil || len(strings.TrimSpace(string(startBytes))) == 0 {
+		t.Fatalf("failed to read start time file: %v", err)
+	}
+
 	// Check log file
 	logBytes, err := os.ReadFile(files.LogFile)
 	if err != nil {
@@ -81,26 +96,26 @@ func TestBuildCheckPidCmd(t *testing.T) {
 	files := NewTaskFiles(tmpDir)
 
 	// 1. Missing PID file -> outputs nothing
-	out, _ := runShell(t, BuildCheckPidCmd(files.PIDFile))
+	out, _ := runShell(t, BuildCheckPidCmd(files.PIDFile, files.StartTimeFile))
 	if out != "" {
 		t.Errorf("expected empty output for missing PID file, got %q", out)
 	}
 
 	// 2. Empty PID file -> outputs nothing
 	_ = os.WriteFile(files.PIDFile, []byte(""), 0644)
-	out, _ = runShell(t, BuildCheckPidCmd(files.PIDFile))
+	out, _ = runShell(t, BuildCheckPidCmd(files.PIDFile, files.StartTimeFile))
 	if out != "" {
 		t.Errorf("expected empty output for empty PID file, got %q", out)
 	}
 
 	// 3. Dead/non-existent PID -> outputs nothing
 	_ = os.WriteFile(files.PIDFile, []byte("9999999"), 0644)
-	out, _ = runShell(t, BuildCheckPidCmd(files.PIDFile))
+	out, _ = runShell(t, BuildCheckPidCmd(files.PIDFile, files.StartTimeFile))
 	if out != "" {
 		t.Errorf("expected empty output for non-existent PID, got %q", out)
 	}
 
-	// 4. Live process -> outputs "alive"
+	// 4. Live process with matching start time -> outputs "alive"
 	cmd := exec.Command("sleep", "30")
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("failed to start sleep process: %v", err)
@@ -112,16 +127,33 @@ func TestBuildCheckPidCmd(t *testing.T) {
 	}()
 
 	livePID := cmd.Process.Pid
-	_ = os.WriteFile(files.PIDFile, []byte(strconv.Itoa(livePID)), 0644)
+	liveStartTime := getLiveProcessStartTime(t, livePID)
 
-	out, err := runShell(t, BuildCheckPidCmd(files.PIDFile))
+	_ = os.WriteFile(files.PIDFile, []byte(strconv.Itoa(livePID)), 0644)
+	_ = os.WriteFile(files.StartTimeFile, []byte(liveStartTime), 0644)
+
+	out, err := runShell(t, BuildCheckPidCmd(files.PIDFile, files.StartTimeFile))
 	if err != nil || out != "alive" {
 		t.Errorf("expected 'alive', got %q (err: %v)", out, err)
+	}
+
+	// 5. Live process with empty start time file (backwards compatibility) -> outputs "alive"
+	_ = os.WriteFile(files.StartTimeFile, []byte(""), 0644)
+	out, err = runShell(t, BuildCheckPidCmd(files.PIDFile, files.StartTimeFile))
+	if err != nil || out != "alive" {
+		t.Errorf("expected 'alive' when start time is empty, got %q (err: %v)", out, err)
+	}
+
+	// 6. Live process with mismatched start time (PID recycling scenario) -> outputs nothing
+	_ = os.WriteFile(files.StartTimeFile, []byte("Thu Jan 1 00:00:00 1970"), 0644)
+	out, _ = runShell(t, BuildCheckPidCmd(files.PIDFile, files.StartTimeFile))
+	if out != "" {
+		t.Errorf("expected empty output for recycled PID with mismatched start time, got %q", out)
 	}
 }
 
 func TestBuildAbortKillCmd(t *testing.T) {
-	t.Run("kills process", func(t *testing.T) {
+	t.Run("kills process when start_time matches", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		files := NewTaskFiles(tmpDir)
 
@@ -136,9 +168,12 @@ func TestBuildAbortKillCmd(t *testing.T) {
 		}()
 
 		livePID := cmd.Process.Pid
-		_ = os.WriteFile(files.PIDFile, []byte(strconv.Itoa(livePID)), 0644)
+		liveStartTime := getLiveProcessStartTime(t, livePID)
 
-		killScript := BuildAbortKillCmd(files.PIDFile, files.ExitCodeFile)
+		_ = os.WriteFile(files.PIDFile, []byte(strconv.Itoa(livePID)), 0644)
+		_ = os.WriteFile(files.StartTimeFile, []byte(liveStartTime), 0644)
+
+		killScript := BuildAbortKillCmd(files.PIDFile, files.StartTimeFile, files.ExitCodeFile)
 		if _, err := runShell(t, killScript); err != nil {
 			t.Fatalf("failed to run abort kill script: %v", err)
 		}
@@ -160,27 +195,7 @@ func TestBuildAbortKillCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("does not overwrite existing exit_code", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		files := NewTaskFiles(tmpDir)
-
-		_ = os.WriteFile(files.ExitCodeFile, []byte("0"), 0644)
-		_ = os.WriteFile(files.PIDFile, []byte("9999999"), 0644)
-
-		killScript := BuildAbortKillCmd(files.PIDFile, files.ExitCodeFile)
-		if _, err := runShell(t, killScript); err != nil {
-			t.Fatalf("failed to run abort kill script: %v", err)
-		}
-
-		ecBytes, _ := os.ReadFile(files.ExitCodeFile)
-		if strings.TrimSpace(string(ecBytes)) != "0" {
-			t.Errorf("expected existing exit_code 0 to remain unchanged, got %q", string(ecBytes))
-		}
-	})
-}
-
-func TestBuildQuotaKillCmd(t *testing.T) {
-	t.Run("kills process and sets exit code 137", func(t *testing.T) {
+	t.Run("does not kill process when start_time mismatches", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		files := NewTaskFiles(tmpDir)
 
@@ -196,8 +211,68 @@ func TestBuildQuotaKillCmd(t *testing.T) {
 
 		livePID := cmd.Process.Pid
 		_ = os.WriteFile(files.PIDFile, []byte(strconv.Itoa(livePID)), 0644)
+		_ = os.WriteFile(files.StartTimeFile, []byte("Thu Jan 1 00:00:00 1970"), 0644)
 
-		killScript := BuildQuotaKillCmd(files.PIDFile, files.ExitCodeFile)
+		killScript := BuildAbortKillCmd(files.PIDFile, files.StartTimeFile, files.ExitCodeFile)
+		if _, err := runShell(t, killScript); err != nil {
+			t.Fatalf("failed to run abort kill script: %v", err)
+		}
+
+		// Process should still be alive
+		time.Sleep(100 * time.Millisecond)
+		out, psErr := exec.Command("ps", "-p", strconv.Itoa(livePID), "-o", "stat=").Output()
+		if psErr != nil || strings.HasPrefix(strings.TrimSpace(string(out)), "Z") {
+			t.Errorf("process %d was killed even though start_time mismatched", livePID)
+		}
+
+		// Exit code 143 should still be recorded if not present
+		ecBytes, _ := os.ReadFile(files.ExitCodeFile)
+		if strings.TrimSpace(string(ecBytes)) != "143" {
+			t.Errorf("expected exit_code 143, got %q", string(ecBytes))
+		}
+	})
+
+	t.Run("does not overwrite existing exit_code", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		files := NewTaskFiles(tmpDir)
+
+		_ = os.WriteFile(files.ExitCodeFile, []byte("0"), 0644)
+		_ = os.WriteFile(files.PIDFile, []byte("9999999"), 0644)
+
+		killScript := BuildAbortKillCmd(files.PIDFile, files.StartTimeFile, files.ExitCodeFile)
+		if _, err := runShell(t, killScript); err != nil {
+			t.Fatalf("failed to run abort kill script: %v", err)
+		}
+
+		ecBytes, _ := os.ReadFile(files.ExitCodeFile)
+		if strings.TrimSpace(string(ecBytes)) != "0" {
+			t.Errorf("expected existing exit_code 0 to remain unchanged, got %q", string(ecBytes))
+		}
+	})
+}
+
+func TestBuildQuotaKillCmd(t *testing.T) {
+	t.Run("kills process and sets exit code 137 when start_time matches", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		files := NewTaskFiles(tmpDir)
+
+		cmd := exec.Command("sleep", "30")
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("failed to start process: %v", err)
+		}
+		defer func() {
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+			}
+		}()
+
+		livePID := cmd.Process.Pid
+		liveStartTime := getLiveProcessStartTime(t, livePID)
+
+		_ = os.WriteFile(files.PIDFile, []byte(strconv.Itoa(livePID)), 0644)
+		_ = os.WriteFile(files.StartTimeFile, []byte(liveStartTime), 0644)
+
+		killScript := BuildQuotaKillCmd(files.PIDFile, files.StartTimeFile, files.ExitCodeFile)
 		if _, err := runShell(t, killScript); err != nil {
 			t.Fatalf("failed to run quota kill script: %v", err)
 		}
@@ -211,6 +286,41 @@ func TestBuildQuotaKillCmd(t *testing.T) {
 		out, psErr := exec.Command("ps", "-p", strconv.Itoa(livePID), "-o", "stat=").Output()
 		if psErr == nil && !strings.HasPrefix(strings.TrimSpace(string(out)), "Z") {
 			t.Errorf("expected process %d to be killed by SIGKILL", livePID)
+		}
+	})
+
+	t.Run("does not kill process when start_time mismatches", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		files := NewTaskFiles(tmpDir)
+
+		cmd := exec.Command("sleep", "30")
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("failed to start process: %v", err)
+		}
+		defer func() {
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+			}
+		}()
+
+		livePID := cmd.Process.Pid
+		_ = os.WriteFile(files.PIDFile, []byte(strconv.Itoa(livePID)), 0644)
+		_ = os.WriteFile(files.StartTimeFile, []byte("Thu Jan 1 00:00:00 1970"), 0644)
+
+		killScript := BuildQuotaKillCmd(files.PIDFile, files.StartTimeFile, files.ExitCodeFile)
+		if _, err := runShell(t, killScript); err != nil {
+			t.Fatalf("failed to run quota kill script: %v", err)
+		}
+
+		time.Sleep(100 * time.Millisecond)
+		out, psErr := exec.Command("ps", "-p", strconv.Itoa(livePID), "-o", "stat=").Output()
+		if psErr != nil || strings.HasPrefix(strings.TrimSpace(string(out)), "Z") {
+			t.Errorf("process %d was killed even though start_time mismatched", livePID)
+		}
+
+		ecBytes, _ := os.ReadFile(files.ExitCodeFile)
+		if strings.TrimSpace(string(ecBytes)) != "137" {
+			t.Errorf("expected exit_code 137, got %q", string(ecBytes))
 		}
 	})
 }
@@ -335,7 +445,7 @@ func TestBuildCheckLatestTaskStatusCmd(t *testing.T) {
 		t.Errorf("expected '137' for missing exit_code with dead PID, got %q (err: %v)", out, err)
 	}
 
-	// 6. exit_code file is missing, but live PID exists -> returns "RUNNING"
+	// 6. exit_code file is missing, but live PID with matching start time exists -> returns "RUNNING"
 	cmd := exec.Command("sleep", "30")
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("failed to start live process: %v", err)
@@ -347,14 +457,24 @@ func TestBuildCheckLatestTaskStatusCmd(t *testing.T) {
 	}()
 
 	livePID := cmd.Process.Pid
+	liveStartTime := getLiveProcessStartTime(t, livePID)
+
 	_ = os.WriteFile(filepath.Join(t1, "pid"), []byte(strconv.Itoa(livePID)), 0644)
+	_ = os.WriteFile(filepath.Join(t1, "start_time"), []byte(liveStartTime), 0644)
 
 	out, err = runShell(t, BuildCheckLatestTaskStatusCmd(tasksDir))
 	if err != nil || out != "RUNNING" {
 		t.Errorf("expected 'RUNNING' for missing exit_code with live process, got %q (err: %v)", out, err)
 	}
 
-	// 7. Multiple task directories: ensure the latest created/modified task directory is evaluated
+	// 7. exit_code file is missing, but live PID with mismatched start time (PID recycled) -> returns "137"
+	_ = os.WriteFile(filepath.Join(t1, "start_time"), []byte("Thu Jan 1 00:00:00 1970"), 0644)
+	out, err = runShell(t, BuildCheckLatestTaskStatusCmd(tasksDir))
+	if err != nil || out != "137" {
+		t.Errorf("expected '137' for missing exit_code with recycled PID, got %q (err: %v)", out, err)
+	}
+
+	// 8. Multiple task directories: ensure the latest created/modified task directory is evaluated
 	time.Sleep(10 * time.Millisecond)
 	t2 := filepath.Join(tasksDir, "task-2")
 	_ = os.MkdirAll(t2, 0755)

--- a/repo-agent/pkg/agentserver/server.go
+++ b/repo-agent/pkg/agentserver/server.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -112,7 +114,8 @@ func serveTasksList(w http.ResponseWriter, r *http.Request) {
 			pidStr := strings.TrimSpace(string(pidBytes))
 			var pid int
 			if _, err := fmt.Sscanf(pidStr, "%d", &pid); err == nil {
-				if isProcessAliveAndNotZombie(pid) {
+				startBytes, _ := os.ReadFile(filepath.Join(p, "start_time"))
+				if isProcessAliveAndNotZombie(pid, strings.TrimSpace(string(startBytes))) {
 					status = "Running"
 				} else {
 					status = "Crashed"
@@ -196,7 +199,7 @@ func serveTelemetryFile(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, telemetryPath)
 }
 
-func isProcessAliveAndNotZombie(pid int) bool {
+func isProcessAliveAndNotZombie(pid int, expectedStartTime string) bool {
 	proc, err := os.FindProcess(pid)
 	if err != nil || proc.Signal(syscall.Signal(0)) != nil {
 		return false
@@ -205,6 +208,17 @@ func isProcessAliveAndNotZombie(pid int) bool {
 	if err == nil {
 		parts := strings.Fields(string(statBytes))
 		if len(parts) >= 3 && strings.HasPrefix(parts[2], "Z") {
+			return false
+		}
+	}
+	if expectedStartTime != "" {
+		out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "lstart=").Output()
+		if err != nil {
+			return false
+		}
+		currentStart := strings.Join(strings.Fields(string(out)), " ")
+		expectedStart := strings.Join(strings.Fields(expectedStartTime), " ")
+		if currentStart != expectedStart {
 			return false
 		}
 	}

--- a/repo-agent/pkg/agentserver/server_test.go
+++ b/repo-agent/pkg/agentserver/server_test.go
@@ -2,18 +2,37 @@ package agentserver
 
 import (
 	"os"
+	"os/exec"
+	"strconv"
+	"strings"
 	"testing"
 )
 
 func TestIsProcessAliveAndNotZombie(t *testing.T) {
-	// 1. Current running process
+	// 1. Current running process with matching start time
 	pid := os.Getpid()
-	if !isProcessAliveAndNotZombie(pid) {
-		t.Errorf("expected current process %d to be alive", pid)
+	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "lstart=").Output()
+	if err != nil {
+		t.Fatalf("failed to get start time: %v", err)
+	}
+	startTime := strings.Join(strings.Fields(string(out)), " ")
+
+	if !isProcessAliveAndNotZombie(pid, startTime) {
+		t.Errorf("expected current process %d with matching start time to be alive", pid)
 	}
 
-	// 2. Non-existent PID
-	if isProcessAliveAndNotZombie(9999999) {
+	// 2. Current running process with empty expected start time (fallback)
+	if !isProcessAliveAndNotZombie(pid, "") {
+		t.Errorf("expected current process %d with empty start time to be alive", pid)
+	}
+
+	// 3. Current running process with mismatched start time (PID recycling test)
+	if isProcessAliveAndNotZombie(pid, "Thu Jan 1 00:00:00 1970") {
+		t.Errorf("expected process %d with mismatched start time to be considered not alive", pid)
+	}
+
+	// 4. Non-existent PID
+	if isProcessAliveAndNotZombie(9999999, "") {
 		t.Errorf("expected non-existent PID to be considered not alive")
 	}
 }


### PR DESCRIPTION
Previously if a sandbox task process crashed without writing an exit_code file and a new unrelated process recycled the same PID, overseer would confuse the new process and the old process when trying to look up the process by PID. This change adds a start_time tracking in order to uniquely identify task processes using the (pid, start_time) tuple.

This fixes an issue where the factory kept treating the task as Running even though it had already exited.