### PR TITLE
feat(watch): propagate human assignees from workflow/parent issues to PRs

### DIFF
--- a/.agents/workflows/kcc-example.txt
+++ b/.agents/workflows/kcc-example.txt
@@ -12,7 +12,7 @@ This is a meta-skill describing the steps to migrate a KCC resource kind to a pr
 
 Instead of doing the coding yourself under this skill, you will coordinate and orchestrate:
 1. Planning the migration steps.
-2. Opening GitHub issues for each step, labeling them with `overseer`, and leaving them unassigned (or assigning them to the current bot user).
+2. Opening GitHub issues for each step, linking them to the parent workflow issue (including `Workflow Issue: #${SESSION_ID#issue-}` in the body), labeling them with `overseer`, and leaving them unassigned (or assigning them to the human assignee(s) of the parent workflow issue).
 3. Monitoring progress of the Pull Requests.
 4. Opening subsequent issues once the prior steps are successfully completed.
 
@@ -88,10 +88,12 @@ The resource must have a direct KRM type (`_types.go`) scaffolded and updated vi
    
 **GitHub Issue Details for Existing Terraform/DCL Resource:**
 *   **Title:** `Implement direct KRM types and generate.sh for {kind}`
-*   **Assignee:** (leave unassigned or assign to the current bot)
+*   **Assignee:** (leave unassigned or assign to the human assignee(s) of the parent workflow issue)
 *   **Labels:** `overseer`, `overseer/review`
 *   **Body:**
     ```
+    Workflow Issue: #${SESSION_ID#issue-}
+
     Please follow the skill .gemini/skills/crd-mapper-fuzzer-existing-type/SKILL.md for {kind}.
 
     Make sure to configure/update `generate.sh` in the resource's service directory (e.g., `apis/{service}/{version}/generate.sh`), ensuring that the direct KRM type is strictly schema-compatible with the existing CRD.
@@ -115,10 +117,12 @@ The resource kind must have an identity and reference type that follow our canon
 
 **GitHub Issue Details:**
 *   **Title:** `Move {kind} to identity and refs pattern`
-*   **Assignee:** (leave unassigned or assign to the current bot)
+*   **Assignee:** (leave unassigned or assign to the human assignee(s) of the parent workflow issue)
 *   **Labels:** `overseer`, `overseer/review`
 *   **Body:**
     ```
+    Workflow Issue: #${SESSION_ID#issue-}
+
     Please follow the skill .gemini/skills/kcc-identity-reference/SKILL.md for {kind}
 
     If you find any shortcomings in the skill (that likely apply to other resources), you may update SKILL.md. Also keep a journal of any less general observations etc. To avoid git merge conflicts, use a file under .gemini/skills/kcc-identity-reference/journal/, named after the kind or a similarly unique name. You may grep journal entries to identify learnings from other resources; if you find an important pattern by doing that you may also update the SKILL.md itself.
@@ -137,10 +141,12 @@ For existing resources transitioning to a direct controller, a round-trip KRM fu
 
 **GitHub Issue Details:**
 *   **Title:** `Implement round-trip KRM fuzzer for {kind}`
-*   **Assignee:** (leave unassigned or assign to the current bot)
+*   **Assignee:** (leave unassigned or assign to the human assignee(s) of the parent workflow issue)
 *   **Labels:** `overseer`
 *   **Body:**
     ```
+    Workflow Issue: #${SESSION_ID#issue-}
+
     Please follow the skill .gemini/skills/create-fuzzer/skill.md to implement a round-trip KRM fuzzer for {kind}.
 
     The expected path for the fuzzer is `pkg/controller/direct/{service}/{kind}_fuzzer.go`. Ensure the direct controller package is imported/registered in `pkg/controller/direct/register/register.go` so the fuzzer executes under the central fuzz test suite.
@@ -157,10 +163,12 @@ We need to ensure that we have a mockgcp that aligns with realgcp.
 
 **GitHub Issue Details:**
 *   **Title:** `Match real gcp behavior in MockGCP for {kind}`
-*   **Assignee:** `factorybot-robot`
+*   **Assignee:** (leave unassigned or assign to the human assignee(s) of the parent workflow issue)
 *   **Labels:** `overseer`
 *   **Body:**
     ```
+    Workflow Issue: #${SESSION_ID#issue-}
+
     Please first check if a mock for the GCP {service},{resource} corresponding to the {kind} already exists in the codebase. Check under mockgcp/ folder.
     If it doesnt exist, please follow the skill .gemini/skills/add-new-mockgcp-resource/SKILL.md to implement the mock for {service}, {resource} first.
 
@@ -192,10 +200,12 @@ The direct controller must be implemented to manage reconciliation logic (Adapte
 
 **GitHub Issue Details:**
 *   **Title:** `Implement direct controller and test fixtures for {kind}`
-*   **Assignee:** (leave unassigned or assign to the current bot)
+*   **Assignee:** (leave unassigned or assign to the human assignee(s) of the parent workflow issue)
 *   **Labels:** `overseer`
 *   **Body:**
     ```
+    Workflow Issue: #${SESSION_ID#issue-}
+
     Please follow the skills:
     - .gemini/skills/kcc-direct-controller-implementer/SKILL.md
     - .gemini/skills/kcc-direct-controller-logic-brownfield/SKILL.md
@@ -212,10 +222,12 @@ The direct controller must be implemented to manage reconciliation logic (Adapte
 
 **GitHub Issue Details:**
 *   **Title:** `Validate direct promotion for {kind}`
-*   **Assignee:** (leave unassigned or assign to the current bot)
+*   **Assignee:** (leave unassigned or assign to the human assignee(s) of the parent workflow issue)
 *   **Labels:** `overseer`
 *   **Body:**
     ```
+    Workflow Issue: #${SESSION_ID#issue-}
+
     Find the tests added under pkg/test/resourcefixture/testdata/basic for the {kind}.
     Include only those tests that are not using direct annotation `alpha.cnrm.cloud.google.com/reconciler: direct` in `create.yaml`
 

--- a/.agents/workflows/kcc-greenfield.txt
+++ b/.agents/workflows/kcc-greenfield.txt
@@ -14,7 +14,7 @@ Compare to Brownfield resources which are already implemented in KCC.
 
 Instead of doing the coding yourself under this skill, you will coordinate and orchestrate:
 1. Planning the migration steps.
-2. Opening GitHub issues for each step, labeling them with `overseer`, and leaving them unassigned (or assigning them to the current bot user).
+2. Opening GitHub issues for each step, linking them to the parent workflow issue (including `Workflow Issue: #${SESSION_ID#issue-}` in the body), labeling them with `overseer`, and leaving them unassigned (or assigning them to the human assignee(s) of the parent workflow issue).
 3. Monitoring progress of the Pull Requests.
 4. Opening subsequent issues once the prior steps are successfully completed.
 
@@ -87,10 +87,12 @@ Open a GitHub issue to coordinate the implementation of direct KRM types, identi
 
 **GitHub Issue Details for Greenfield Resource:**
 *   **Title:** `Greenfield: Implement direct KRM types, identity, and generate.sh for {kind}`
-*   **Assignee:** (leave unassigned or assign to the current bot)
+*   **Assignee:** (leave unassigned or assign to the human assignee(s) of the parent workflow issue)
 *   **Labels:** `overseer`, `greenfield`,`step/gen-types`, `overseer/review`
 *   **Body:**
     ````
+    Workflow Issue: #${SESSION_ID#issue-}
+
     Please follow the skill `.gemini/skills/kcc-direct-greenfield-types-implementer/SKILL.md` for generating types for {kind}.
     Please follow the skill `.gemini/skills/kcc-identity-reference/SKILL.md` for generating identity for {kind}.
 
@@ -115,10 +117,12 @@ Open a GitHub issue to coordinate the implementation of the direct controller an
 
 **GitHub Issue Details:**
 *   **Title:** `Greenfield: Implement direct controller, E2E fixtures, and fuzzer for {kind}`
-*   **Assignee:** (leave unassigned or assign to the current bot)
+*   **Assignee:** (leave unassigned or assign to the human assignee(s) of the parent workflow issue)
 *   **Labels:** `overseer`, `greenfield`, `step/controller` `overseer/review`
 *   **Body:**
     ````
+    Workflow Issue: #${SESSION_ID#issue-}
+
     Please follow the skill `.gemini/skills/kcc-direct-controller-logic-greenfield-implementer/SKILL.md` to implement the direct controller and record/verify E2E fixtures for {kind}.
 
     If you find any shortcomings in this skill (that likely apply to other resources), you may update it. Also keep a journal of any less general observations etc. To avoid git merge conflicts, use a file under its respective journal/ folder, named after the kind or a similarly unique name.
@@ -138,10 +142,12 @@ Open a GitHub issue to coordinate the implementation of the mockGCP for a specif
 
 **GitHub Issue Details for Greenfield Resource:**
 *   **Title:** `Greenfield: Implement MockGCP and Alignment for {kind}`
-*   **Assignee:** (leave unassigned or assign to the current bot)
+*   **Assignee:** (leave unassigned or assign to the human assignee(s) of the parent workflow issue)
 *   **Labels:** `overseer`, `greenfield`,`step/mockgcp`
 *   **Body:**
     ````
+    Workflow Issue: #${SESSION_ID#issue-}
+
     Please follow the skill `.gemini/skills/kcc-direct-mockgcp-implementer/SKILL.md` to implement Phase 3 (MockGCP and Alignment) for {kind} to verify behavioral correctness against the simulated GCP services.
 
     When creating the PR, include the release note block for adding new alpha resources:
@@ -156,10 +162,12 @@ Open a GitHub issue to coordinate the alignment of MockGCP logs with RealGCP out
 
 **GitHub Issue Details:**
 *   **Title:** `Greenfield: Align MockGCP logs with RealGCP for {kind}`
-*   **Assignee:** (leave unassigned or assign to the current bot)
+*   **Assignee:** (leave unassigned or assign to the human assignee(s) of the parent workflow issue)
 *   **Labels:** `overseer`, `greenfield`, `step/mockgcp-alignment`
 *   **Body:**
     ````
+    Workflow Issue: #${SESSION_ID#issue-}
+
     Please follow the skill `.gemini/skills/match-mockgcp-with-realgcp/SKILL.md` to align the MockGCP logs with the RealGCP output for {kind}.
 
     When creating the PR, include the release note block set to NONE:

--- a/factory/pkg/commands/common/github.go
+++ b/factory/pkg/commands/common/github.go
@@ -37,6 +37,28 @@ func GetReferencedIssues(pr *githubv39.PullRequest) map[int]bool {
 	return referenced
 }
 
+// GetParentIssuesFromIssue scans an issue's title and body for parent/workflow issue numbers.
+// It matches patterns like "Workflow: #123", "Workflow Issue: #123", "Parent: #123", "Part of #123", etc.
+func GetParentIssuesFromIssue(issue *githubv39.Issue) map[int]bool {
+	referenced := make(map[int]bool)
+	if issue == nil {
+		return referenced
+	}
+
+	re := regexp.MustCompile(`(?i)\b(?:workflow(?:\s+issue)?|parent(?:\s+issue)?|part\s+of|tracked\s+in|fixes|closes|resolves)\s*:?\s*#?\s*(\d+)\b`)
+	for _, text := range []string{issue.GetTitle(), issue.GetBody()} {
+		for _, match := range re.FindAllStringSubmatch(text, -1) {
+			if len(match) > 1 {
+				if num, err := strconv.Atoi(match[1]); err == nil && num < 10000000 && num != issue.GetNumber() {
+					referenced[num] = true
+				}
+			}
+		}
+	}
+
+	return referenced
+}
+
 // ListAllCheckRuns retrieves all check runs for a ref handling pagination and deduplicating by name.
 func ListAllCheckRuns(ctx context.Context, client *githubv39.Client, owner, repo, ref string) ([]*githubv39.CheckRun, error) {
 	var allRuns []*githubv39.CheckRun

--- a/factory/pkg/commands/common/github_test.go
+++ b/factory/pkg/commands/common/github_test.go
@@ -79,6 +79,75 @@ func TestGetReferencedIssues(t *testing.T) {
 	}
 }
 
+func TestGetParentIssuesFromIssue(t *testing.T) {
+	tests := []struct {
+		name     string
+		issueNum int
+		title    string
+		body     string
+		expected map[int]bool
+	}{
+		{
+			name:     "Workflow Issue reference in body",
+			issueNum: 101,
+			title:    "Greenfield: Implement direct KRM types for Foo",
+			body:     "Workflow Issue: #100\n\nPlease follow the skill...",
+			expected: map[int]bool{100: true},
+		},
+		{
+			name:     "Part of and parent reference in body",
+			issueNum: 102,
+			title:    "Implement controller for Bar",
+			body:     "Part of #200\nParent: #300",
+			expected: map[int]bool{200: true, 300: true},
+		},
+		{
+			name:     "Keyword without hash and case insensitivity",
+			issueNum: 103,
+			title:    "WORKFLOW 400",
+			body:     "tracked in 500",
+			expected: map[int]bool{400: true, 500: true},
+		},
+		{
+			name:     "Does not match unrelated numbers or self reference",
+			issueNum: 104,
+			title:    "Step 1: Direct API Types for #104",
+			body:     "Phase 2 has 3 steps. Port 8080. line #123 should not match.",
+			expected: map[int]bool{},
+		},
+		{
+			name:     "Nil issue",
+			issueNum: 0,
+			title:    "",
+			body:     "",
+			expected: map[int]bool{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var issue *githubv39.Issue
+			if tc.name != "Nil issue" {
+				num := tc.issueNum
+				issue = &githubv39.Issue{
+					Number: &num,
+					Title:  &tc.title,
+					Body:   &tc.body,
+				}
+			}
+			got := GetParentIssuesFromIssue(issue)
+			if len(got) != len(tc.expected) {
+				t.Fatalf("GetParentIssuesFromIssue() returned %v; want %v", got, tc.expected)
+			}
+			for num := range tc.expected {
+				if !got[num] {
+					t.Errorf("GetParentIssuesFromIssue() missed expected issue %d in %v", num, got)
+				}
+			}
+		})
+	}
+}
+
 func stringPtr(s string) *string {
 	return &s
 }

--- a/factory/pkg/commands/watch/github_helpers.go
+++ b/factory/pkg/commands/watch/github_helpers.go
@@ -55,15 +55,48 @@ func listAllOpenPRs(ctx context.Context, ghClient *githubv39.Client, owner, repo
 	return allPRs, nil
 }
 
-func syncReferencedIssueLabels(ctx context.Context, ghClient *githubv39.Client, owner, repo string, pr *githubv39.PullRequest, prIssue *githubv39.Issue) {
-	var refIssues []*githubv39.Issue
-	for refIssueNum := range common.GetReferencedIssues(pr) {
-		refIssue, _, err := ghClient.Issues.Get(ctx, owner, repo, refIssueNum)
+func fetchReferencedIssuesHierarchy(ctx context.Context, ghClient *githubv39.Client, owner, repo string, pr *githubv39.PullRequest) []*githubv39.Issue {
+	if ghClient == nil || pr == nil {
+		return nil
+	}
+
+	var result []*githubv39.Issue
+	visited := make(map[int]bool)
+	var queue []int
+
+	for refNum := range common.GetReferencedIssues(pr) {
+		if !visited[refNum] {
+			visited[refNum] = true
+			queue = append(queue, refNum)
+		}
+	}
+
+	maxIssues := 10
+	for len(queue) > 0 && len(result) < maxIssues {
+		issueNum := queue[0]
+		queue = queue[1:]
+
+		issue, _, err := ghClient.Issues.Get(ctx, owner, repo, issueNum)
 		if err != nil {
-			klog.Warningf("Failed to fetch referenced parent issue #%d for PR #%d: %v", refIssueNum, pr.GetNumber(), err)
+			klog.Warningf("Failed to fetch referenced issue #%d for PR #%d: %v", issueNum, pr.GetNumber(), err)
 			continue
 		}
-		refIssues = append(refIssues, refIssue)
+		result = append(result, issue)
+
+		for parentNum := range common.GetParentIssuesFromIssue(issue) {
+			if !visited[parentNum] {
+				visited[parentNum] = true
+				queue = append(queue, parentNum)
+			}
+		}
+	}
+
+	return result
+}
+
+func syncReferencedIssueLabels(ctx context.Context, ghClient *githubv39.Client, owner, repo string, pr *githubv39.PullRequest, prIssue *githubv39.Issue, refIssues []*githubv39.Issue) {
+	if ghClient == nil || pr == nil || prIssue == nil || len(refIssues) == 0 {
+		return
 	}
 
 	allMissingLabels := getMissingLabelsForPR(prIssue.Labels, refIssues)
@@ -72,8 +105,96 @@ func syncReferencedIssueLabels(ctx context.Context, ghClient *githubv39.Client, 
 		klog.Infof("Adding inherited labels %v to PR #%d", allMissingLabels, pr.GetNumber())
 		if _, _, err := ghClient.Issues.AddLabelsToIssue(ctx, owner, repo, pr.GetNumber(), allMissingLabels); err != nil {
 			klog.Errorf("Failed to add labels %v to PR #%d: %v", allMissingLabels, pr.GetNumber(), err)
+		} else {
+			for _, labelName := range allMissingLabels {
+				l := labelName
+				prIssue.Labels = append(prIssue.Labels, &githubv39.Label{Name: &l})
+			}
 		}
 	}
+}
+
+func (w *Watcher) syncReferencedIssueAssignees(ctx context.Context, pr *githubv39.PullRequest, prIssue *githubv39.Issue, refIssues []*githubv39.Issue) {
+	if w.ghClient == nil || pr == nil || prIssue == nil || len(refIssues) == 0 {
+		return
+	}
+
+	missingAssignees := getMissingHumanAssigneesForPR(prIssue.Assignees, refIssues, w.allBotUsers, w.githubLogin)
+	if len(missingAssignees) == 0 {
+		return
+	}
+
+	if w.DryRun {
+		fmt.Printf("[DRYRUN] Would add human assignees %v to PR #%d\n", missingAssignees, pr.GetNumber())
+		for _, name := range missingAssignees {
+			login := name
+			prIssue.Assignees = append(prIssue.Assignees, &githubv39.User{Login: &login})
+		}
+		return
+	}
+
+	klog.Infof("Adding inherited human assignees %v to PR #%d", missingAssignees, pr.GetNumber())
+	if _, _, err := w.ghClient.Issues.AddAssignees(ctx, w.Repo.Owner, w.Repo.Repo, pr.GetNumber(), missingAssignees); err != nil {
+		klog.Errorf("Failed to add human assignees %v to PR #%d: %v", missingAssignees, pr.GetNumber(), err)
+	} else {
+		for _, name := range missingAssignees {
+			login := name
+			prIssue.Assignees = append(prIssue.Assignees, &githubv39.User{Login: &login})
+		}
+	}
+}
+
+func isHumanUser(user *githubv39.User, botUsers []string, githubLogin string) bool {
+	if user == nil || user.GetLogin() == "" {
+		return false
+	}
+	if strings.EqualFold(user.GetType(), "Bot") {
+		return false
+	}
+	loginLower := strings.ToLower(user.GetLogin())
+	if strings.HasSuffix(loginLower, "[bot]") {
+		return false
+	}
+	if githubLogin != "" && strings.EqualFold(user.GetLogin(), githubLogin) {
+		return false
+	}
+	for _, bot := range botUsers {
+		if strings.EqualFold(user.GetLogin(), bot) {
+			return false
+		}
+	}
+	return true
+}
+
+func getMissingHumanAssigneesForPR(prAssignees []*githubv39.User, refIssues []*githubv39.Issue, botUsers []string, githubLogin string) []string {
+	prAssigneesSet := make(map[string]bool)
+	for _, user := range prAssignees {
+		if user.GetLogin() != "" {
+			prAssigneesSet[strings.ToLower(user.GetLogin())] = true
+		}
+	}
+
+	var missingAssignees []string
+	seen := make(map[string]bool)
+
+	for _, refIssue := range refIssues {
+		if refIssue == nil {
+			continue
+		}
+		for _, user := range refIssue.Assignees {
+			if !isHumanUser(user, botUsers, githubLogin) {
+				continue
+			}
+			login := user.GetLogin()
+			loginLower := strings.ToLower(login)
+			if !prAssigneesSet[loginLower] && !seen[loginLower] {
+				seen[loginLower] = true
+				missingAssignees = append(missingAssignees, login)
+			}
+		}
+	}
+
+	return missingAssignees
 }
 
 func getMissingLabelsForPR(prLabels []*githubv39.Label, refIssues []*githubv39.Issue) []string {

--- a/factory/pkg/commands/watch/github_helpers_test.go
+++ b/factory/pkg/commands/watch/github_helpers_test.go
@@ -101,6 +101,176 @@ func TestGetMissingLabelsForPR(t *testing.T) {
 	}
 }
 
+func TestGetMissingHumanAssigneesForPR(t *testing.T) {
+	tests := []struct {
+		name        string
+		prAssignees []string
+		refIssues   []struct {
+			users []*githubv39.User
+		}
+		botUsers    []string
+		githubLogin string
+		expected    []string
+	}{
+		{
+			name:        "Propagate human assignees from single parent issue",
+			prAssignees: []string{},
+			refIssues: []struct {
+				users []*githubv39.User
+			}{
+				{
+					users: []*githubv39.User{
+						{Login: stringPtr("barni")},
+						{Login: stringPtr("codebot-robot")},
+					},
+				},
+			},
+			botUsers:    []string{"codebot-robot", "reviewbot-robot"},
+			githubLogin: "codebot-robot",
+			expected:    []string{"barni"},
+		},
+		{
+			name:        "Propagate human assignees across multiple hierarchy levels and deduplicate",
+			prAssignees: []string{},
+			refIssues: []struct {
+				users []*githubv39.User
+			}{
+				{
+					users: []*githubv39.User{
+						{Login: stringPtr("barni")},
+					},
+				},
+				{
+					users: []*githubv39.User{
+						{Login: stringPtr("barni")},
+						{Login: stringPtr("alice")},
+					},
+				},
+			},
+			botUsers:    []string{"codebot-robot"},
+			githubLogin: "",
+			expected:    []string{"barni", "alice"},
+		},
+		{
+			name:        "Human already assigned to PR",
+			prAssignees: []string{"barni"},
+			refIssues: []struct {
+				users []*githubv39.User
+			}{
+				{
+					users: []*githubv39.User{
+						{Login: stringPtr("barni")},
+					},
+				},
+			},
+			botUsers:    []string{"codebot-robot"},
+			githubLogin: "",
+			expected:    []string{},
+		},
+		{
+			name:        "Filter out Type=Bot, [bot] suffix, githubLogin, and botUsers",
+			prAssignees: []string{},
+			refIssues: []struct {
+				users []*githubv39.User
+			}{
+				{
+					users: []*githubv39.User{
+						{Login: stringPtr("app[bot]")},
+						{Login: stringPtr("some-bot"), Type: stringPtr("Bot")},
+						{Login: stringPtr("factory-user")},
+						{Login: stringPtr("my-bot")},
+						{Login: stringPtr("charlie")},
+					},
+				},
+			},
+			botUsers:    []string{"my-bot"},
+			githubLogin: "factory-user",
+			expected:    []string{"charlie"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var prAssignees []*githubv39.User
+			for _, login := range tc.prAssignees {
+				prAssignees = append(prAssignees, &githubv39.User{Login: stringPtr(login)})
+			}
+
+			var refIssues []*githubv39.Issue
+			for _, r := range tc.refIssues {
+				refIssues = append(refIssues, &githubv39.Issue{Assignees: r.users})
+			}
+
+			got := getMissingHumanAssigneesForPR(prAssignees, refIssues, tc.botUsers, tc.githubLogin)
+			if len(got) != len(tc.expected) {
+				t.Fatalf("getMissingHumanAssigneesForPR() returned %v (len %d); want %v (len %d)", got, len(got), tc.expected, len(tc.expected))
+			}
+			for i, val := range tc.expected {
+				if got[i] != val {
+					t.Errorf("getMissingHumanAssigneesForPR()[%d] = %q; want %q", i, got[i], val)
+				}
+			}
+		})
+	}
+}
+
+func TestFetchReferencedIssuesHierarchy(t *testing.T) {
+	mux := http.NewServeMux()
+	// PR #102: references #101
+	// Issue #101: references #100 via "Workflow Issue: #100"
+	// Issue #100: parent workflow issue
+	mux.HandleFunc("/repos/test-owner/test-repo/issues/101", func(w http.ResponseWriter, r *http.Request) {
+		body := "Workflow Issue: #100\nPlease implement direct types."
+		num := 101
+		_ = json.NewEncoder(w).Encode(&githubv39.Issue{
+			Number: &num,
+			Body:   &body,
+			Assignees: []*githubv39.User{
+				{Login: stringPtr("codebot-robot")},
+			},
+		})
+	})
+	mux.HandleFunc("/repos/test-owner/test-repo/issues/100", func(w http.ResponseWriter, r *http.Request) {
+		body := "Migrate Foo resource kind."
+		num := 100
+		_ = json.NewEncoder(w).Encode(&githubv39.Issue{
+			Number: &num,
+			Body:   &body,
+			Assignees: []*githubv39.User{
+				{Login: stringPtr("barni")},
+			},
+		})
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := githubv39.NewClient(nil)
+	u, _ := url.Parse(server.URL + "/")
+	client.BaseURL = u
+
+	prTitle := "Fixes #101"
+	pr := &githubv39.PullRequest{
+		Title: &prTitle,
+	}
+
+	issues := fetchReferencedIssuesHierarchy(context.Background(), client, "test-owner", "test-repo", pr)
+	if len(issues) != 2 {
+		t.Fatalf("fetchReferencedIssuesHierarchy() returned %d issues; want 2", len(issues))
+	}
+	if issues[0].GetNumber() != 101 {
+		t.Errorf("issues[0].Number = %d; want 101", issues[0].GetNumber())
+	}
+	if issues[1].GetNumber() != 100 {
+		t.Errorf("issues[1].Number = %d; want 100", issues[1].GetNumber())
+	}
+
+	missing := getMissingHumanAssigneesForPR(nil, issues, []string{"codebot-robot"}, "")
+	if len(missing) != 1 || missing[0] != "barni" {
+		t.Fatalf("getMissingHumanAssigneesForPR() = %v; want [barni]", missing)
+	}
+}
+
 func TestGetInvestigationCount(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/factory/pkg/commands/watch/scan_pr.go
+++ b/factory/pkg/commands/watch/scan_pr.go
@@ -110,10 +110,17 @@ func (w *Watcher) processPRs(ctx context.Context, prIssues []*githubv39.Issue) {
 			continue
 		}
 
+		// Fetch referenced parent issues (and parent workflow issues)
+		refIssues := fetchReferencedIssuesHierarchy(ctx, w.ghClient, w.Repo.Owner, w.Repo.Repo, pr)
+
 		// Sync labels from referenced parent issues to the PR
-		syncReferencedIssueLabels(ctx, w.ghClient, w.Repo.Owner, w.Repo.Repo, pr, prIssue)
+		syncReferencedIssueLabels(ctx, w.ghClient, w.Repo.Owner, w.Repo.Repo, pr, prIssue, refIssues)
+
+		// Sync human assignees from referenced parent issues to the PR
+		w.syncReferencedIssueAssignees(ctx, pr, prIssue, refIssues)
+
 		if hasStopLabel(prIssue.Labels, w.triggerLabel) {
-			klog.Infof("Skipping PR #%d after label sync because it has the stop label ('overseer/stop' or '%s/stop')", num, w.triggerLabel)
+			klog.Infof("Skipping PR #%d after label/assignee sync because it has the stop label ('overseer/stop' or '%s/stop')", num, w.triggerLabel)
 			w.reconcileReadyForHumanLabel(ctx, num, prIssue, false, "")
 			removePendingTasksForNumber(w.incomingDir, num)
 			continue
@@ -657,9 +664,8 @@ func (w *Watcher) processPRs(ctx context.Context, prIssues []*githubv39.Issue) {
 							if pr.GetBody() != "" {
 								bodies = append(bodies, pr.GetBody())
 							}
-							for refIssueNum := range common.GetReferencedIssues(pr) {
-								refIssue, _, err := w.ghClient.Issues.Get(ctx, w.Repo.Owner, w.Repo.Repo, refIssueNum)
-								if err == nil && refIssue.GetBody() != "" {
+							for _, refIssue := range refIssues {
+								if refIssue != nil && refIssue.GetBody() != "" {
 									bodies = append(bodies, refIssue.GetBody())
 								}
 							}


### PR DESCRIPTION
## Summary
When automated workflows (such as `kcc-greenfield.txt` or `kcc-example.txt`) orchestrate tasks, the workflow bot creates child issues, and code-fixing bots create PRs. Previously, human assignees from the root workflow issue (or parent issue) were not propagated to the PRs, leaving PRs without human assignees when bot review passed and the bot unassigned itself.

This change:
1. Adds `common.GetParentIssuesFromIssue` to parse parent issue links (e.g. `Workflow Issue: #100`, `Parent: #100`, `Part of #100`).
2. Implements `fetchReferencedIssuesHierarchy` in `watch` to recursively discover parent and workflow issues (`PR -> Child Issue -> Workflow Issue`).
3. Implements `syncReferencedIssueAssignees` to propagate human assignees from referenced issues down to the PR, filtering out bot accounts (`allBotUsers`, `[bot]`, `Type: Bot`).
4. Updates workflow templates (`kcc-greenfield.txt`, `kcc-example.txt`) to include `Workflow Issue: #${SESSION_ID#issue-}` in child issue bodies and assign human assignees.

```release-note
NONE
```