### PR TITLE
fix(watch): gate ready-for-human and bot unassignment on active PR tasks

### DIFF
--- a/factory/pkg/commands/watch/queue.go
+++ b/factory/pkg/commands/watch/queue.go
@@ -314,6 +314,24 @@ func removePendingTasksForNumber(incomingDir string, number int) {
 	}
 }
 
+// hasActivePRTask reports whether any task for the given PR number is currently
+// pending in the incoming queue or executing in the processing directory.
+func hasActivePRTask(incomingDir, processingDir string, number int) bool {
+	prefix := fmt.Sprintf("task-pr-%d-", number)
+	for _, dir := range []string{incomingDir, processingDir} {
+		files, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, f := range files {
+			if !f.IsDir() && strings.HasPrefix(f.Name(), prefix) && strings.HasSuffix(f.Name(), ".yaml") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func isPRTask(taskType string) bool {
 	return taskType == "pr-investigate" || taskType == "pr-comments" || taskType == "pr-iterate"
 }

--- a/factory/pkg/commands/watch/queue_test.go
+++ b/factory/pkg/commands/watch/queue_test.go
@@ -447,3 +447,53 @@ func TestWorkflowCooldownCompletedAt(t *testing.T) {
 		t.Fatalf("lastRunTime = %v, want %v", lastRunTime, completedAt)
 	}
 }
+
+func TestHasActivePRTask(t *testing.T) {
+	tempDir := t.TempDir()
+	incomingDir := filepath.Join(tempDir, "incoming")
+	processingDir := filepath.Join(tempDir, "processing")
+	_ = os.MkdirAll(incomingDir, 0755)
+	_ = os.MkdirAll(processingDir, 0755)
+
+	prNum := 12046
+
+	// 1. Initially empty
+	if hasActivePRTask(incomingDir, processingDir, prNum) {
+		t.Errorf("expected hasActivePRTask to be false for empty directories")
+	}
+
+	// 2. Task in incoming directory
+	incomingTask := filepath.Join(incomingDir, "task-pr-12046-comments.yaml")
+	_ = os.WriteFile(incomingTask, []byte("type: pr-comments\n"), 0644)
+	if !hasActivePRTask(incomingDir, processingDir, prNum) {
+		t.Errorf("expected hasActivePRTask to be true when task is in incomingDir")
+	}
+
+	// 3. Different PR number in incoming directory
+	if hasActivePRTask(incomingDir, processingDir, 9999) {
+		t.Errorf("expected hasActivePRTask to be false for different PR number")
+	}
+
+	// 4. Move task to processing directory
+	_ = os.Remove(incomingTask)
+	processingTask := filepath.Join(processingDir, "task-pr-12046-investigate.yaml")
+	_ = os.WriteFile(processingTask, []byte("type: pr-investigate\n"), 0644)
+	if !hasActivePRTask(incomingDir, processingDir, prNum) {
+		t.Errorf("expected hasActivePRTask to be true when task is in processingDir")
+	}
+
+	// 5. Remove task from processing directory
+	_ = os.Remove(processingTask)
+	if hasActivePRTask(incomingDir, processingDir, prNum) {
+		t.Errorf("expected hasActivePRTask to be false after removing tasks")
+	}
+
+	// 6. Non-matching files (e.g. issues or non-yaml files)
+	issueTask := filepath.Join(incomingDir, "task-issue-12046.yaml")
+	_ = os.WriteFile(issueTask, []byte("type: issue-fix\n"), 0644)
+	logFile := filepath.Join(processingDir, "task-pr-12046-comments.log")
+	_ = os.WriteFile(logFile, []byte("log output"), 0644)
+	if hasActivePRTask(incomingDir, processingDir, prNum) {
+		t.Errorf("expected hasActivePRTask to be false for issue tasks and log files")
+	}
+}

--- a/factory/pkg/commands/watch/scan_pr.go
+++ b/factory/pkg/commands/watch/scan_pr.go
@@ -624,9 +624,12 @@ func (w *Watcher) processPRs(ctx context.Context, prIssues []*githubv39.Issue) {
 				hasBotReviewOnHead := hasCompletedBotReviewOnHead(reviews, headSHA, lastCommitTime, w.cfg)
 				reviewSatisfied := !isReviewRequired || hasBotReviewOnHead
 
+				hasActiveTask := hasActivePRTask(w.incomingDir, w.processingDir, num)
+
 				isReadyForHuman := !isConflicting &&
 					!hasFailure &&
 					!hasNewComments &&
+					!hasActiveTask &&
 					reviewSatisfied &&
 					!hasStopLabel(prIssue.Labels, w.triggerLabel) &&
 					!pr.GetDraft() &&

--- a/factory/pkg/commands/watch/scan_pr_test.go
+++ b/factory/pkg/commands/watch/scan_pr_test.go
@@ -2,9 +2,16 @@ package watch
 
 import (
 	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/common"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/config"
@@ -83,4 +90,155 @@ func TestProcessPRs_DisabledMode(t *testing.T) {
 	}
 	// Should return immediately without doing any operations
 	w.processPRs(context.Background(), nil)
+}
+
+func TestProcessPRs_ReadyForHuman_GatedByActiveTask(t *testing.T) {
+	tempDir := t.TempDir()
+	incomingDir := filepath.Join(tempDir, "incoming")
+	processingDir := filepath.Join(tempDir, "processing")
+	processedDir := filepath.Join(tempDir, "processed")
+	_ = os.MkdirAll(incomingDir, 0755)
+	_ = os.MkdirAll(processingDir, 0755)
+	_ = os.MkdirAll(processedDir, 0755)
+
+	prNum := 10
+	mergeable := true
+	headSHA := "sha-1234"
+	now := time.Now()
+
+	var addedLabels []string
+	var unassignCalls []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/pulls/10":
+			pr := &githubv39.PullRequest{
+				Number:    &prNum,
+				Mergeable: &mergeable,
+				State:     stringPtr("open"),
+				User:      &githubv39.User{Login: stringPtr("bot1")},
+				Head:      &githubv39.PullRequestBranch{SHA: stringPtr(headSHA)},
+				CreatedAt: &now,
+			}
+			_ = json.NewEncoder(w).Encode(pr)
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/pulls/10/commits":
+			commits := []*githubv39.RepositoryCommit{
+				{
+					SHA: stringPtr(headSHA),
+					Commit: &githubv39.Commit{
+						Committer: &githubv39.CommitAuthor{Date: &now},
+					},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(commits)
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/issues/10/comments":
+			_ = json.NewEncoder(w).Encode([]*githubv39.IssueComment{})
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/pulls/10/reviews":
+			reviews := []*githubv39.PullRequestReview{
+				{
+					User:        &githubv39.User{Login: stringPtr("reviewbot")},
+					CommitID:    stringPtr(headSHA),
+					State:       stringPtr("APPROVED"),
+					SubmittedAt: &now,
+				},
+			}
+			_ = json.NewEncoder(w).Encode(reviews)
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/commits/"+headSHA+"/check-runs":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"check_runs": []interface{}{}})
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/statuses/"+headSHA:
+			_ = json.NewEncoder(w).Encode([]interface{}{})
+		case r.Method == "POST" && r.URL.Path == "/repos/test-owner/test-repo/issues/10/labels":
+			var labels []string
+			_ = json.NewDecoder(r.Body).Decode(&labels)
+			addedLabels = append(addedLabels, labels...)
+			_ = json.NewEncoder(w).Encode([]interface{}{})
+		case r.Method == "DELETE" && r.URL.Path == "/repos/test-owner/test-repo/issues/10/assignees":
+			bodyBytes, _ := io.ReadAll(r.Body)
+			unassignCalls = append(unassignCalls, strings.TrimSpace(string(bodyBytes)))
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := githubv39.NewClient(nil)
+	ghClient.BaseURL, _ = url.Parse(server.URL + "/")
+
+	w := &Watcher{
+		Flags: Flags{
+			Repo: RepoFlag{
+				Owner: "test-owner",
+				Repo:  "test-repo",
+			},
+			QueueDir: tempDir,
+		},
+		ghClient:      ghClient,
+		allBotUsers:   []string{"bot1"},
+		githubLogin:   "bot1",
+		incomingDir:   incomingDir,
+		processingDir: processingDir,
+		processedDir:  processedDir,
+		triggerLabel:  "factory",
+		processedPRs:  make(map[int]prWatchState),
+		cfg: &config.FactoryConfig{
+			Roles: map[string]config.RoleConfig{
+				"reviewer": {Users: []string{"reviewbot"}},
+			},
+		},
+	}
+
+	prIssue := &githubv39.Issue{
+		Number: &prNum,
+		Assignees: []*githubv39.User{
+			{Login: stringPtr("bot1")},
+		},
+		Labels: []*githubv39.Label{
+			{Name: stringPtr("factory")},
+		},
+	}
+
+	// 1. When a task is pending in incomingDir, PR must NOT be marked ready for human
+	taskPath := filepath.Join(incomingDir, "task-pr-10-comments.yaml")
+	_ = os.WriteFile(taskPath, []byte("type: pr-comments\n"), 0644)
+
+	w.processPRs(context.Background(), []*githubv39.Issue{prIssue})
+
+	if len(addedLabels) != 0 {
+		t.Errorf("expected 0 added labels while task is in incomingDir, got %d (%v)", len(addedLabels), addedLabels)
+	}
+	if len(unassignCalls) != 0 {
+		t.Errorf("expected 0 unassign calls while task is in incomingDir, got %d (%v)", len(unassignCalls), unassignCalls)
+	}
+
+	// 2. When the task moves to processingDir, PR must still NOT be marked ready for human
+	_ = os.Remove(taskPath)
+	processingTaskPath := filepath.Join(processingDir, "task-pr-10-comments.yaml")
+	_ = os.WriteFile(processingTaskPath, []byte("type: pr-comments\n"), 0644)
+
+	w.processPRs(context.Background(), []*githubv39.Issue{prIssue})
+
+	if len(addedLabels) != 0 {
+		t.Errorf("expected 0 added labels while task is in processingDir, got %d (%v)", len(addedLabels), addedLabels)
+	}
+	if len(unassignCalls) != 0 {
+		t.Errorf("expected 0 unassign calls while task is in processingDir, got %d (%v)", len(unassignCalls), unassignCalls)
+	}
+
+	// 3. When the task is completed and moved to processedDir, PR SHOULD be marked ready for human
+	_ = os.Remove(processingTaskPath)
+	processedTaskPath := filepath.Join(processedDir, "task-pr-10-comments.yaml")
+	_ = os.WriteFile(processedTaskPath, []byte("type: pr-comments\nstatus: Completed\n"), 0644)
+
+	w.processPRs(context.Background(), []*githubv39.Issue{prIssue})
+
+	if len(addedLabels) != 1 || addedLabels[0] != "factory/ready-for-human" {
+		t.Errorf("expected ready-for-human label added after task completion, got %v", addedLabels)
+	}
+	if len(unassignCalls) != 1 {
+		t.Errorf("expected 1 unassign call after task completion, got %d (%v)", len(unassignCalls), unassignCalls)
+	}
 }


### PR DESCRIPTION
Why ready-for-human flapping occurred:
When review comments were detected on a PR (such as PR #12046), the watcher enqueued a task (task-pr-<num>-comments.yaml) in incomingDir, acknowledged the comments on GitHub with :eyes: reactions, and set state.lastCommentAddressedTime = time.Now(), removing the ready-for-human label.

However, while the task remained queued in incomingDir or was actively executing inside a sandbox in processingDir, subsequent scan cycles checked the PR again. In these subsequent cycles, hasNewComments evaluated to false because the comments were already marked as acknowledged. Because isReadyForHuman only inspected instantaneous GitHub flags without checking whether a task was already pending or running for that PR, isReadyForHuman falsely evaluated to true. This caused the watcher to prematurely re-add overseer/ready-for-human and unassign the bot while the task was still queued or while Overseer was actively spinning up a sandbox to address the feedback.

How this change resolves the issue:
1. Active PR Task Checking:
   - Introduces hasActivePRTask(incomingDir, processingDir, num) to check if any PR task matching task-pr-<num>-*.yaml exists in either the incoming queue or the processing directory.
2. Gate isReadyForHuman on Active Tasks:
   - Updates isReadyForHuman in scan_pr.go to require !hasActiveTask.
   - Prevents ready-for-human from being added and prevents bot unassignment while Overseer has queued or in-flight work for the PR.
3. Test Coverage:
   - Adds TestHasActivePRTask to queue_test.go.
   - Adds TestProcessPRs_ReadyForHuman_GatedByActiveTask to scan_pr_test.go.