### PR TITLE
fix(watch): gate ready-for-human label and reviews on pending CI checks

### DIFF
--- a/factory/pkg/commands/common/github.go
+++ b/factory/pkg/commands/common/github.go
@@ -76,3 +76,35 @@ func ListAllCheckRuns(ctx context.Context, client *githubv39.Client, owner, repo
 	}
 	return deduplicated, nil
 }
+
+// ListAllStatuses retrieves all commit statuses for a ref handling pagination and deduplicating by context (keeping the latest status per context).
+func ListAllStatuses(ctx context.Context, client *githubv39.Client, owner, repo, ref string) ([]*githubv39.RepoStatus, error) {
+	var allStatuses []*githubv39.RepoStatus
+	opts := &githubv39.ListOptions{
+		PerPage: 100,
+	}
+	for {
+		statuses, resp, err := client.Repositories.ListStatuses(ctx, owner, repo, ref, opts)
+		if err != nil {
+			return nil, err
+		}
+		allStatuses = append(allStatuses, statuses...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	// Deduplicate statuses by context, keeping only the latest status (first encountered since ListStatuses is reverse-chronological)
+	seenContexts := make(map[string]bool)
+	var deduplicated []*githubv39.RepoStatus
+	for _, status := range allStatuses {
+		ctxName := status.GetContext()
+		if seenContexts[ctxName] {
+			continue
+		}
+		seenContexts[ctxName] = true
+		deduplicated = append(deduplicated, status)
+	}
+	return deduplicated, nil
+}

--- a/factory/pkg/commands/common/github_test.go
+++ b/factory/pkg/commands/common/github_test.go
@@ -1,6 +1,11 @@
 package common
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	githubv39 "github.com/google/go-github/v39/github"
@@ -71,5 +76,119 @@ func TestGetReferencedIssues(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func int64Ptr(i int64) *int64 {
+	return &i
+}
+
+func TestListAllCheckRuns(t *testing.T) {
+	// Simulated check runs with duplicate names where higher ID is newer
+	runs := []*githubv39.CheckRun{
+		{
+			ID:         int64Ptr(10),
+			Name:       stringPtr("unit-tests"),
+			Status:     stringPtr("completed"),
+			Conclusion: stringPtr("failure"),
+		},
+		{
+			ID:         int64Ptr(20),
+			Name:       stringPtr("unit-tests"),
+			Status:     stringPtr("completed"),
+			Conclusion: stringPtr("success"),
+		},
+		{
+			ID:         int64Ptr(15),
+			Name:       stringPtr("lint"),
+			Status:     stringPtr("completed"),
+			Conclusion: stringPtr("success"),
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"check_runs": runs})
+	}))
+	defer server.Close()
+
+	client := githubv39.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	result, err := ListAllCheckRuns(context.Background(), client, "owner", "repo", "sha123")
+	if err != nil {
+		t.Fatalf("ListAllCheckRuns returned error: %v", err)
+	}
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 deduplicated check runs, got %d", len(result))
+	}
+
+	var unitTestRun *githubv39.CheckRun
+	for _, r := range result {
+		if r.GetName() == "unit-tests" {
+			unitTestRun = r
+		}
+	}
+
+	if unitTestRun == nil {
+		t.Fatalf("expected unit-tests check run in results")
+	}
+	if unitTestRun.GetID() != 20 || unitTestRun.GetConclusion() != "success" {
+		t.Errorf("expected unit-tests check run with ID 20 and conclusion success, got ID %d conclusion %s", unitTestRun.GetID(), unitTestRun.GetConclusion())
+	}
+}
+
+func TestListAllStatuses(t *testing.T) {
+	// Simulated statuses returned newest first by GitHub API
+	statuses := []*githubv39.RepoStatus{
+		{
+			Context: stringPtr("ci/prow"),
+			State:   stringPtr("success"),
+		},
+		{
+			Context: stringPtr("cla/google"),
+			State:   stringPtr("pending"),
+		},
+		{
+			Context: stringPtr("ci/prow"),
+			State:   stringPtr("pending"),
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(statuses)
+	}))
+	defer server.Close()
+
+	client := githubv39.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	result, err := ListAllStatuses(context.Background(), client, "owner", "repo", "sha123")
+	if err != nil {
+		t.Fatalf("ListAllStatuses returned error: %v", err)
+	}
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 deduplicated statuses, got %d", len(result))
+	}
+
+	var prowStatus *githubv39.RepoStatus
+	for _, s := range result {
+		if s.GetContext() == "ci/prow" {
+			prowStatus = s
+		}
+	}
+
+	if prowStatus == nil {
+		t.Fatalf("expected ci/prow status in results")
+	}
+	if prowStatus.GetState() != "success" {
+		t.Errorf("expected ci/prow status to have state success (newest), got %s", prowStatus.GetState())
 	}
 }

--- a/factory/pkg/commands/pr.go
+++ b/factory/pkg/commands/pr.go
@@ -162,7 +162,7 @@ func runInvestigate(ctx context.Context, prURL, prompt string, continueSession b
 	}
 
 	var failedProwRuns []string
-	statuses, _, err := ghClient.Repositories.ListStatuses(ctx, owner, repo, headSHA, nil)
+	statuses, err := common.ListAllStatuses(ctx, ghClient, owner, repo, headSHA)
 	if err == nil {
 		for _, status := range statuses {
 			if status.GetState() == "failure" || status.GetState() == "error" {
@@ -710,7 +710,7 @@ func runPRWatch(ctx context.Context, prURL string, interval time.Duration, dryRu
 			}
 		}
 
-		statuses, _, err := ghClient.Repositories.ListStatuses(ctx, owner, repo, headSHA, nil)
+		statuses, err := common.ListAllStatuses(ctx, ghClient, owner, repo, headSHA)
 		if err == nil {
 			for _, status := range statuses {
 				if status.GetState() == "failure" || status.GetState() == "error" {

--- a/factory/pkg/commands/watch/scan_pr.go
+++ b/factory/pkg/commands/watch/scan_pr.go
@@ -238,25 +238,30 @@ func (w *Watcher) processPRs(ctx context.Context, prIssues []*githubv39.Issue) {
 			continue
 		}
 
-		// Check CI Check Failures
+		// Check CI Check Failures and Pending Status
 		hasFailure := false
+		hasPending := false
 		checkRuns, err := common.ListAllCheckRuns(ctx, w.ghClient, w.Repo.Owner, w.Repo.Repo, headSHA)
 		if err == nil {
 			for _, run := range checkRuns {
+				if run.GetStatus() != "completed" {
+					hasPending = true
+				}
 				c := run.GetConclusion()
-				if c == "failure" || c == "timed_out" || c == "cancelled" {
+				if c == "failure" || c == "timed_out" || c == "cancelled" || c == "action_required" || c == "stale" {
 					hasFailure = true
-					break
 				}
 			}
 		}
 
-		statuses, _, err := w.ghClient.Repositories.ListStatuses(ctx, w.Repo.Owner, w.Repo.Repo, headSHA, nil)
+		statuses, err := common.ListAllStatuses(ctx, w.ghClient, w.Repo.Owner, w.Repo.Repo, headSHA)
 		if err == nil {
 			for _, status := range statuses {
+				if status.GetState() == "pending" {
+					hasPending = true
+				}
 				if status.GetState() == "failure" || status.GetState() == "error" {
 					hasFailure = true
-					break
 				}
 			}
 		}
@@ -514,7 +519,7 @@ func (w *Watcher) processPRs(ctx context.Context, prIssues []*githubv39.Issue) {
 						}
 					}
 				}
-			} else if !hasFailure && !isApproved && state.lastReviewedSHA != headSHA && shouldAutoReviewPR(ctx, w.ghClient, w.Repo.Owner, w.Repo.Repo, pr, prIssue, w.triggerLabel) {
+			} else if !hasFailure && !hasPending && !isApproved && state.lastReviewedSHA != headSHA && shouldAutoReviewPR(ctx, w.ghClient, w.Repo.Owner, w.Repo.Repo, pr, prIssue, w.triggerLabel) {
 				hasBotReviewAfterLastCommit := false
 				for _, r := range reviews {
 					if isBotReply(r.GetUser(), w.githubLogin, bots) && (r.GetSubmittedAt().After(lastCommitTime) || r.GetCommitID() == headSHA) {
@@ -590,6 +595,7 @@ func (w *Watcher) processPRs(ctx context.Context, prIssues []*githubv39.Issue) {
 
 				isReadyForHuman := !isConflicting &&
 					!hasFailure &&
+					!hasPending &&
 					!hasNewComments &&
 					!hasActiveTask &&
 					reviewSatisfied &&

--- a/factory/pkg/commands/watch/scan_pr_test.go
+++ b/factory/pkg/commands/watch/scan_pr_test.go
@@ -13,9 +13,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/clients"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/common"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/config"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/k8s"
 	githubv39 "github.com/google/go-github/v39/github"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 )
 
 func TestProcessPRs_Filters(t *testing.T) {
@@ -146,7 +151,7 @@ func TestProcessPRs_ReadyForHuman_GatedByActiveTask(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(reviews)
 		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/commits/"+headSHA+"/check-runs":
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{"check_runs": []interface{}{}})
-		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/statuses/"+headSHA:
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/commits/"+headSHA+"/statuses":
 			_ = json.NewEncoder(w).Encode([]interface{}{})
 		case r.Method == "POST" && r.URL.Path == "/repos/test-owner/test-repo/issues/10/labels":
 			var labels []string
@@ -295,7 +300,7 @@ func TestProcessPRs_UnassignOnReadyForHuman(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(reviews)
 		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/commits/"+headSHA+"/check-runs":
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{"check_runs": []interface{}{}})
-		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/statuses/"+headSHA:
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/commits/"+headSHA+"/statuses":
 			_ = json.NewEncoder(w).Encode([]interface{}{})
 		case r.Method == "POST" && r.URL.Path == "/repos/test-owner/test-repo/issues/10/labels":
 			_ = json.NewEncoder(w).Encode([]interface{}{})
@@ -354,5 +359,380 @@ func TestProcessPRs_UnassignOnReadyForHuman(t *testing.T) {
 	}
 	if !strings.Contains(unassignCalls[0], "bot1") {
 		t.Errorf("expected unassign call body to contain 'bot1', got %s", unassignCalls[0])
+	}
+}
+
+func TestProcessPRs_ReadyForHuman_GatedByPendingCheckRuns(t *testing.T) {
+	tempDir := t.TempDir()
+	incomingDir := filepath.Join(tempDir, "incoming")
+	processingDir := filepath.Join(tempDir, "processing")
+	processedDir := filepath.Join(tempDir, "processed")
+	_ = os.MkdirAll(incomingDir, 0755)
+	_ = os.MkdirAll(processingDir, 0755)
+	_ = os.MkdirAll(processedDir, 0755)
+
+	prNum := 10
+	mergeable := true
+	headSHA := "sha-1234"
+	now := time.Now()
+
+	var addedLabels []string
+	var removedLabels []string
+	checkRunStatus := "in_progress"
+	checkRunConclusion := ""
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/pulls/10":
+			pr := &githubv39.PullRequest{
+				Number:    &prNum,
+				Mergeable: &mergeable,
+				State:     stringPtr("open"),
+				User:      &githubv39.User{Login: stringPtr("bot1")},
+				Head:      &githubv39.PullRequestBranch{SHA: stringPtr(headSHA)},
+				CreatedAt: &now,
+			}
+			_ = json.NewEncoder(w).Encode(pr)
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/pulls/10/commits":
+			commits := []*githubv39.RepositoryCommit{
+				{
+					SHA: stringPtr(headSHA),
+					Commit: &githubv39.Commit{
+						Committer: &githubv39.CommitAuthor{Date: &now},
+					},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(commits)
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/issues/10/comments":
+			_ = json.NewEncoder(w).Encode([]*githubv39.IssueComment{})
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/pulls/10/reviews":
+			_ = json.NewEncoder(w).Encode([]*githubv39.PullRequestReview{})
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/commits/"+headSHA+"/check-runs":
+			runs := []*githubv39.CheckRun{
+				{
+					ID:         githubv39.Int64(1),
+					Name:       stringPtr("tests"),
+					Status:     stringPtr(checkRunStatus),
+					Conclusion: stringPtr(checkRunConclusion),
+				},
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"check_runs": runs})
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/commits/"+headSHA+"/statuses":
+			_ = json.NewEncoder(w).Encode([]interface{}{})
+		case r.Method == "POST" && r.URL.Path == "/repos/test-owner/test-repo/issues/10/labels":
+			var labels []string
+			_ = json.NewDecoder(r.Body).Decode(&labels)
+			addedLabels = append(addedLabels, labels...)
+			_ = json.NewEncoder(w).Encode([]interface{}{})
+		case r.Method == "DELETE" && strings.HasPrefix(r.URL.Path, "/repos/test-owner/test-repo/issues/10/labels/"):
+			label := strings.TrimPrefix(r.URL.Path, "/repos/test-owner/test-repo/issues/10/labels/")
+			removedLabels = append(removedLabels, label)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{})
+		case r.Method == "DELETE" && r.URL.Path == "/repos/test-owner/test-repo/issues/10/assignees":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := githubv39.NewClient(nil)
+	ghClient.BaseURL, _ = url.Parse(server.URL + "/")
+
+	w := &Watcher{
+		Flags: Flags{
+			Repo: RepoFlag{
+				Owner: "test-owner",
+				Repo:  "test-repo",
+			},
+			QueueDir: tempDir,
+		},
+		ghClient:      ghClient,
+		allBotUsers:   []string{"bot1"},
+		githubLogin:   "bot1",
+		incomingDir:   incomingDir,
+		processingDir: processingDir,
+		processedDir:  processedDir,
+		triggerLabel:  "factory",
+		processedPRs:  make(map[int]prWatchState),
+	}
+
+	prIssue := &githubv39.Issue{
+		Number: &prNum,
+		Assignees: []*githubv39.User{
+			{Login: stringPtr("bot1")},
+		},
+		Labels: []*githubv39.Label{
+			{Name: stringPtr("factory")},
+		},
+	}
+
+	// 1. Check runs are in_progress -> label must NOT be added
+	w.processPRs(context.Background(), []*githubv39.Issue{prIssue})
+	if len(addedLabels) != 0 {
+		t.Errorf("expected 0 added labels while check runs are in_progress, got %v", addedLabels)
+	}
+
+	// 2. Check runs complete successfully -> label SHOULD be added
+	checkRunStatus = "completed"
+	checkRunConclusion = "success"
+	w.processPRs(context.Background(), []*githubv39.Issue{prIssue})
+	if len(addedLabels) != 1 || addedLabels[0] != "factory/ready-for-human" {
+		t.Errorf("expected ready-for-human label added after check runs completed, got %v", addedLabels)
+	}
+
+	// 3. New commit or check run becomes queued/in_progress on PR with label -> label SHOULD be removed
+	prIssue.Labels = append(prIssue.Labels, &githubv39.Label{Name: stringPtr("factory/ready-for-human")})
+	checkRunStatus = "queued"
+	checkRunConclusion = ""
+	w.processPRs(context.Background(), []*githubv39.Issue{prIssue})
+	if len(removedLabels) != 1 || removedLabels[0] != "factory/ready-for-human" {
+		t.Errorf("expected ready-for-human label removed when checks become queued, got %v", removedLabels)
+	}
+}
+
+func TestProcessPRs_ReadyForHuman_GatedByPendingCommitStatus(t *testing.T) {
+	tempDir := t.TempDir()
+	incomingDir := filepath.Join(tempDir, "incoming")
+	processingDir := filepath.Join(tempDir, "processing")
+	processedDir := filepath.Join(tempDir, "processed")
+	_ = os.MkdirAll(incomingDir, 0755)
+	_ = os.MkdirAll(processingDir, 0755)
+	_ = os.MkdirAll(processedDir, 0755)
+
+	prNum := 10
+	mergeable := true
+	headSHA := "sha-1234"
+	now := time.Now()
+
+	var addedLabels []string
+	commitState := "pending"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/pulls/10":
+			pr := &githubv39.PullRequest{
+				Number:    &prNum,
+				Mergeable: &mergeable,
+				State:     stringPtr("open"),
+				User:      &githubv39.User{Login: stringPtr("bot1")},
+				Head:      &githubv39.PullRequestBranch{SHA: stringPtr(headSHA)},
+				CreatedAt: &now,
+			}
+			_ = json.NewEncoder(w).Encode(pr)
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/pulls/10/commits":
+			commits := []*githubv39.RepositoryCommit{
+				{
+					SHA: stringPtr(headSHA),
+					Commit: &githubv39.Commit{
+						Committer: &githubv39.CommitAuthor{Date: &now},
+					},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(commits)
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/issues/10/comments":
+			_ = json.NewEncoder(w).Encode([]*githubv39.IssueComment{})
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/pulls/10/reviews":
+			_ = json.NewEncoder(w).Encode([]*githubv39.PullRequestReview{})
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/commits/"+headSHA+"/check-runs":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"check_runs": []interface{}{}})
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/commits/"+headSHA+"/statuses":
+			statuses := []*githubv39.RepoStatus{
+				{
+					Context: stringPtr("ci/prow/presubmit"),
+					State:   stringPtr(commitState),
+				},
+			}
+			_ = json.NewEncoder(w).Encode(statuses)
+		case r.Method == "POST" && r.URL.Path == "/repos/test-owner/test-repo/issues/10/labels":
+			var labels []string
+			_ = json.NewDecoder(r.Body).Decode(&labels)
+			addedLabels = append(addedLabels, labels...)
+			_ = json.NewEncoder(w).Encode([]interface{}{})
+		case r.Method == "DELETE" && r.URL.Path == "/repos/test-owner/test-repo/issues/10/assignees":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := githubv39.NewClient(nil)
+	ghClient.BaseURL, _ = url.Parse(server.URL + "/")
+
+	w := &Watcher{
+		Flags: Flags{
+			Repo: RepoFlag{
+				Owner: "test-owner",
+				Repo:  "test-repo",
+			},
+			QueueDir: tempDir,
+		},
+		ghClient:      ghClient,
+		allBotUsers:   []string{"bot1"},
+		githubLogin:   "bot1",
+		incomingDir:   incomingDir,
+		processingDir: processingDir,
+		processedDir:  processedDir,
+		triggerLabel:  "factory",
+		processedPRs:  make(map[int]prWatchState),
+	}
+
+	prIssue := &githubv39.Issue{
+		Number: &prNum,
+		Assignees: []*githubv39.User{
+			{Login: stringPtr("bot1")},
+		},
+		Labels: []*githubv39.Label{
+			{Name: stringPtr("factory")},
+		},
+	}
+
+	// 1. Status is pending -> label must NOT be added
+	w.processPRs(context.Background(), []*githubv39.Issue{prIssue})
+	if len(addedLabels) != 0 {
+		t.Errorf("expected 0 added labels while commit status is pending, got %v", addedLabels)
+	}
+
+	// 2. Status is success -> label SHOULD be added
+	commitState = "success"
+	w.processPRs(context.Background(), []*githubv39.Issue{prIssue})
+	if len(addedLabels) != 1 || addedLabels[0] != "factory/ready-for-human" {
+		t.Errorf("expected ready-for-human label added after commit status became success, got %v", addedLabels)
+	}
+}
+
+func TestProcessPRs_Review_GatedByPendingCheckRuns(t *testing.T) {
+	tempDir := t.TempDir()
+	incomingDir := filepath.Join(tempDir, "incoming")
+	processingDir := filepath.Join(tempDir, "processing")
+	processedDir := filepath.Join(tempDir, "processed")
+	_ = os.MkdirAll(incomingDir, 0755)
+	_ = os.MkdirAll(processingDir, 0755)
+	_ = os.MkdirAll(processedDir, 0755)
+
+	prNum := 10
+	mergeable := true
+	headSHA := "sha-1234"
+	now := time.Now()
+
+	checkRunStatus := "in_progress"
+	checkRunConclusion := ""
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/pulls/10":
+			pr := &githubv39.PullRequest{
+				Number:    &prNum,
+				Mergeable: &mergeable,
+				State:     stringPtr("open"),
+				User:      &githubv39.User{Login: stringPtr("bot1")},
+				Head:      &githubv39.PullRequestBranch{SHA: stringPtr(headSHA)},
+				CreatedAt: &now,
+			}
+			_ = json.NewEncoder(w).Encode(pr)
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/pulls/10/commits":
+			commits := []*githubv39.RepositoryCommit{
+				{
+					SHA: stringPtr(headSHA),
+					Commit: &githubv39.Commit{
+						Committer: &githubv39.CommitAuthor{Date: &now},
+					},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(commits)
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/issues/10/comments":
+			_ = json.NewEncoder(w).Encode([]*githubv39.IssueComment{})
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/pulls/10/reviews":
+			_ = json.NewEncoder(w).Encode([]*githubv39.PullRequestReview{})
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/commits/"+headSHA+"/check-runs":
+			runs := []*githubv39.CheckRun{
+				{
+					ID:         githubv39.Int64(1),
+					Name:       stringPtr("tests"),
+					Status:     stringPtr(checkRunStatus),
+					Conclusion: stringPtr(checkRunConclusion),
+				},
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"check_runs": runs})
+		case r.Method == "GET" && r.URL.Path == "/repos/test-owner/test-repo/commits/"+headSHA+"/statuses":
+			_ = json.NewEncoder(w).Encode([]interface{}{})
+		case r.Method == "DELETE" && r.URL.Path == "/repos/test-owner/test-repo/issues/10/assignees":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := githubv39.NewClient(nil)
+	ghClient.BaseURL, _ = url.Parse(server.URL + "/")
+
+	scheme := runtime.NewScheme()
+	fakeDynamic := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{
+		k8s.SandboxGVR: "SandboxList",
+	})
+	kubeClient := &clients.KubernetesClient{
+		DynamicClient: fakeDynamic,
+	}
+
+	w := &Watcher{
+		Flags: Flags{
+			Repo: RepoFlag{
+				Owner: "test-owner",
+				Repo:  "test-repo",
+			},
+			QueueDir: tempDir,
+		},
+		kubeClient:    kubeClient,
+		ghClient:      ghClient,
+		allBotUsers:   []string{"bot1"},
+		githubLogin:   "bot1",
+		incomingDir:   incomingDir,
+		processingDir: processingDir,
+		processedDir:  processedDir,
+		triggerLabel:  "factory",
+		processedPRs:  make(map[int]prWatchState),
+		cfg: &config.FactoryConfig{
+			Roles: map[string]config.RoleConfig{
+				"reviewer": {Users: []string{"reviewbot"}},
+			},
+		},
+	}
+
+	prIssue := &githubv39.Issue{
+		Number: &prNum,
+		Assignees: []*githubv39.User{
+			{Login: stringPtr("bot1")},
+		},
+		Labels: []*githubv39.Label{
+			{Name: stringPtr("factory")},
+			{Name: stringPtr("factory/review")},
+		},
+	}
+
+	// 1. While CI is in_progress -> review task must NOT be queued
+	w.processPRs(context.Background(), []*githubv39.Issue{prIssue})
+	reviewTaskFile := filepath.Join(incomingDir, "task-pr-10-review.yaml")
+	if _, err := os.Stat(reviewTaskFile); !os.IsNotExist(err) {
+		t.Errorf("expected review task NOT to be created while CI is in_progress")
+	}
+
+	// 2. Once CI completes successfully -> review task SHOULD be queued
+	checkRunStatus = "completed"
+	checkRunConclusion = "success"
+	w.processPRs(context.Background(), []*githubv39.Issue{prIssue})
+	if _, err := os.Stat(reviewTaskFile); os.IsNotExist(err) {
+		t.Errorf("expected review task to be created once CI completes successfully")
 	}
 }


### PR DESCRIPTION
Why ready-for-human label flapping occurred:
When a PR had active or newly pushed commits (such as PR #12607), the factory watcher scanned the PR while CI presubmit workflows were still running. At that point, active check runs had status "queued" or "in_progress" with null/empty conclusions. Because isReadyForHuman only checked !hasFailure, and no check runs had failed *yet*, hasFailure evaluated to false. Since bot reviews were not requested (or already satisfied), isReadyForHuman falsely evaluated to true. This caused the watcher to prematurely apply the overseer/ready-for-human label and unassign the bot while CI checks were still in progress. Once a long-running test eventually failed 10-15 minutes later, hasFailure became true and the watcher removed the label, causing repeated add/remove flapping cycles.

How this change resolves the issue:

1. Pending CI State Tracking:
   - Check Runs: Evaluates run.GetStatus() != "completed" and sets hasPending = true. Also flags non-passing completed conclusions ("failure", "timed_out", "cancelled", "action_required", "stale") as hasFailure = true.
   - Commit Statuses: Evaluates status.GetState() == "pending" and sets hasPending = true.

2. Reusable ListAllStatuses Helper:
   - Implements common.ListAllStatuses in pkg/commands/common/github.go to handle pagination and deduplicate commit status history by context name (keeping the newest status per context from the reverse-chronological list).
   - Refactors scan_pr.go and pr.go to use common.ListAllStatuses instead of unpaginated raw status calls.

3. Gate isReadyForHuman and Bot Review on Completed CI:
   - Updates isReadyForHuman in scan_pr.go to require !hasPending in addition to !hasFailure.
   - Updates automated reviewer bot triggering in scan_pr.go to require !hasPending so reviews are not run on incomplete/in-progress builds.

4. Test Coverage:
   - Adds TestListAllCheckRuns and TestListAllStatuses in common/github_test.go to verify pagination and deduplication logic.
   - Adds TestProcessPRs_ReadyForHuman_GatedByPendingCheckRuns in scan_pr_test.go to test that ready-for-human is blocked when check runs are in-progress and removed when checks become queued.
   - Adds TestProcessPRs_ReadyForHuman_GatedByPendingCommitStatus in scan_pr_test.go to test that ready-for-human is blocked when commit statuses are pending.
   - Adds TestProcessPRs_Review_GatedByPendingCheckRuns in scan_pr_test.go to verify review task queueing is gated on completed CI.