### PR TITLE
feat: add ready-for-human label support to watch

### DIFF
--- a/factory/design/pr-automated-review.md
+++ b/factory/design/pr-automated-review.md
@@ -95,3 +95,21 @@ roles:
 - `factory pr review` runs inside a dedicated Kubernetes Pod (`factory-pr-<num>-review`) in the configured namespace.
 - It mounts the onboarded Kubernetes secret for `reviewbot-robot`, containing that account's `GITHUB_TOKEN`.
 - All inline review comments, approvals (`APPROVED`), and change requests (`CHANGES_REQUESTED`) posted to GitHub are authored by **`reviewbot-robot`**.
+
+---
+
+## 5. Ready-for-Human Signaling (`overseer/ready-for-human`)
+
+Once a PR successfully passes automated code review by the reviewer bot, the factory watcher automatically applies the `overseer/ready-for-human` label (or `<triggerLabel>/ready-for-human`).
+
+### A. Ready Conditions
+The label is applied when all of the following conditions are met:
+1. **Review Completed on HEAD (if enabled)**: If automated bot review is opted in via `overseer/review` (or inherited from parent issue), a configured reviewer bot must have completed its review on the latest `headSHA`. If automated review is not enabled, this prerequisite is automatically satisfied.
+2. **Review Passed**: The latest review from the reviewer bot is not `CHANGES_REQUESTED` and all review feedback has been resolved (`!hasNewComments`).
+3. **Passing CI Checks**: All GitHub check runs and commit statuses for `headSHA` are green (`!hasFailure`).
+4. **Mergeable**: No merge conflicts or pending rebases (`!isConflicting`).
+5. **Active & Open**: PR is open, not in draft mode, and not stopped (`!hasStopLabel`).
+
+### B. Invalidation & Removal
+The label is automatically removed if any condition ceases to hold (e.g. new commits pushed, new comments added, CI check failures, or merge conflicts), ensuring humans only review PRs that currently pass all automated criteria.
+

--- a/factory/pkg/commands/watch/github_helpers.go
+++ b/factory/pkg/commands/watch/github_helpers.go
@@ -325,6 +325,71 @@ func shouldAutoReviewPR(ctx context.Context, ghClient *githubv39.Client, owner, 
 	return false
 }
 
+func getReadyForHumanLabel(triggerLabel string) string {
+	if triggerLabel != "" && !strings.EqualFold(triggerLabel, "overseer") {
+		return triggerLabel + "/ready-for-human"
+	}
+	return "overseer/ready-for-human"
+}
+
+func hasReadyForHumanLabel(labels []*githubv39.Label, triggerLabel string) bool {
+	readyLabels := []string{"overseer/ready-for-human"}
+	if triggerLabel != "" && !strings.EqualFold(triggerLabel, "overseer") {
+		readyLabels = append(readyLabels, triggerLabel+"/ready-for-human")
+	}
+	for _, label := range labels {
+		for _, ready := range readyLabels {
+			if strings.EqualFold(label.GetName(), ready) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasCompletedBotReviewOnHead(reviews []*githubv39.PullRequestReview, headSHA string, lastCommitTime time.Time, cfg *config.FactoryConfig) bool {
+	var latestReview *githubv39.PullRequestReview
+	for _, r := range reviews {
+		if isReviewerBot(r.GetUser(), cfg) && (r.GetSubmittedAt().After(lastCommitTime) || r.GetCommitID() == headSHA) {
+			if latestReview == nil || r.GetSubmittedAt().After(latestReview.GetSubmittedAt()) {
+				latestReview = r
+			}
+		}
+	}
+	if latestReview == nil {
+		return false
+	}
+	return latestReview.GetState() != "CHANGES_REQUESTED"
+}
+
+func (w *Watcher) reconcileReadyForHumanLabel(ctx context.Context, num int, prIssue *githubv39.Issue, isReady bool, headSHA string) {
+	if w.ghClient == nil || prIssue == nil {
+		return
+	}
+	readyLabel := getReadyForHumanLabel(w.triggerLabel)
+	hasLabel := hasReadyForHumanLabel(prIssue.Labels, w.triggerLabel)
+
+	if isReady && !hasLabel {
+		if w.DryRun {
+			fmt.Printf("[DRYRUN] Would add label '%s' to PR #%d (passed review on SHA %s)\n", readyLabel, num, headSHA)
+		} else {
+			klog.Infof("PR #%d passed automated review on SHA %s. Adding label '%s'.", num, headSHA, readyLabel)
+			if _, _, err := w.ghClient.Issues.AddLabelsToIssue(ctx, w.Repo.Owner, w.Repo.Repo, num, []string{readyLabel}); err != nil {
+				klog.Errorf("Failed to add label '%s' to PR #%d: %v", readyLabel, num, err)
+			}
+		}
+	} else if !isReady && hasLabel {
+		if w.DryRun {
+			fmt.Printf("[DRYRUN] Would remove label '%s' from PR #%d\n", readyLabel, num)
+		} else {
+			klog.Infof("PR #%d is no longer ready for human review. Removing label '%s'.", num, readyLabel)
+			if _, err := w.ghClient.Issues.RemoveLabelForIssue(ctx, w.Repo.Owner, w.Repo.Repo, num, readyLabel); err != nil {
+				klog.Errorf("Failed to remove label '%s' from PR #%d: %v", readyLabel, num, err)
+			}
+		}
+	}
+}
+
 func (w *Watcher) selectUserForTask(ctx context.Context, taskType string, prNum int) (string, error) {
 	if w.cfg == nil || len(w.cfg.Roles) == 0 {
 		return "", nil // default fallback to factory-user

--- a/factory/pkg/commands/watch/github_helpers_test.go
+++ b/factory/pkg/commands/watch/github_helpers_test.go
@@ -1,6 +1,13 @@
 package watch
 
 import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -493,5 +500,309 @@ func TestAssignedBotUser(t *testing.T) {
 	gotNone := assignedBotUser(issue, []string{"other-bot"})
 	if gotNone != "" {
 		t.Errorf("assignedBotUser = %q, want empty", gotNone)
+	}
+}
+
+func TestGetReadyForHumanLabel(t *testing.T) {
+	if getReadyForHumanLabel("") != "overseer/ready-for-human" {
+		t.Errorf("getReadyForHumanLabel(\"\") = %q, want 'overseer/ready-for-human'", getReadyForHumanLabel(""))
+	}
+	if getReadyForHumanLabel("overseer") != "overseer/ready-for-human" {
+		t.Errorf("getReadyForHumanLabel(\"overseer\") = %q, want 'overseer/ready-for-human'", getReadyForHumanLabel("overseer"))
+	}
+	if getReadyForHumanLabel("mybot") != "mybot/ready-for-human" {
+		t.Errorf("getReadyForHumanLabel(\"mybot\") = %q, want 'mybot/ready-for-human'", getReadyForHumanLabel("mybot"))
+	}
+}
+
+func TestHasReadyForHumanLabel(t *testing.T) {
+	labelsWithOverseer := []*githubv39.Label{{Name: stringPtr("overseer/ready-for-human")}}
+	labelsWithCustom := []*githubv39.Label{{Name: stringPtr("mybot/ready-for-human")}}
+	labelsWithout := []*githubv39.Label{{Name: stringPtr("bug")}}
+
+	if !hasReadyForHumanLabel(labelsWithOverseer, "") {
+		t.Errorf("expected hasReadyForHumanLabel with overseer/ready-for-human to be true")
+	}
+	if !hasReadyForHumanLabel(labelsWithCustom, "mybot") {
+		t.Errorf("expected hasReadyForHumanLabel with mybot/ready-for-human and triggerLabel=mybot to be true")
+	}
+	if !hasReadyForHumanLabel(labelsWithOverseer, "mybot") {
+		t.Errorf("expected hasReadyForHumanLabel with fallback overseer/ready-for-human to be true")
+	}
+	if hasReadyForHumanLabel(labelsWithout, "mybot") {
+		t.Errorf("expected hasReadyForHumanLabel with no ready-for-human label to be false")
+	}
+}
+
+func TestHasCompletedBotReviewOnHead(t *testing.T) {
+	cfg := &config.FactoryConfig{
+		Roles: map[string]config.RoleConfig{
+			"reviewer": {Users: []string{"custom-reviewbot"}},
+		},
+	}
+	now := time.Now()
+	commitTime := now.Add(-10 * time.Minute)
+	headSHA := "abc1234"
+
+	// 1. Review after last commit with COMMENTED
+	reviews1 := []*githubv39.PullRequestReview{
+		{
+			User:        &githubv39.User{Login: stringPtr("custom-reviewbot")},
+			SubmittedAt: &time.Time{},
+			State:       stringPtr("COMMENTED"),
+		},
+	}
+	*reviews1[0].SubmittedAt = now.Add(-5 * time.Minute)
+	if !hasCompletedBotReviewOnHead(reviews1, headSHA, commitTime, cfg) {
+		t.Errorf("expected hasCompletedBotReviewOnHead with recent review to be true")
+	}
+
+	// 2. Review matching headSHA with APPROVED
+	reviews2 := []*githubv39.PullRequestReview{
+		{
+			User:        &githubv39.User{Login: stringPtr("reviewbot-robot")},
+			CommitID:    stringPtr("abc1234"),
+			SubmittedAt: &time.Time{},
+			State:       stringPtr("APPROVED"),
+		},
+	}
+	*reviews2[0].SubmittedAt = now.Add(-15 * time.Minute)
+	if !hasCompletedBotReviewOnHead(reviews2, headSHA, commitTime, cfg) {
+		t.Errorf("expected hasCompletedBotReviewOnHead with matching headSHA to be true")
+	}
+
+	// 3. Review with CHANGES_REQUESTED
+	reviews3 := []*githubv39.PullRequestReview{
+		{
+			User:        &githubv39.User{Login: stringPtr("custom-reviewbot")},
+			CommitID:    stringPtr("abc1234"),
+			SubmittedAt: &time.Time{},
+			State:       stringPtr("CHANGES_REQUESTED"),
+		},
+	}
+	*reviews3[0].SubmittedAt = now.Add(-5 * time.Minute)
+	if hasCompletedBotReviewOnHead(reviews3, headSHA, commitTime, cfg) {
+		t.Errorf("expected hasCompletedBotReviewOnHead with CHANGES_REQUESTED to be false")
+	}
+
+	// 4. Review by non-reviewer bot
+	reviews4 := []*githubv39.PullRequestReview{
+		{
+			User:        &githubv39.User{Login: stringPtr("coder-bot")},
+			CommitID:    stringPtr("abc1234"),
+			SubmittedAt: &time.Time{},
+			State:       stringPtr("APPROVED"),
+		},
+	}
+	*reviews4[0].SubmittedAt = now.Add(-5 * time.Minute)
+	if hasCompletedBotReviewOnHead(reviews4, headSHA, commitTime, cfg) {
+		t.Errorf("expected hasCompletedBotReviewOnHead with non-reviewer bot to be false")
+	}
+
+	// 5. Review before last commit and differing SHA
+	reviews5 := []*githubv39.PullRequestReview{
+		{
+			User:        &githubv39.User{Login: stringPtr("custom-reviewbot")},
+			CommitID:    stringPtr("oldsha123"),
+			SubmittedAt: &time.Time{},
+			State:       stringPtr("APPROVED"),
+		},
+	}
+	*reviews5[0].SubmittedAt = now.Add(-20 * time.Minute)
+	if hasCompletedBotReviewOnHead(reviews5, headSHA, commitTime, cfg) {
+		t.Errorf("expected hasCompletedBotReviewOnHead with stale review on old SHA to be false")
+	}
+
+	// 6. Multiple reviews: first CHANGES_REQUESTED, later COMMENTED/APPROVED
+	reviews6 := []*githubv39.PullRequestReview{
+		{
+			User:        &githubv39.User{Login: stringPtr("custom-reviewbot")},
+			CommitID:    stringPtr("abc1234"),
+			SubmittedAt: &time.Time{},
+			State:       stringPtr("CHANGES_REQUESTED"),
+		},
+		{
+			User:        &githubv39.User{Login: stringPtr("custom-reviewbot")},
+			CommitID:    stringPtr("abc1234"),
+			SubmittedAt: &time.Time{},
+			State:       stringPtr("APPROVED"),
+		},
+	}
+	*reviews6[0].SubmittedAt = now.Add(-10 * time.Minute)
+	*reviews6[1].SubmittedAt = now.Add(-2 * time.Minute)
+	if !hasCompletedBotReviewOnHead(reviews6, headSHA, commitTime, cfg) {
+		t.Errorf("expected hasCompletedBotReviewOnHead with latest APPROVED to be true")
+	}
+}
+
+func TestReconcileReadyForHumanLabel(t *testing.T) {
+	type apiCall struct {
+		method string
+		path   string
+		body   string
+	}
+
+	tests := []struct {
+		name           string
+		triggerLabel   string
+		isReady        bool
+		existingLabels []string
+		dryRun         bool
+		nilClient      bool
+		expectedCalls  []apiCall
+	}{
+		{
+			name:           "Ready without label adds overseer/ready-for-human",
+			triggerLabel:   "",
+			isReady:        true,
+			existingLabels: []string{"bug"},
+			expectedCalls: []apiCall{
+				{
+					method: "POST",
+					path:   "/repos/test-owner/test-repo/issues/100/labels",
+					body:   `["overseer/ready-for-human"]`,
+				},
+			},
+		},
+		{
+			name:           "Not ready with label removes overseer/ready-for-human",
+			triggerLabel:   "",
+			isReady:        false,
+			existingLabels: []string{"bug", "overseer/ready-for-human"},
+			expectedCalls: []apiCall{
+				{
+					method: "DELETE",
+					path:   "/repos/test-owner/test-repo/issues/100/labels/overseer/ready-for-human",
+				},
+			},
+		},
+		{
+			name:           "Custom trigger label adds custom/ready-for-human",
+			triggerLabel:   "mybot",
+			isReady:        true,
+			existingLabels: []string{"bug"},
+			expectedCalls: []apiCall{
+				{
+					method: "POST",
+					path:   "/repos/test-owner/test-repo/issues/100/labels",
+					body:   `["mybot/ready-for-human"]`,
+				},
+			},
+		},
+		{
+			name:           "Custom trigger label removes custom/ready-for-human",
+			triggerLabel:   "mybot",
+			isReady:        false,
+			existingLabels: []string{"mybot/ready-for-human"},
+			expectedCalls: []apiCall{
+				{
+					method: "DELETE",
+					path:   "/repos/test-owner/test-repo/issues/100/labels/mybot/ready-for-human",
+				},
+			},
+		},
+		{
+			name:           "Idempotent: Ready and already has label makes 0 API calls",
+			triggerLabel:   "",
+			isReady:        true,
+			existingLabels: []string{"overseer/ready-for-human"},
+			expectedCalls:  nil,
+		},
+		{
+			name:           "Idempotent: Not ready and already without label makes 0 API calls",
+			triggerLabel:   "",
+			isReady:        false,
+			existingLabels: []string{"bug"},
+			expectedCalls:  nil,
+		},
+		{
+			name:           "Dry-run mode makes 0 API calls",
+			triggerLabel:   "",
+			isReady:        true,
+			existingLabels: []string{"bug"},
+			dryRun:         true,
+			expectedCalls:  nil,
+		},
+		{
+			name:           "Nil GitHub client does not panic and makes 0 calls",
+			triggerLabel:   "",
+			isReady:        true,
+			existingLabels: []string{"bug"},
+			nilClient:      true,
+			expectedCalls:  nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var recordedCalls []apiCall
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				bodyBytes, _ := io.ReadAll(r.Body)
+				recordedCalls = append(recordedCalls, apiCall{
+					method: r.Method,
+					path:   r.URL.Path,
+					body:   strings.TrimSpace(string(bodyBytes)),
+				})
+				if r.Method == "POST" {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`[{"name":"test"}]`))
+				} else if r.Method == "DELETE" {
+					w.WriteHeader(http.StatusNoContent)
+				}
+			}))
+			defer server.Close()
+
+			var ghClient *githubv39.Client
+			if !tc.nilClient {
+				ghClient = githubv39.NewClient(nil)
+				ghClient.BaseURL, _ = url.Parse(server.URL + "/")
+			}
+
+			w := &Watcher{
+				Flags: Flags{
+					DryRun: tc.dryRun,
+					Repo: RepoFlag{
+						Owner: "test-owner",
+						Repo:  "test-repo",
+					},
+				},
+				ghClient:     ghClient,
+				triggerLabel: tc.triggerLabel,
+			}
+
+			prNum := 100
+			var labels []*githubv39.Label
+			for _, l := range tc.existingLabels {
+				labels = append(labels, &githubv39.Label{Name: stringPtr(l)})
+			}
+			prIssue := &githubv39.Issue{
+				Number: &prNum,
+				Labels: labels,
+			}
+
+			w.reconcileReadyForHumanLabel(context.Background(), prNum, prIssue, tc.isReady, "sha123")
+
+			if len(recordedCalls) != len(tc.expectedCalls) {
+				t.Fatalf("recorded %d API calls (%v); want %d (%v)", len(recordedCalls), recordedCalls, len(tc.expectedCalls), tc.expectedCalls)
+			}
+			for i, exp := range tc.expectedCalls {
+				got := recordedCalls[i]
+				if got.method != exp.method {
+					t.Errorf("call [%d] method = %s; want %s", i, got.method, exp.method)
+				}
+				if got.path != exp.path {
+					t.Errorf("call [%d] path = %s; want %s", i, got.path, exp.path)
+				}
+				if exp.body != "" {
+					var gotJSON, expJSON interface{}
+					_ = json.Unmarshal([]byte(got.body), &gotJSON)
+					_ = json.Unmarshal([]byte(exp.body), &expJSON)
+					if got.body != exp.body {
+						t.Errorf("call [%d] body = %s; want %s", i, got.body, exp.body)
+					}
+				}
+			}
+		})
 	}
 }

--- a/factory/pkg/commands/watch/scan_pr.go
+++ b/factory/pkg/commands/watch/scan_pr.go
@@ -86,6 +86,7 @@ func (w *Watcher) processPRs(ctx context.Context, prIssues []*githubv39.Issue) {
 		}
 		if hasStopLabel(prIssue.Labels, w.triggerLabel) {
 			klog.Infof("Skipping PR #%d because it has the stop label ('overseer/stop' or '%s/stop')", num, w.triggerLabel)
+			w.reconcileReadyForHumanLabel(ctx, num, prIssue, false, "")
 			removePendingTasksForNumber(w.incomingDir, num)
 			continue
 		}
@@ -113,6 +114,7 @@ func (w *Watcher) processPRs(ctx context.Context, prIssues []*githubv39.Issue) {
 		syncReferencedIssueLabels(ctx, w.ghClient, w.Repo.Owner, w.Repo.Repo, pr, prIssue)
 		if hasStopLabel(prIssue.Labels, w.triggerLabel) {
 			klog.Infof("Skipping PR #%d after label sync because it has the stop label ('overseer/stop' or '%s/stop')", num, w.triggerLabel)
+			w.reconcileReadyForHumanLabel(ctx, num, prIssue, false, "")
 			removePendingTasksForNumber(w.incomingDir, num)
 			continue
 		}
@@ -159,6 +161,7 @@ func (w *Watcher) processPRs(ctx context.Context, prIssues []*githubv39.Issue) {
 			lastActivity := getLastPRActivityTime(pr, comments, reviews, revCommentsMap, w.githubLogin, bots)
 			if time.Since(lastActivity) > w.PRInactivityTimeout {
 				stopLabel := getStopLabel(w.triggerLabel)
+				w.reconcileReadyForHumanLabel(ctx, num, prIssue, false, headSHA)
 				if w.DryRun {
 					fmt.Printf("[DRYRUN] Would pause automated processing on PR #%d and apply label '%s' due to inactivity since %v\n", num, stopLabel, lastActivity)
 				} else {
@@ -179,6 +182,7 @@ func (w *Watcher) processPRs(ctx context.Context, prIssues []*githubv39.Issue) {
 		isConflicting := pr.Mergeable != nil && !*pr.Mergeable
 
 		if isConflicting {
+			w.reconcileReadyForHumanLabel(ctx, num, prIssue, false, headSHA)
 			if state.lastIteratedSHA != "" && state.lastIteratedSHA == headSHA {
 				klog.Infof("Skipping PR #%d rebase/conflict resolution because an iterate task was already processed for head SHA %s.", num, headSHA)
 				continue
@@ -612,6 +616,23 @@ func (w *Watcher) processPRs(ctx context.Context, prIssues []*githubv39.Issue) {
 						}
 					}
 				}
+			}
+
+			// Check and reconcile ready-for-human label
+			if listReviewsErr == nil {
+				isReviewRequired := shouldAutoReviewPR(ctx, w.ghClient, w.Repo.Owner, w.Repo.Repo, pr, prIssue, w.triggerLabel)
+				hasBotReviewOnHead := hasCompletedBotReviewOnHead(reviews, headSHA, lastCommitTime, w.cfg)
+				reviewSatisfied := !isReviewRequired || hasBotReviewOnHead
+
+				isReadyForHuman := !isConflicting &&
+					!hasFailure &&
+					!hasNewComments &&
+					reviewSatisfied &&
+					!hasStopLabel(prIssue.Labels, w.triggerLabel) &&
+					!pr.GetDraft() &&
+					pr.GetState() == "open"
+
+				w.reconcileReadyForHumanLabel(ctx, num, prIssue, isReadyForHuman, headSHA)
 			}
 		}
 	}


### PR DESCRIPTION
This adds a new ready-for-human label which is managed by the factory watcher. This label is intended to indicate that a PR has passed all checks and automated reviews by the review-bot, and is ready for a human to review the PR. It is implemented in the factory watcher so that it is generic (not skill specific) and deterministic/predictable.