### PR TITLE
refactor(watch): move task queue and HTTP types into watch/api package

### DIFF
--- a/factory/pkg/commands/watch/api/queue.go
+++ b/factory/pkg/commands/watch/api/queue.go
@@ -1,0 +1,153 @@
+package api
+
+import (
+	"time"
+)
+
+// TaskType represents the type of work to be performed by a queue task.
+type TaskType string
+
+const (
+	TypeIssueFix      TaskType = "issue-fix"
+	TypePRInvestigate TaskType = "pr-investigate"
+	TypePRComments    TaskType = "pr-comments"
+	TypePRIterate     TaskType = "pr-iterate"
+	TypePRReview      TaskType = "pr-review"
+	TypeAgentChore    TaskType = "agent-chore"
+)
+
+// TaskPriority represents the priority or urgency of a queue task.
+type TaskPriority string
+
+const (
+	PriorityCritical  TaskPriority = "critical"
+	PriorityUrgent    TaskPriority = "urgent"
+	PriorityImportant TaskPriority = "important"
+	PriorityHigh      TaskPriority = "high"
+	PriorityMedium    TaskPriority = "medium"
+	PriorityLow       TaskPriority = "low"
+	PriorityUnknown   TaskPriority = "unknown"
+)
+
+// TaskPhase represents the execution phase order of a queue task.
+type TaskPhase int
+
+const (
+	PhaseRebase      TaskPhase = 1 // Rebase/iterate
+	PhaseIterate     TaskPhase = 1
+	PhaseComments    TaskPhase = 2 // Comments
+	PhaseInvestigate TaskPhase = 3 // Investigate/Fix
+	PhaseFix         TaskPhase = 3
+	PhaseChores      TaskPhase = 4 // Chores
+)
+
+// TaskStatus represents the lifecycle status of a queue task.
+type TaskStatus string
+
+const (
+	StatusPending   TaskStatus = "Pending"
+	StatusRunning   TaskStatus = "Running"
+	StatusCompleted TaskStatus = "Completed"
+	StatusFailed    TaskStatus = "Failed"
+)
+
+// TriggerReason represents a machine-readable, PascalCase reason for why a queue task was triggered,
+// following Kubernetes API conventions.
+type TriggerReason string
+
+const (
+	// TriggerReasonIssueCreated indicates the task was triggered because an issue was newly created
+	// (either already labeled with the trigger label or auto-labeled by the watcher).
+	TriggerReasonIssueCreated TriggerReason = "IssueCreated"
+
+	// TriggerReasonIssueLabeled indicates the task was triggered because the trigger label was
+	// added to an existing issue after its creation.
+	TriggerReasonIssueLabeled TriggerReason = "IssueLabeled"
+
+	// TriggerReasonPRCommentsAdded indicates the task was triggered by new unaddressed comments or reviews on a PR.
+	TriggerReasonPRCommentsAdded TriggerReason = "PRCommentsAdded"
+
+	// TriggerReasonPRCheckFailed indicates the task was triggered by a failed CI check run or commit status.
+	TriggerReasonPRCheckFailed TriggerReason = "PRCheckFailed"
+
+	// TriggerReasonPRMergeConflict indicates the task was triggered by merge conflicts with the base branch.
+	TriggerReasonPRMergeConflict TriggerReason = "PRMergeConflict"
+
+	// TriggerReasonPRReadyForReview indicates the task was triggered because all CI checks passed and the PR is ready for automated review.
+	TriggerReasonPRReadyForReview TriggerReason = "PRReadyForReview"
+
+	// TriggerReasonChoreScheduled indicates the task was triggered by a scheduled cron chore.
+	TriggerReasonChoreScheduled TriggerReason = "ChoreScheduled"
+)
+
+// QueueTask represents an actionable unit of work to be scheduled and executed in a sandbox.
+type QueueTask struct {
+	Type       TaskType     `yaml:"type"` // "issue-fix", "pr-investigate", "pr-comments", "pr-iterate", "pr-review", "agent-chore"
+	URL        string       `yaml:"url"`
+	Number     int          `yaml:"number"`
+	Priority   TaskPriority `yaml:"priority"` // "critical", "urgent", "important", "high", "medium", "low"
+	Phase      TaskPhase    `yaml:"phase"`    // 1: Rebase/iterate, 2: Comments, 3: Investigate/Fix, 4: Chores
+	CreatedAt  time.Time    `yaml:"createdAt"`
+	EnqueuedAt time.Time    `yaml:"enqueuedAt,omitempty"`
+	// TriggerEventTime is the timestamp when the original event that triggered this task occurred
+	// (e.g. oldest comment time, earliest CI check failure, or issue creation/labeling time).
+	TriggerEventTime time.Time `yaml:"triggerEventTime,omitempty"`
+	// TriggerReason is a machine-readable enum indicating the type of triggering event (e.g. IssueCreated, PRCommentsAdded).
+	TriggerReason TriggerReason `yaml:"triggerReason,omitempty"`
+	// TriggerNotes contains human-readable details about the triggering event (e.g. specific check that failed, comment author).
+	TriggerNotes string `yaml:"triggerNotes,omitempty"`
+	// StartedAt is the timestamp when the task began execution in processing.
+	StartedAt time.Time `yaml:"startedAt,omitempty"`
+	// CompletedAt is the timestamp when the task completed execution (either Completed or Failed).
+	CompletedAt  time.Time  `yaml:"completedAt,omitempty"`
+	Assignee     string     `yaml:"assignee,omitempty"`
+	Status       TaskStatus `yaml:"status"` // "Pending", "Running", "Completed", "Failed"
+	Error        string     `yaml:"error,omitempty"`
+	AgentFile    string     `yaml:"agentFile,omitempty"` // For chore tasks
+	SessionID    string     `yaml:"sessionId,omitempty"` // For workflow sessions
+	CommitSHA    string     `yaml:"commitSHA,omitempty"`
+	Instructions []string   `yaml:"instructions,omitempty"`
+	Recovered    bool       `yaml:"recovered,omitempty"`
+}
+
+// Duration returns the elapsed execution duration between StartedAt and CompletedAt,
+// or 0 if either timestamp is unset or CompletedAt is before StartedAt.
+func (t *QueueTask) Duration() time.Duration {
+	if !t.StartedAt.IsZero() && !t.CompletedAt.IsZero() && t.CompletedAt.After(t.StartedAt) {
+		return t.CompletedAt.Sub(t.StartedAt)
+	}
+	return 0
+}
+
+// TaskItem represents a queue task bundled with its filename.
+type TaskItem struct {
+	Filename string
+	Task     *QueueTask
+}
+
+// JournalEvent represents an append-only log record written to journal.jsonl for observability.
+type JournalEvent struct {
+	Timestamp        time.Time     `json:"timestamp"`
+	TaskID           string        `json:"taskId"`
+	Event            string        `json:"event"`
+	Type             TaskType      `json:"type"`
+	URL              string        `json:"url"`
+	Priority         TaskPriority  `json:"priority"`
+	TriggerEventTime time.Time     `json:"triggerEventTime,omitempty"`
+	TriggerReason    TriggerReason `json:"triggerReason,omitempty"`
+	TriggerNotes     string        `json:"triggerNotes,omitempty"`
+	StartedAt        time.Time     `json:"startedAt,omitempty"`
+	CompletedAt      time.Time     `json:"completedAt,omitempty"`
+	Error            string        `json:"error,omitempty"`
+	DurationSecond   float64       `json:"durationSeconds,omitempty"`
+}
+
+// IsPRTask reports whether a given task type corresponds to an automated PR task.
+func IsPRTask(taskType TaskType) bool {
+	switch taskType {
+	case TypePRInvestigate, TypePRComments, TypePRIterate:
+		return true
+	default:
+		return false
+	}
+}

--- a/factory/pkg/commands/watch/api/queue_test.go
+++ b/factory/pkg/commands/watch/api/queue_test.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+func TestQueueTask_Duration(t *testing.T) {
+	task := &QueueTask{}
+	if d := task.Duration(); d != 0 {
+		t.Errorf("expected 0 duration for unset timestamps, got %v", d)
+	}
+
+	start := time.Now()
+	task.StartedAt = start
+	task.CompletedAt = start.Add(1500 * time.Millisecond)
+
+	if d := task.Duration(); d != 1500*time.Millisecond {
+		t.Errorf("expected 1.5s duration, got %v", d)
+	}
+
+	// Completed before started
+	task.CompletedAt = start.Add(-1 * time.Second)
+	if d := task.Duration(); d != 0 {
+		t.Errorf("expected 0 duration when completed before started, got %v", d)
+	}
+}
+
+func TestIsPRTask(t *testing.T) {
+	tests := []struct {
+		taskType TaskType
+		expected bool
+	}{
+		{TypePRInvestigate, true},
+		{TypePRComments, true},
+		{TypePRIterate, true},
+		{TypePRReview, false},
+		{TypeIssueFix, false},
+		{TypeAgentChore, false},
+		{"", false},
+		{"unknown", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.taskType), func(t *testing.T) {
+			got := IsPRTask(tc.taskType)
+			if got != tc.expected {
+				t.Errorf("IsPRTask(%q) = %v, want %v", tc.taskType, got, tc.expected)
+			}
+		})
+	}
+}

--- a/factory/pkg/commands/watch/api/server.go
+++ b/factory/pkg/commands/watch/api/server.go
@@ -1,0 +1,41 @@
+package api
+
+// QueueTaskItem represents a formatted task representation exposed via the HTTP API.
+type QueueTaskItem struct {
+	FileName         string        `json:"fileName"`
+	QueueState       string        `json:"queueState"`
+	Type             TaskType      `json:"type"`
+	URL              string        `json:"url"`
+	Number           int           `json:"number"`
+	Priority         TaskPriority  `json:"priority"`
+	Phase            TaskPhase     `json:"phase"`
+	CreatedAt        string        `json:"createdAt"`
+	EnqueuedAt       string        `json:"enqueuedAt,omitempty"`
+	StartedAt        string        `json:"startedAt,omitempty"`
+	CompletedAt      string        `json:"completedAt,omitempty"`
+	DurationSeconds  float64       `json:"durationSeconds,omitempty"`
+	TriggerEventTime string        `json:"triggerEventTime,omitempty"`
+	TriggerReason    TriggerReason `json:"triggerReason,omitempty"`
+	TriggerNotes     string        `json:"triggerNotes,omitempty"`
+	Assignee         string        `json:"assignee"`
+	Status           TaskStatus    `json:"status"`
+	CommitSHA        string        `json:"commitSHA"`
+	Rank             int           `json:"rank,omitempty"`
+}
+
+// QueueSummary contains aggregated counts of tasks in each queue state and breakdown by priority/type.
+type QueueSummary struct {
+	TotalPending    int                  `json:"totalPending"`
+	TotalProcessing int                  `json:"totalProcessing"`
+	TotalCompleted  int                  `json:"totalCompleted"`
+	ByPriority      map[TaskPriority]int `json:"byPriority"`
+	ByType          map[TaskType]int     `json:"byType"`
+}
+
+// QueueResponse is the response payload served by GET /api/v1/queue.
+type QueueResponse struct {
+	Summary    QueueSummary    `json:"summary"`
+	Incoming   []QueueTaskItem `json:"incoming"`
+	Processing []QueueTaskItem `json:"processing"`
+	Processed  []QueueTaskItem `json:"processed"`
+}

--- a/factory/pkg/commands/watch/chores.go
+++ b/factory/pkg/commands/watch/chores.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/common"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/watch/api"
 	githubv39 "github.com/google/go-github/v39/github"
 	"github.com/robfig/cron/v3"
 	"k8s.io/klog/v2"
@@ -94,7 +95,7 @@ func (w *Watcher) scanChores(ctx context.Context) {
 						dueTime = sched.Next(lastRun)
 					}
 				}
-				reason := TriggerReasonChoreScheduled
+				reason := api.TriggerReasonChoreScheduled
 				lastRunStr := "never"
 				if !lastRun.IsZero() {
 					lastRunStr = lastRun.Format(time.RFC3339)

--- a/factory/pkg/commands/watch/github_helpers.go
+++ b/factory/pkg/commands/watch/github_helpers.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/common"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/watch/api"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/config"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/k8s"
 	githubv39 "github.com/google/go-github/v39/github"
@@ -154,7 +155,7 @@ func hasLinkedPRWithTimeline(ctx context.Context, client *githubv39.Client, owne
 	return hasLinkedPR(ctx, client, owner, repo, issueNum)
 }
 
-func getIssueTriggerInfo(issue *githubv39.Issue, timeline []*githubv39.Timeline, triggerLabel string, wasAutoLabeled bool) (time.Time, TriggerReason, string) {
+func getIssueTriggerInfo(issue *githubv39.Issue, timeline []*githubv39.Timeline, triggerLabel string, wasAutoLabeled bool) (time.Time, api.TriggerReason, string) {
 	createTime := issue.GetCreatedAt()
 	num := issue.GetNumber()
 
@@ -164,7 +165,7 @@ func getIssueTriggerInfo(issue *githubv39.Issue, timeline []*githubv39.Timeline,
 			user = fmt.Sprintf(" by %s", issue.GetUser().GetLogin())
 		}
 		notes := fmt.Sprintf("Issue #%d created%s at %s; trigger label '%s' auto-applied by watcher", num, user, createTime.Format(time.RFC3339), triggerLabel)
-		return createTime, TriggerReasonIssueCreated, notes
+		return createTime, api.TriggerReasonIssueCreated, notes
 	}
 
 	var latestLabelTime time.Time
@@ -189,11 +190,11 @@ func getIssueTriggerInfo(issue *githubv39.Issue, timeline []*githubv39.Timeline,
 			actorStr = fmt.Sprintf(" by %s", labelActor)
 		}
 		notes := fmt.Sprintf("Issue #%d created at %s; trigger label '%s' added%s at %s", num, createTime.Format(time.RFC3339), triggerLabel, actorStr, latestLabelTime.Format(time.RFC3339))
-		return latestLabelTime, TriggerReasonIssueLabeled, notes
+		return latestLabelTime, api.TriggerReasonIssueLabeled, notes
 	}
 
 	notes := fmt.Sprintf("Issue #%d created at %s with trigger label '%s'", num, createTime.Format(time.RFC3339), triggerLabel)
-	return createTime, TriggerReasonIssueCreated, notes
+	return createTime, api.TriggerReasonIssueCreated, notes
 }
 
 func isPRApprovedOrLGTM(pr *githubv39.PullRequest, prIssue *githubv39.Issue, reviews []*githubv39.PullRequestReview) bool {
@@ -438,7 +439,7 @@ func (w *Watcher) reconcileReadyForHumanLabel(ctx context.Context, num int, prIs
 	}
 }
 
-func (w *Watcher) selectUserForTask(ctx context.Context, taskType string, prNum int) (string, error) {
+func (w *Watcher) selectUserForTask(ctx context.Context, taskType api.TaskType, prNum int) (string, error) {
 	if w.cfg == nil || len(w.cfg.Roles) == 0 {
 		return "", nil // default fallback to factory-user
 	}
@@ -447,7 +448,7 @@ func (w *Watcher) selectUserForTask(ctx context.Context, taskType string, prNum 
 	role := ""
 	for roleName, rCfg := range w.cfg.Roles {
 		for _, t := range rCfg.Tasks {
-			if strings.EqualFold(t, taskType) {
+			if strings.EqualFold(t, string(taskType)) {
 				role = roleName
 				break
 			}
@@ -459,13 +460,13 @@ func (w *Watcher) selectUserForTask(ctx context.Context, taskType string, prNum 
 
 	if role == "" {
 		switch {
-		case taskType == "agent-chore":
+		case taskType == api.TypeAgentChore:
 			if rCfg, ok := w.cfg.Roles["agent"]; ok && len(rCfg.Users) > 0 {
 				role = "agent"
 			} else {
 				role = "coder"
 			}
-		case isPRTask(taskType):
+		case api.IsPRTask(taskType):
 			if prNum > 0 {
 				pr, _, err := w.ghClient.PullRequests.Get(ctx, w.Repo.Owner, w.Repo.Repo, prNum)
 				if err == nil {
@@ -491,9 +492,9 @@ func (w *Watcher) selectUserForTask(ctx context.Context, taskType string, prNum 
 			if role == "" {
 				role = "coder"
 			}
-		case taskType == "issue-fix":
+		case taskType == api.TypeIssueFix:
 			role = "coder"
-		case taskType == "pr-review":
+		case taskType == api.TypePRReview:
 			role = "reviewer"
 		default:
 			return "", nil // default fallback
@@ -512,15 +513,15 @@ func (w *Watcher) selectUserForTask(ctx context.Context, taskType string, prNum 
 	}
 
 	// 2. Select bot based on new vs existing PR/Issue
-	isIssueTask := taskType == "issue-fix" || taskType == "agent-chore"
+	isIssueTask := taskType == api.TypeIssueFix || taskType == api.TypeAgentChore
 	if isIssueTask {
 		if prNum > 0 {
 			// A. First check if a Sandbox already exists for this task on the cluster
 			// and has been pinned to a specific user.
 			var sandboxName string
-			if taskType == "issue-fix" {
+			if taskType == api.TypeIssueFix {
 				sandboxName = fmt.Sprintf("fix-%s-%d", w.Repo.Repo, prNum)
-			} else if taskType == "agent-chore" {
+			} else if taskType == api.TypeAgentChore {
 				sandboxName = fmt.Sprintf("wf-issue-%d", prNum)
 			}
 
@@ -581,7 +582,7 @@ func (w *Watcher) selectUserForTask(ctx context.Context, taskType string, prNum 
 			return "", fmt.Errorf("empty author login for PR %d", prNum)
 		}
 
-		if taskType == "pr-review" {
+		if taskType == api.TypePRReview {
 			reviewerRoleCfg, ok := w.cfg.Roles["reviewer"]
 			if ok && len(reviewerRoleCfg.Users) > 0 {
 				idx := time.Now().UnixNano() % int64(len(reviewerRoleCfg.Users))

--- a/factory/pkg/commands/watch/queue.go
+++ b/factory/pkg/commands/watch/queue.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/watch/api"
 	githubv39 "github.com/google/go-github/v39/github"
 	"gopkg.in/yaml.v3"
 	"k8s.io/klog/v2"
@@ -18,7 +19,7 @@ import (
 
 // getEnqueueTime returns the timestamp when a task was enqueued, falling back to
 // file modification time or task creation time if EnqueuedAt is unset.
-func getEnqueueTime(t *QueueTask, modTime time.Time) time.Time {
+func getEnqueueTime(t *api.QueueTask, modTime time.Time) time.Time {
 	if !t.EnqueuedAt.IsZero() {
 		return t.EnqueuedAt
 	}
@@ -30,7 +31,7 @@ func getEnqueueTime(t *QueueTask, modTime time.Time) time.Time {
 
 // getEntityKey returns the unique key representing the target entity (PR, issue, or chore)
 // for a given queue task.
-func getEntityKey(t *QueueTask) string {
+func getEntityKey(t *api.QueueTask) string {
 	if t.Number > 0 {
 		return fmt.Sprintf("%d", t.Number)
 	}
@@ -46,17 +47,17 @@ func getEntityKey(t *QueueTask) string {
 	return "default"
 }
 
-// priorityRankValue converts a priority string into an integer rank where lower numbers indicate higher priority.
-func priorityRankValue(p string) int {
-	priorityRank := map[string]int{
-		"critical":  1,
-		"urgent":    2,
-		"important": 3,
-		"high":      4,
-		"medium":    5,
-		"low":       6,
+// priorityRankValue converts a Priority into an integer rank where lower numbers indicate higher priority.
+func priorityRankValue(p api.TaskPriority) int {
+	priorityRank := map[api.TaskPriority]int{
+		api.PriorityCritical:  1,
+		api.PriorityUrgent:    2,
+		api.PriorityImportant: 3,
+		api.PriorityHigh:      4,
+		api.PriorityMedium:    5,
+		api.PriorityLow:       6,
 	}
-	if r, ok := priorityRank[strings.ToLower(p)]; ok {
+	if r, ok := priorityRank[api.TaskPriority(strings.ToLower(string(p)))]; ok {
 		return r
 	}
 	return 5
@@ -64,18 +65,18 @@ func priorityRankValue(p string) int {
 
 // isLessTask reports whether task a should be ordered before task b based on priority rank,
 // phase rank, enqueue timestamp (FIFO), creation timestamp, and filename tiebreaking.
-func isLessTask(a, b taskItem) bool {
-	rankA := priorityRankValue(a.task.Priority)
-	rankB := priorityRankValue(b.task.Priority)
+func isLessTask(a, b api.TaskItem) bool {
+	rankA := priorityRankValue(a.Task.Priority)
+	rankB := priorityRankValue(b.Task.Priority)
 	if rankA != rankB {
 		return rankA < rankB
 	}
 
-	phaseA := a.task.Phase
+	phaseA := a.Task.Phase
 	if phaseA == 0 {
 		phaseA = 3
 	}
-	phaseB := b.task.Phase
+	phaseB := b.Task.Phase
 	if phaseB == 0 {
 		phaseB = 3
 	}
@@ -83,28 +84,28 @@ func isLessTask(a, b taskItem) bool {
 		return phaseA < phaseB
 	}
 
-	if !a.task.EnqueuedAt.Equal(b.task.EnqueuedAt) {
-		return a.task.EnqueuedAt.Before(b.task.EnqueuedAt)
+	if !a.Task.EnqueuedAt.Equal(b.Task.EnqueuedAt) {
+		return a.Task.EnqueuedAt.Before(b.Task.EnqueuedAt)
 	}
 
-	if !a.task.CreatedAt.Equal(b.task.CreatedAt) {
-		return a.task.CreatedAt.Before(b.task.CreatedAt)
+	if !a.Task.CreatedAt.Equal(b.Task.CreatedAt) {
+		return a.Task.CreatedAt.Before(b.Task.CreatedAt)
 	}
 
-	return a.filename < b.filename
+	return a.Filename < b.Filename
 }
 
 // sortTasksFairly sorts queue tasks using a hybrid round-robin algorithm across entity buckets
 // while maintaining FIFO arrival order, priority ranks, and phase dependencies within each entity.
-func sortTasksFairly(items []taskItem) []taskItem {
+func sortTasksFairly(items []api.TaskItem) []api.TaskItem {
 	if len(items) <= 1 {
 		return items
 	}
 
-	bucketsMap := make(map[string][]taskItem)
+	bucketsMap := make(map[string][]api.TaskItem)
 
 	for _, item := range items {
-		key := getEntityKey(item.task)
+		key := getEntityKey(item.Task)
 		bucketsMap[key] = append(bucketsMap[key], item)
 	}
 
@@ -115,7 +116,7 @@ func sortTasksFairly(items []taskItem) []taskItem {
 		bucketsMap[key] = bucket
 	}
 
-	var result []taskItem
+	var result []api.TaskItem
 
 	for len(bucketsMap) > 0 {
 		var activeKeys []string
@@ -149,7 +150,7 @@ func sortTasksFairly(items []taskItem) []taskItem {
 	return result
 }
 
-func writeTaskAtomically(dir string, filename string, task *QueueTask) error {
+func writeTaskAtomically(dir string, filename string, task *api.QueueTask) error {
 	data, err := yaml.Marshal(task)
 	if err != nil {
 		return fmt.Errorf("marshaling task to YAML: %w", err)
@@ -201,21 +202,21 @@ func isDoNotProcess(queueDir string) bool {
 	return false
 }
 
-func getIssuePriority(issue *githubv39.Issue) string {
+func getIssuePriority(issue *githubv39.Issue) api.TaskPriority {
 	for _, l := range issue.Labels {
 		name := l.GetName()
 		if strings.HasPrefix(name, "priority/") {
-			return strings.TrimPrefix(name, "priority/")
+			return api.TaskPriority(strings.TrimPrefix(name, "priority/"))
 		}
 	}
-	return "medium"
+	return api.PriorityMedium
 }
 
-func getPRPriority(prIssue *githubv39.Issue) string {
+func getPRPriority(prIssue *githubv39.Issue) api.TaskPriority {
 	return getIssuePriority(prIssue)
 }
 
-func writeTaskJournalEvent(queueDir string, taskFilename string, task *QueueTask, event string, duration time.Duration) {
+func writeTaskJournalEvent(queueDir string, taskFilename string, task *api.QueueTask, event string, duration time.Duration) {
 	journalPath := filepath.Join(queueDir, "journal.jsonl")
 	f, err := os.OpenFile(journalPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
@@ -224,7 +225,7 @@ func writeTaskJournalEvent(queueDir string, taskFilename string, task *QueueTask
 	}
 	defer f.Close()
 
-	je := JournalEvent{
+	je := api.JournalEvent{
 		Timestamp:        time.Now(),
 		TaskID:           strings.TrimSuffix(taskFilename, ".yaml"),
 		Event:            event,
@@ -259,12 +260,12 @@ func parseProcessedPRTask(filePath string, name string, fInfo os.FileInfo, state
 	isReview := strings.HasSuffix(name, "-review")
 	isIterate := strings.HasSuffix(name, "-iterate")
 
-	var t QueueTask
+	var t api.QueueTask
 	hasTask := false
 	if data, err := os.ReadFile(filePath); err == nil {
 		if err := yaml.Unmarshal(data, &t); err == nil {
 			hasTask = true
-			if strings.EqualFold(t.Status, "Failed") {
+			if strings.EqualFold(string(t.Status), "Failed") {
 				return state
 			}
 		}
@@ -337,10 +338,6 @@ func hasActivePRTask(incomingDir, processingDir string, number int) bool {
 	return false
 }
 
-func isPRTask(taskType string) bool {
-	return taskType == "pr-investigate" || taskType == "pr-comments" || taskType == "pr-iterate"
-}
-
 func loadProcessedTasks(processedDir string) (map[int]time.Time, map[int]prWatchState) {
 	processedIssues := make(map[int]time.Time)
 	processedPRs := make(map[int]prWatchState)
@@ -357,14 +354,14 @@ func loadProcessedTasks(processedDir string) (map[int]time.Time, map[int]prWatch
 			trimmed := strings.TrimPrefix(f.Name(), "task-issue-")
 			trimmed = strings.TrimSuffix(trimmed, ".yaml")
 			if num, err := strconv.Atoi(trimmed); err == nil {
-				var t QueueTask
+				var t api.QueueTask
 				hasTask := false
 				if data, err := os.ReadFile(filePath); err == nil {
 					if err := yaml.Unmarshal(data, &t); err == nil {
 						hasTask = true
 					}
 				}
-				if hasTask && strings.EqualFold(t.Status, "Failed") {
+				if hasTask && strings.EqualFold(string(t.Status), "Failed") {
 					continue
 				}
 				if info, err := f.Info(); err == nil {
@@ -418,7 +415,7 @@ func (w *Watcher) recoverStuckTasks(ctx context.Context) {
 
 			// Read the task
 			if data, err := os.ReadFile(processingPath); err == nil {
-				var t QueueTask
+				var t api.QueueTask
 				if err := yaml.Unmarshal(data, &t); err == nil {
 					sandboxName := w.resolveSandboxName(ctx, t.Type, t.Number)
 					if w.kubeClient != nil && sandboxName != "" {
@@ -430,7 +427,7 @@ func (w *Watcher) recoverStuckTasks(ctx context.Context) {
 						completed, err := isSandboxTaskCompleted(ctx, w.kubeClient, w.Namespace, sandboxName, t.Type)
 						if err == nil && completed {
 							klog.Infof("Task %s already completed in sandbox %s. Moving from processing to processed.", f.Name(), sandboxName)
-							t.Status = "Completed"
+							t.Status = api.StatusCompleted
 							if t.StartedAt.IsZero() {
 								t.StartedAt = t.EnqueuedAt
 							}
@@ -449,7 +446,7 @@ func (w *Watcher) recoverStuckTasks(ctx context.Context) {
 						}
 					}
 
-					t.Status = "Pending"
+					t.Status = api.StatusPending
 					t.Recovered = true
 					if err := writeTaskAtomically(w.incomingDir, f.Name(), &t); err == nil {
 						_ = os.Remove(processingPath)
@@ -472,20 +469,20 @@ func (w *Watcher) recoverStuckTasks(ctx context.Context) {
 
 // PRTaskOptions specifies parameters for constructing a pull request QueueTask.
 type PRTaskOptions struct {
-	Type             string
+	Type             api.TaskType
 	PR               *githubv39.PullRequest
 	PRIssue          *githubv39.Issue
-	Phase            int
+	Phase            api.TaskPhase
 	Assignee         string
 	CommitSHA        string
 	TriggerEventTime time.Time
-	TriggerReason    TriggerReason
+	TriggerReason    api.TriggerReason
 	TriggerNotes     string
 	Instructions     []string
 }
 
 // newPRQueueTask constructs a QueueTask for pull request tasks with consistent defaults.
-func (w *Watcher) newPRQueueTask(opts PRTaskOptions) *QueueTask {
+func (w *Watcher) newPRQueueTask(opts PRTaskOptions) *api.QueueTask {
 	num := opts.PR.GetNumber()
 	eventTime := opts.TriggerEventTime
 	if eventTime.IsZero() {
@@ -494,7 +491,7 @@ func (w *Watcher) newPRQueueTask(opts PRTaskOptions) *QueueTask {
 	if eventTime.IsZero() {
 		eventTime = opts.PR.GetCreatedAt()
 	}
-	return &QueueTask{
+	return &api.QueueTask{
 		Type:             opts.Type,
 		URL:              fmt.Sprintf("https://github.com/%s/%s/pull/%d", w.Repo.Owner, w.Repo.Repo, num),
 		Number:           num,
@@ -506,7 +503,7 @@ func (w *Watcher) newPRQueueTask(opts PRTaskOptions) *QueueTask {
 		TriggerReason:    opts.TriggerReason,
 		TriggerNotes:     opts.TriggerNotes,
 		Assignee:         opts.Assignee,
-		Status:           "Pending",
+		Status:           api.StatusPending,
 		CommitSHA:        opts.CommitSHA,
 		Instructions:     opts.Instructions,
 	}
@@ -514,21 +511,21 @@ func (w *Watcher) newPRQueueTask(opts PRTaskOptions) *QueueTask {
 
 // IssueTaskOptions specifies parameters for constructing an issue QueueTask.
 type IssueTaskOptions struct {
-	Type             string
+	Type             api.TaskType
 	Issue            *githubv39.Issue
-	Phase            int
+	Phase            api.TaskPhase
 	Assignee         string
 	TriggerEventTime time.Time
-	TriggerReason    TriggerReason
+	TriggerReason    api.TriggerReason
 	TriggerNotes     string
 	AgentFile        string
 	SessionID        string
 }
 
 // newIssueQueueTask constructs a QueueTask for issue tasks with consistent defaults.
-func (w *Watcher) newIssueQueueTask(opts IssueTaskOptions) *QueueTask {
+func (w *Watcher) newIssueQueueTask(opts IssueTaskOptions) *api.QueueTask {
 	num := opts.Issue.GetNumber()
-	return &QueueTask{
+	return &api.QueueTask{
 		Type:             opts.Type,
 		URL:              fmt.Sprintf("https://github.com/%s/%s/issues/%d", w.Repo.Owner, w.Repo.Repo, num),
 		Number:           num,
@@ -540,7 +537,7 @@ func (w *Watcher) newIssueQueueTask(opts IssueTaskOptions) *QueueTask {
 		TriggerReason:    opts.TriggerReason,
 		TriggerNotes:     opts.TriggerNotes,
 		Assignee:         opts.Assignee,
-		Status:           "Pending",
+		Status:           api.StatusPending,
 		AgentFile:        opts.AgentFile,
 		SessionID:        opts.SessionID,
 	}
@@ -550,23 +547,23 @@ func (w *Watcher) newIssueQueueTask(opts IssueTaskOptions) *QueueTask {
 type ChoreTaskOptions struct {
 	AgentFile        string
 	TriggerEventTime time.Time
-	TriggerReason    TriggerReason
+	TriggerReason    api.TriggerReason
 	TriggerNotes     string
 }
 
 // newChoreQueueTask constructs a QueueTask for scheduled chore tasks with consistent defaults.
-func (w *Watcher) newChoreQueueTask(opts ChoreTaskOptions) *QueueTask {
-	return &QueueTask{
-		Type:             "agent-chore",
+func (w *Watcher) newChoreQueueTask(opts ChoreTaskOptions) *api.QueueTask {
+	return &api.QueueTask{
+		Type:             api.TypeAgentChore,
 		URL:              fmt.Sprintf("https://github.com/%s/%s", w.Repo.Owner, w.Repo.Repo),
-		Priority:         "medium",
-		Phase:            4,
+		Priority:         api.PriorityMedium,
+		Phase:            api.PhaseChores,
 		CreatedAt:        time.Now(),
 		EnqueuedAt:       time.Now(),
 		TriggerEventTime: opts.TriggerEventTime,
 		TriggerReason:    opts.TriggerReason,
 		TriggerNotes:     opts.TriggerNotes,
-		Status:           "Pending",
+		Status:           api.StatusPending,
 		AgentFile:        opts.AgentFile,
 	}
 }

--- a/factory/pkg/commands/watch/queue_test.go
+++ b/factory/pkg/commands/watch/queue_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/watch/api"
 	githubv39 "github.com/google/go-github/v39/github"
 	"sigs.k8s.io/yaml"
 )
@@ -118,119 +119,119 @@ func TestSortTasksFairly(t *testing.T) {
 	baseTime := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
 
 	t.Run("FIFO within single entity prevents LIFO starvation", func(t *testing.T) {
-		task1 := taskItem{
-			filename: "task1.yaml",
-			task: &QueueTask{
-				Type:       "pr-comments",
+		task1 := api.TaskItem{
+			Filename: "task1.yaml",
+			Task: &api.QueueTask{
+				Type:       api.TypePRComments,
 				Number:     10,
-				Priority:   "medium",
-				Phase:      2,
+				Priority:   api.PriorityMedium,
+				Phase:      api.PhaseComments,
 				CreatedAt:  baseTime,
 				EnqueuedAt: baseTime.Add(1 * time.Minute),
 			},
 		}
-		task2 := taskItem{
-			filename: "task2.yaml",
-			task: &QueueTask{
-				Type:       "pr-comments",
+		task2 := api.TaskItem{
+			Filename: "task2.yaml",
+			Task: &api.QueueTask{
+				Type:       api.TypePRComments,
 				Number:     10,
-				Priority:   "medium",
-				Phase:      2,
+				Priority:   api.PriorityMedium,
+				Phase:      api.PhaseComments,
 				CreatedAt:  baseTime.Add(1 * time.Hour),
 				EnqueuedAt: baseTime.Add(2 * time.Minute),
 			},
 		}
-		task3 := taskItem{
-			filename: "task3.yaml",
-			task: &QueueTask{
-				Type:       "pr-comments",
+		task3 := api.TaskItem{
+			Filename: "task3.yaml",
+			Task: &api.QueueTask{
+				Type:       api.TypePRComments,
 				Number:     10,
-				Priority:   "medium",
-				Phase:      2,
+				Priority:   api.PriorityMedium,
+				Phase:      api.PhaseComments,
 				CreatedAt:  baseTime.Add(2 * time.Hour),
 				EnqueuedAt: baseTime.Add(3 * time.Minute),
 			},
 		}
 
-		items := []taskItem{task3, task2, task1}
+		items := []api.TaskItem{task3, task2, task1}
 		got := sortTasksFairly(items)
 
 		expectedOrder := []string{"task1.yaml", "task2.yaml", "task3.yaml"}
 		for i, expected := range expectedOrder {
-			if got[i].filename != expected {
-				t.Errorf("at index %d: expected %s, got %s", i, expected, got[i].filename)
+			if got[i].Filename != expected {
+				t.Errorf("at index %d: expected %s, got %s", i, expected, got[i].Filename)
 			}
 		}
 	})
 
 	t.Run("Round-Robin across entities prevents entity starvation", func(t *testing.T) {
-		pr10Task1 := taskItem{
-			filename: "pr10_1.yaml",
-			task:     &QueueTask{Number: 10, Priority: "medium", Phase: 3, EnqueuedAt: baseTime.Add(1 * time.Minute)},
+		pr10Task1 := api.TaskItem{
+			Filename: "pr10_1.yaml",
+			Task:     &api.QueueTask{Number: 10, Priority: api.PriorityMedium, Phase: api.PhaseComments, EnqueuedAt: baseTime.Add(1 * time.Minute)},
 		}
-		pr10Task2 := taskItem{
-			filename: "pr10_2.yaml",
-			task:     &QueueTask{Number: 10, Priority: "medium", Phase: 3, EnqueuedAt: baseTime.Add(3 * time.Minute)},
+		pr10Task2 := api.TaskItem{
+			Filename: "pr10_2.yaml",
+			Task:     &api.QueueTask{Number: 10, Priority: api.PriorityMedium, Phase: api.PhaseComments, EnqueuedAt: baseTime.Add(3 * time.Minute)},
 		}
-		pr10Task3 := taskItem{
-			filename: "pr10_3.yaml",
-			task:     &QueueTask{Number: 10, Priority: "medium", Phase: 3, EnqueuedAt: baseTime.Add(4 * time.Minute)},
-		}
-
-		pr20Task1 := taskItem{
-			filename: "pr20_1.yaml",
-			task:     &QueueTask{Number: 20, Priority: "medium", Phase: 3, EnqueuedAt: baseTime.Add(5 * time.Minute)},
+		pr10Task3 := api.TaskItem{
+			Filename: "pr10_3.yaml",
+			Task:     &api.QueueTask{Number: 10, Priority: api.PriorityMedium, Phase: api.PhaseComments, EnqueuedAt: baseTime.Add(4 * time.Minute)},
 		}
 
-		pr20Task2 := taskItem{
-			filename: "pr20_2.yaml",
-			task:     &QueueTask{Number: 20, Priority: "medium", Phase: 3, EnqueuedAt: baseTime.Add(6 * time.Minute)},
+		pr20Task1 := api.TaskItem{
+			Filename: "pr20_1.yaml",
+			Task:     &api.QueueTask{Number: 20, Priority: api.PriorityMedium, Phase: api.PhaseComments, EnqueuedAt: baseTime.Add(5 * time.Minute)},
 		}
 
-		items := []taskItem{pr10Task1, pr10Task2, pr10Task3, pr20Task1, pr20Task2}
+		pr20Task2 := api.TaskItem{
+			Filename: "pr20_2.yaml",
+			Task:     &api.QueueTask{Number: 20, Priority: api.PriorityMedium, Phase: api.PhaseComments, EnqueuedAt: baseTime.Add(6 * time.Minute)},
+		}
+
+		items := []api.TaskItem{pr10Task1, pr10Task2, pr10Task3, pr20Task1, pr20Task2}
 		got := sortTasksFairly(items)
 
 		expectedOrder := []string{"pr10_1.yaml", "pr20_1.yaml", "pr10_2.yaml", "pr20_2.yaml", "pr10_3.yaml"}
 		for i, expected := range expectedOrder {
-			if got[i].filename != expected {
-				t.Errorf("at index %d: expected %s, got %s", i, expected, got[i].filename)
+			if got[i].Filename != expected {
+				t.Errorf("at index %d: expected %s, got %s", i, expected, got[i].Filename)
 			}
 		}
 	})
 
 	t.Run("Priority and Phase are respected across entities", func(t *testing.T) {
-		criticalTask := taskItem{
-			filename: "critical.yaml",
-			task:     &QueueTask{Number: 10, Priority: "critical", Phase: 3, EnqueuedAt: baseTime.Add(5 * time.Minute)},
+		criticalTask := api.TaskItem{
+			Filename: "critical.yaml",
+			Task:     &api.QueueTask{Number: 10, Priority: api.PriorityCritical, Phase: api.PhaseComments, EnqueuedAt: baseTime.Add(5 * time.Minute)},
 		}
-		mediumTask := taskItem{
-			filename: "medium.yaml",
-			task:     &QueueTask{Number: 20, Priority: "medium", Phase: 3, EnqueuedAt: baseTime.Add(1 * time.Minute)},
+		mediumTask := api.TaskItem{
+			Filename: "medium.yaml",
+			Task:     &api.QueueTask{Number: 20, Priority: api.PriorityMedium, Phase: api.PhaseComments, EnqueuedAt: baseTime.Add(1 * time.Minute)},
 		}
-		phase1Task := taskItem{
-			filename: "phase1.yaml",
-			task:     &QueueTask{Number: 20, Priority: "medium", Phase: 1, EnqueuedAt: baseTime.Add(2 * time.Minute)},
+		phase1Task := api.TaskItem{
+			Filename: "phase1.yaml",
+			Task:     &api.QueueTask{Number: 20, Priority: api.PriorityMedium, Phase: api.PhaseIterate, EnqueuedAt: baseTime.Add(2 * time.Minute)},
 		}
 
-		items := []taskItem{mediumTask, criticalTask, phase1Task}
+		items := []api.TaskItem{mediumTask, criticalTask, phase1Task}
 		got := sortTasksFairly(items)
 
 		expectedOrder := []string{"critical.yaml", "phase1.yaml", "medium.yaml"}
 		for i, expected := range expectedOrder {
-			if got[i].filename != expected {
-				t.Errorf("at index %d: expected %s, got %s", i, expected, got[i].filename)
+			if got[i].Filename != expected {
+				t.Errorf("at index %d: expected %s, got %s", i, expected, got[i].Filename)
 			}
 		}
 	})
 
 	t.Run("Fallback to modTime or CreatedAt when EnqueuedAt is zero", func(t *testing.T) {
-		taskOldCreated := &QueueTask{
+		taskOldCreated := &api.QueueTask{
 			CreatedAt: baseTime,
 		}
-		taskNewCreated := &QueueTask{
+		taskNewCreated := &api.QueueTask{
 			CreatedAt: baseTime.Add(1 * time.Hour),
 		}
-		taskWithEnqueued := &QueueTask{
+		taskWithEnqueued := &api.QueueTask{
 			CreatedAt:  baseTime.Add(2 * time.Hour),
 			EnqueuedAt: baseTime.Add(10 * time.Minute),
 		}
@@ -256,11 +257,11 @@ func TestWriteTaskAtomicallyAndTaskExists(t *testing.T) {
 	dir := t.TempDir()
 	procDir := t.TempDir()
 
-	task := &QueueTask{
-		Type:     "issue-fix",
+	task := &api.QueueTask{
+		Type:     api.TypeIssueFix,
 		Number:   42,
-		Priority: "high",
-		Status:   "Pending",
+		Priority: api.PriorityHigh,
+		Status:   api.StatusPending,
 	}
 
 	filename := "task-issue-42.yaml"
@@ -304,16 +305,16 @@ func TestIsDoNotProcess(t *testing.T) {
 
 func TestPriorityRankValue(t *testing.T) {
 	tests := []struct {
-		priority string
+		priority api.TaskPriority
 		want     int
 	}{
-		{"critical", 1},
-		{"urgent", 2},
-		{"important", 3},
-		{"high", 4},
-		{"medium", 5},
-		{"low", 6},
-		{"unknown", 5},
+		{api.PriorityCritical, 1},
+		{api.PriorityUrgent, 2},
+		{api.PriorityImportant, 3},
+		{api.PriorityHigh, 4},
+		{api.PriorityMedium, 5},
+		{api.PriorityLow, 6},
+		{api.PriorityUnknown, 5},
 	}
 
 	for _, tc := range tests {
@@ -325,27 +326,27 @@ func TestPriorityRankValue(t *testing.T) {
 }
 
 func TestGetEntityKey(t *testing.T) {
-	t1 := &QueueTask{Number: 99}
+	t1 := &api.QueueTask{Number: 99}
 	if getEntityKey(t1) != "99" {
 		t.Errorf("expected '99', got %q", getEntityKey(t1))
 	}
 
-	t2 := &QueueTask{AgentFile: "test-chore.yaml"}
+	t2 := &api.QueueTask{AgentFile: "test-chore.yaml"}
 	if getEntityKey(t2) != "chore:test-chore.yaml" {
 		t.Errorf("expected 'chore:test-chore.yaml', got %q", getEntityKey(t2))
 	}
 
-	t3 := &QueueTask{URL: "https://github.com/org/repo"}
+	t3 := &api.QueueTask{URL: "https://github.com/org/repo"}
 	if getEntityKey(t3) != "url:https://github.com/org/repo" {
 		t.Errorf("expected 'url:https://github.com/org/repo', got %q", getEntityKey(t3))
 	}
 
-	t4 := &QueueTask{Type: "custom"}
+	t4 := &api.QueueTask{Type: "custom"}
 	if getEntityKey(t4) != "type:custom" {
 		t.Errorf("expected 'type:custom', got %q", getEntityKey(t4))
 	}
 
-	t5 := &QueueTask{}
+	t5 := &api.QueueTask{}
 	if getEntityKey(t5) != "default" {
 		t.Errorf("expected 'default', got %q", getEntityKey(t5))
 	}
@@ -388,15 +389,6 @@ func TestRemovePendingTasksForNumber(t *testing.T) {
 	}
 	if _, err := os.Stat(f3); os.IsNotExist(err) {
 		t.Errorf("expected f3 to NOT be removed")
-	}
-}
-
-func TestIsPRTask(t *testing.T) {
-	if !isPRTask("pr-investigate") || !isPRTask("pr-comments") || !isPRTask("pr-iterate") {
-		t.Errorf("expected true for PR task types")
-	}
-	if isPRTask("issue-fix") || isPRTask("agent-chore") || isPRTask("pr-review") {
-		t.Errorf("expected false for non-PR iterate/investigate/comments task types")
 	}
 }
 
@@ -458,7 +450,7 @@ func TestWorkflowCooldownCompletedAt(t *testing.T) {
 
 	lastRunTime := info.ModTime()
 	if data, err := os.ReadFile(processedPath); err == nil {
-		var q QueueTask
+		var q api.QueueTask
 		if err := yaml.Unmarshal(data, &q); err == nil && !q.CompletedAt.IsZero() {
 			lastRunTime = q.CompletedAt
 		}

--- a/factory/pkg/commands/watch/runner.go
+++ b/factory/pkg/commands/watch/runner.go
@@ -9,12 +9,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/watch/api"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/k8s"
 	"gopkg.in/yaml.v3"
 	"k8s.io/klog/v2"
 )
 
-func (w *Watcher) buildTaskCommandArgs(t *QueueTask, selectedUser string) []string {
+func (w *Watcher) buildTaskCommandArgs(t *api.QueueTask, selectedUser string) []string {
 	var args []string
 	switch t.Type {
 	case "issue-fix":
@@ -74,7 +75,7 @@ func (w *Watcher) buildTaskCommandArgs(t *QueueTask, selectedUser string) []stri
 	return args
 }
 
-func (w *Watcher) runSingleTask(ctx context.Context, taskFilename string, t *QueueTask) {
+func (w *Watcher) runSingleTask(ctx context.Context, taskFilename string, t *api.QueueTask) {
 	fmt.Printf("Starting task %s (Type: %s, URL: %s)...\n", taskFilename, t.Type, t.URL)
 	if t.StartedAt.IsZero() {
 		t.StartedAt = time.Now()
@@ -122,12 +123,12 @@ func (w *Watcher) runSingleTask(ctx context.Context, taskFilename string, t *Que
 
 	selectedUser := t.Assignee
 	var sUserErr error
-	if selectedUser == "" || (isPRTask(t.Type) && strings.EqualFold(selectedUser, w.targetAssignee)) {
+	if selectedUser == "" || (api.IsPRTask(t.Type) && strings.EqualFold(selectedUser, w.targetAssignee)) {
 		selectedUser, sUserErr = w.selectUserForTask(ctx, t.Type, t.Number)
 	}
 	if sUserErr != nil {
 		klog.Errorf("Failed to select user for task %s: %v", taskFilename, sUserErr)
-		t.Status = "Failed"
+		t.Status = api.StatusFailed
 		t.Error = sUserErr.Error()
 		_ = writeTaskAtomically(w.processingDir, taskFilename, t)
 		writeTaskJournalEvent(w.QueueDir, taskFilename, t, "Failed", 0)
@@ -167,7 +168,7 @@ func (w *Watcher) runSingleTask(ctx context.Context, taskFilename string, t *Que
 
 	if taskErr != nil {
 		klog.Errorf("Task %s failed: %v", taskFilename, taskErr)
-		t.Status = "Failed"
+		t.Status = api.StatusFailed
 		t.Error = taskErr.Error()
 		t.CompletedAt = time.Now()
 		writeTaskJournalEvent(w.QueueDir, taskFilename, t, "Failed", duration)
@@ -205,7 +206,7 @@ func (w *Watcher) runSingleTask(ctx context.Context, taskFilename string, t *Que
 		}
 	} else {
 		fmt.Printf("Task %s completed successfully.\n", taskFilename)
-		t.Status = "Completed"
+		t.Status = api.StatusCompleted
 		t.CompletedAt = time.Now()
 		writeTaskJournalEvent(w.QueueDir, taskFilename, t, "Completed", duration)
 		if t.Type == "pr-comments" && w.cfg != nil {
@@ -233,7 +234,7 @@ func (w *Watcher) runTasks(ctx context.Context) {
 		return
 	}
 
-	var taskItems []taskItem
+	var taskItems []api.TaskItem
 
 	for _, f := range incomingFiles {
 		if f.IsDir() || !strings.HasPrefix(f.Name(), "task-") || !strings.HasSuffix(f.Name(), ".yaml") {
@@ -248,7 +249,7 @@ func (w *Watcher) runTasks(ctx context.Context) {
 			continue
 		}
 
-		var t QueueTask
+		var t api.QueueTask
 		if err := parseTaskYAML(data, &t); err != nil {
 			klog.Errorf("Failed to parse task file %s: %v", filename, err)
 			continue
@@ -263,9 +264,9 @@ func (w *Watcher) runTasks(ctx context.Context) {
 			t.EnqueuedAt = getEnqueueTime(&t, modTime)
 		}
 
-		taskItems = append(taskItems, taskItem{
-			filename: filename,
-			task:     &t,
+		taskItems = append(taskItems, api.TaskItem{
+			Filename: filename,
+			Task:     &t,
 		})
 	}
 
@@ -303,8 +304,8 @@ func (w *Watcher) runTasks(ctx context.Context) {
 			break
 		}
 
-		filename := item.filename
-		task := item.task
+		filename := item.Filename
+		task := item.Task
 
 		sandboxName := w.resolveSandboxName(ctx, task.Type, task.Number)
 		if activeSandboxesInCycle[sandboxName] {
@@ -337,7 +338,7 @@ func (w *Watcher) runTasks(ctx context.Context) {
 			}
 		}
 
-		if task.Type != "agent-chore" && task.Recovered {
+		if task.Type != api.TypeAgentChore && task.Recovered {
 			completed, err := isSandboxTaskCompleted(ctx, w.kubeClient, w.Namespace, sandboxName, task.Type)
 			if err != nil {
 				klog.Errorf("Failed to check if sandbox %s completed task: %v", sandboxName, err)
@@ -350,7 +351,7 @@ func (w *Watcher) runTasks(ctx context.Context) {
 				}
 				incomingPath := filepath.Join(w.incomingDir, filename)
 				processedPath := filepath.Join(w.processedDir, filename)
-				task.Status = "Completed"
+				task.Status = api.StatusCompleted
 				if task.StartedAt.IsZero() {
 					task.StartedAt = task.EnqueuedAt
 				}
@@ -385,7 +386,7 @@ func (w *Watcher) runTasks(ctx context.Context) {
 		}
 
 		activeSandboxesInCycle[sandboxName] = true
-		task.Status = "Running"
+		task.Status = api.StatusRunning
 		task.StartedAt = time.Now()
 		_ = writeTaskAtomically(w.processingDir, filename, task)
 		writeTaskJournalEvent(w.QueueDir, filename, task, "Started", 0)
@@ -394,13 +395,13 @@ func (w *Watcher) runTasks(ctx context.Context) {
 		filesInProcessing++
 
 		w.wg.Add(1)
-		go func(taskFilename string, t *QueueTask) {
+		go func(taskFilename string, t *api.QueueTask) {
 			defer w.wg.Done()
 			w.runSingleTask(ctx, taskFilename, t)
 		}(filename, task)
 	}
 }
 
-func parseTaskYAML(data []byte, t *QueueTask) error {
+func parseTaskYAML(data []byte, t *api.QueueTask) error {
 	return yaml.Unmarshal(data, t)
 }

--- a/factory/pkg/commands/watch/runner_test.go
+++ b/factory/pkg/commands/watch/runner_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/common"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/watch/api"
 )
 
 func TestBuildTaskCommandArgs(t *testing.T) {
@@ -25,8 +26,8 @@ func TestBuildTaskCommandArgs(t *testing.T) {
 	}
 
 	t.Run("issue-fix task", func(t *testing.T) {
-		task := &QueueTask{
-			Type:   "issue-fix",
+		task := &api.QueueTask{
+			Type:   api.TypeIssueFix,
 			URL:    "https://github.com/test-owner/test-repo/issues/123",
 			Number: 123,
 		}
@@ -72,8 +73,8 @@ func TestBuildTaskCommandArgs(t *testing.T) {
 	})
 
 	t.Run("pr-review task with instructions", func(t *testing.T) {
-		task := &QueueTask{
-			Type:         "pr-review",
+		task := &api.QueueTask{
+			Type:         api.TypePRReview,
 			URL:          "https://github.com/test-owner/test-repo/pull/456",
 			Number:       456,
 			Instructions: []string{"check security", "check unit tests"},
@@ -99,8 +100,8 @@ func TestBuildTaskCommandArgs(t *testing.T) {
 	})
 
 	t.Run("agent-chore task with session-id", func(t *testing.T) {
-		task := &QueueTask{
-			Type:      "agent-chore",
+		task := &api.QueueTask{
+			Type:      api.TypeAgentChore,
 			URL:       "https://github.com/test-owner/test-repo/issues/789",
 			Number:    789,
 			AgentFile: ".agents/chore.md",
@@ -127,7 +128,7 @@ func TestBuildTaskCommandArgs(t *testing.T) {
 	})
 
 	t.Run("unknown task type returns nil", func(t *testing.T) {
-		task := &QueueTask{
+		task := &api.QueueTask{
 			Type: "unknown-type",
 		}
 		args := w.buildTaskCommandArgs(task, "bot")

--- a/factory/pkg/commands/watch/sandbox.go
+++ b/factory/pkg/commands/watch/sandbox.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/clients"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/common"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/watch/api"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/envd"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/k8s"
 	factorysandbox "github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/sandbox"
@@ -19,8 +20,8 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func (w *Watcher) resolveSandboxName(ctx context.Context, taskType string, num int) string {
-	if taskType == "issue-fix" || taskType == "agent-chore" {
+func (w *Watcher) resolveSandboxName(ctx context.Context, taskType api.TaskType, num int) string {
+	if taskType == api.TypeIssueFix || taskType == api.TypeAgentChore {
 		wfName := fmt.Sprintf("wf-issue-%d", num)
 		if w.kubeClient != nil {
 			if _, err := w.kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(w.Namespace).Get(ctx, wfName, metav1.GetOptions{}); err == nil {
@@ -163,7 +164,7 @@ func isSandboxTaskRunning(ctx context.Context, kubeClient *clients.KubernetesCli
 	return false, nil
 }
 
-func isSandboxTaskCompleted(ctx context.Context, kubeClient *clients.KubernetesClient, namespace, name, taskType string) (bool, error) {
+func isSandboxTaskCompleted(ctx context.Context, kubeClient *clients.KubernetesClient, namespace, name string, taskType api.TaskType) (bool, error) {
 	unstructObj, err := kubeClient.DynamicClient.Resource(k8s.SandboxGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
@@ -180,19 +181,19 @@ func isSandboxTaskCompleted(ctx context.Context, kubeClient *clients.KubernetesC
 	state := annotations["sandbox.gemini.google.com/last-task-state"]
 	tType := annotations["sandbox.gemini.google.com/last-task-type"]
 
-	sbTaskType := taskType
+	sbTaskType := string(taskType)
 	switch taskType {
-	case "issue-fix":
+	case api.TypeIssueFix:
 		sbTaskType = "fix-issue"
-	case "agent-chore":
+	case api.TypeAgentChore:
 		sbTaskType = "agent"
-	case "pr-comments":
+	case api.TypePRComments:
 		sbTaskType = "address-comments"
-	case "pr-investigate":
+	case api.TypePRInvestigate:
 		sbTaskType = "investigate"
-	case "pr-iterate":
+	case api.TypePRIterate:
 		sbTaskType = "iterate"
-	case "pr-review":
+	case api.TypePRReview:
 		sbTaskType = "review"
 	}
 

--- a/factory/pkg/commands/watch/sandbox_test.go
+++ b/factory/pkg/commands/watch/sandbox_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/clients"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/common"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/watch/api"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/k8s"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -22,19 +23,19 @@ func TestIsSandboxTaskCompleted(t *testing.T) {
 	ns := "test-ns"
 
 	tests := []struct {
-		taskType          string
+		taskType          api.TaskType
 		annotatedTaskType string
 		state             string
 		expectedCompleted bool
 	}{
-		{"pr-comments", "address-comments", "Completed", true},
-		{"pr-comments", "address-comments", "Running", false},
-		{"pr-investigate", "investigate", "Completed", true},
-		{"pr-iterate", "iterate", "Completed", true},
-		{"pr-review", "review", "Completed", true},
-		{"issue-fix", "fix-issue", "Completed", true},
-		{"agent-chore", "agent", "Completed", true},
-		{"pr-comments", "wrong-type", "Completed", false},
+		{api.TypePRComments, "address-comments", "Completed", true},
+		{api.TypePRComments, "address-comments", "Running", false},
+		{api.TypePRInvestigate, "investigate", "Completed", true},
+		{api.TypePRIterate, "iterate", "Completed", true},
+		{api.TypePRReview, "review", "Completed", true},
+		{api.TypeIssueFix, "fix-issue", "Completed", true},
+		{api.TypeAgentChore, "agent", "Completed", true},
+		{api.TypePRComments, "wrong-type", "Completed", false},
 	}
 
 	for _, tc := range tests {
@@ -187,19 +188,19 @@ func TestResolveSandboxName(t *testing.T) {
 	}
 
 	// Issue task name
-	name := w.resolveSandboxName(context.Background(), "issue-fix", 10)
+	name := w.resolveSandboxName(context.Background(), api.TypeIssueFix, 10)
 	if name != "fix-test-repo-10" {
 		t.Errorf("expected 'fix-test-repo-10', got %q", name)
 	}
 
 	// Chore task name fallback
-	name = w.resolveSandboxName(context.Background(), "agent-chore", 10)
+	name = w.resolveSandboxName(context.Background(), api.TypeAgentChore, 10)
 	if name != "fix-test-repo-10" {
 		t.Errorf("expected 'fix-test-repo-10', got %q", name)
 	}
 
 	// PR task name fallback
-	name = w.resolveSandboxName(context.Background(), "pr-review", 55)
+	name = w.resolveSandboxName(context.Background(), api.TypePRReview, 55)
 	if name != "factory-pr-55" {
 		t.Errorf("expected 'factory-pr-55', got %q", name)
 	}

--- a/factory/pkg/commands/watch/scan_issue.go
+++ b/factory/pkg/commands/watch/scan_issue.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/common"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/watch/api"
 	githubv39 "github.com/google/go-github/v39/github"
 	"gopkg.in/yaml.v3"
 	"k8s.io/klog/v2"
@@ -60,7 +61,7 @@ func (w *Watcher) queueIssueTasks(ctx context.Context, issues []*githubv39.Issue
 		if info, err := os.Stat(processedPath); err == nil {
 			lastRunTime := info.ModTime()
 			if data, err := os.ReadFile(processedPath); err == nil {
-				var t QueueTask
+				var t api.QueueTask
 				if err := yaml.Unmarshal(data, &t); err == nil && !t.CompletedAt.IsZero() {
 					lastRunTime = t.CompletedAt
 				}
@@ -129,9 +130,9 @@ func (w *Watcher) queueIssueTasks(ctx context.Context, issues []*githubv39.Issue
 
 			triggerEventTime, triggerReason, triggerNotes := getIssueTriggerInfo(issue, timeline, w.triggerLabel, wasAutoLabeled)
 
-			taskType := "issue-fix"
+			taskType := api.TypeIssueFix
 			if workflowName != "" {
-				taskType = "agent-chore"
+				taskType = api.TypeAgentChore
 			}
 
 			taskAssignee, err := w.selectUserForTask(ctx, taskType, num)
@@ -143,12 +144,12 @@ func (w *Watcher) queueIssueTasks(ctx context.Context, issues []*githubv39.Issue
 				taskAssignee = w.targetAssignee
 			}
 
-			var task *QueueTask
+			var task *api.QueueTask
 			if workflowName != "" {
 				task = w.newIssueQueueTask(IssueTaskOptions{
-					Type:             "agent-chore",
+					Type:             api.TypeAgentChore,
 					Issue:            issue,
-					Phase:            4,
+					Phase:            api.PhaseChores,
 					Assignee:         taskAssignee,
 					TriggerEventTime: triggerEventTime,
 					TriggerReason:    triggerReason,
@@ -158,9 +159,9 @@ func (w *Watcher) queueIssueTasks(ctx context.Context, issues []*githubv39.Issue
 				})
 			} else {
 				task = w.newIssueQueueTask(IssueTaskOptions{
-					Type:             "issue-fix",
+					Type:             api.TypeIssueFix,
 					Issue:            issue,
-					Phase:            3,
+					Phase:            api.PhaseInvestigate,
 					Assignee:         taskAssignee,
 					TriggerEventTime: triggerEventTime,
 					TriggerReason:    triggerReason,

--- a/factory/pkg/commands/watch/scan_pr.go
+++ b/factory/pkg/commands/watch/scan_pr.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/common"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/watch/api"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/github"
 	githubv39 "github.com/google/go-github/v39/github"
 	"gopkg.in/yaml.v3"
@@ -537,7 +538,7 @@ func (w *Watcher) handlePRIterate(ctx context.Context, pc *prContext) {
 
 	filename := fmt.Sprintf("task-pr-%d-iterate.yaml", num)
 	if !taskExists(w.incomingDir, w.processingDir, filename) {
-		sandboxName := w.resolveSandboxName(ctx, "pr-iterate", num)
+		sandboxName := w.resolveSandboxName(ctx, api.TypePRIterate, num)
 		running, err := isSandboxTaskRunning(ctx, w.kubeClient, w.Namespace, sandboxName)
 		if err != nil {
 			klog.Errorf("Failed to check if sandbox %s is running: %v", sandboxName, err)
@@ -554,14 +555,14 @@ func (w *Watcher) handlePRIterate(ctx context.Context, pc *prContext) {
 		notes := fmt.Sprintf("PR #%d has merge conflicts with base branch '%s'; head commit %s committer date %s, PR updated at %s", num, baseRef, pc.shortSHA, pc.lastCommitTime.Format(time.RFC3339), pc.pr.GetUpdatedAt().Format(time.RFC3339))
 
 		task := w.newPRQueueTask(PRTaskOptions{
-			Type:             "pr-iterate",
+			Type:             api.TypePRIterate,
 			PR:               pc.pr,
 			PRIssue:          pc.prIssue,
-			Phase:            1,
+			Phase:            api.PhaseRebase,
 			Assignee:         pc.taskAssignee,
 			CommitSHA:        pc.headSHA,
 			TriggerEventTime: pc.lastCommitTime,
-			TriggerReason:    TriggerReasonPRMergeConflict,
+			TriggerReason:    api.TriggerReasonPRMergeConflict,
 			TriggerNotes:     notes,
 		})
 
@@ -600,7 +601,7 @@ func (w *Watcher) canInvestigatePR(
 	prevFailed := false
 	processedPath := filepath.Join(w.processedDir, filename)
 	if data, err := os.ReadFile(processedPath); err == nil {
-		var t QueueTask
+		var t api.QueueTask
 		if err := yaml.Unmarshal(data, &t); err == nil {
 			if t.Status == "Failed" {
 				prevFailed = true
@@ -639,7 +640,7 @@ func (w *Watcher) handlePRInvestigate(
 		prevFailed := false
 		processedPath := filepath.Join(w.processedDir, filename)
 		if data, err := os.ReadFile(processedPath); err == nil {
-			var t QueueTask
+			var t api.QueueTask
 			if err := yaml.Unmarshal(data, &t); err == nil {
 				if t.Status == "Failed" {
 					prevFailed = true
@@ -648,7 +649,7 @@ func (w *Watcher) handlePRInvestigate(
 		}
 
 		if state.lastInvestigatedSHA != pc.headSHA || prevFailed || pc.isExplicitlyAssigned || time.Since(state.lastInvestigatedTime) > 2*time.Hour {
-			sandboxName := w.resolveSandboxName(ctx, "pr-investigate", num)
+			sandboxName := w.resolveSandboxName(ctx, api.TypePRInvestigate, num)
 			running, err := isSandboxTaskRunning(ctx, w.kubeClient, w.Namespace, sandboxName)
 			if err != nil {
 				klog.Errorf("Failed to check if sandbox %s is running: %v", sandboxName, err)
@@ -673,14 +674,14 @@ func (w *Watcher) handlePRInvestigate(
 			notes := fmt.Sprintf("Earliest CI failure in '%s' (%s) at %s; total %d failed check(s) on commit %s", failName, failConclusion, eventTime.Format(time.RFC3339), checkAnalysis.failedCount, pc.shortSHA)
 
 			task := w.newPRQueueTask(PRTaskOptions{
-				Type:             "pr-investigate",
+				Type:             api.TypePRInvestigate,
 				PR:               pc.pr,
 				PRIssue:          pc.prIssue,
-				Phase:            3,
+				Phase:            api.PhaseInvestigate,
 				Assignee:         pc.taskAssignee,
 				CommitSHA:        pc.headSHA,
 				TriggerEventTime: eventTime,
-				TriggerReason:    TriggerReasonPRCheckFailed,
+				TriggerReason:    api.TriggerReasonPRCheckFailed,
 				TriggerNotes:     notes,
 			})
 
@@ -710,7 +711,7 @@ func (w *Watcher) handlePRComments(ctx context.Context, pc *prContext, commentAn
 	filename := fmt.Sprintf("task-pr-%d-comments.yaml", num)
 
 	if !taskExists(w.incomingDir, w.processingDir, filename) {
-		sandboxName := w.resolveSandboxName(ctx, "pr-comments", num)
+		sandboxName := w.resolveSandboxName(ctx, api.TypePRComments, num)
 		running, err := isSandboxTaskRunning(ctx, w.kubeClient, w.Namespace, sandboxName)
 		if err != nil {
 			klog.Errorf("Failed to check if sandbox %s is running: %v", sandboxName, err)
@@ -735,14 +736,14 @@ func (w *Watcher) handlePRComments(ctx context.Context, pc *prContext, commentAn
 		notes := fmt.Sprintf("Oldest unaddressed %s%s added at %s (ID %d)%s", cType, authorStr, commentAnalysis.oldestCommentTime.Format(time.RFC3339), commentAnalysis.oldestCommentID, commitInfo)
 
 		task := w.newPRQueueTask(PRTaskOptions{
-			Type:             "pr-comments",
+			Type:             api.TypePRComments,
 			PR:               pc.pr,
 			PRIssue:          pc.prIssue,
-			Phase:            2,
+			Phase:            api.PhaseComments,
 			Assignee:         pc.taskAssignee,
 			CommitSHA:        pc.headSHA,
 			TriggerEventTime: commentAnalysis.oldestCommentTime,
-			TriggerReason:    TriggerReasonPRCommentsAdded,
+			TriggerReason:    api.TriggerReasonPRCommentsAdded,
 			TriggerNotes:     notes,
 		})
 
@@ -777,7 +778,7 @@ func (w *Watcher) handlePRReview(ctx context.Context, pc *prContext, checkRuns [
 	filename := fmt.Sprintf("task-pr-%d-review.yaml", num)
 
 	if !taskExists(w.incomingDir, w.processingDir, filename) {
-		sandboxName := w.resolveSandboxName(ctx, "pr-review", num)
+		sandboxName := w.resolveSandboxName(ctx, api.TypePRReview, num)
 		running, err := isSandboxTaskRunning(ctx, w.kubeClient, w.Namespace, sandboxName)
 		if err != nil {
 			klog.Errorf("Failed to check if sandbox %s is running: %v", sandboxName, err)
@@ -816,13 +817,13 @@ func (w *Watcher) handlePRReview(ctx context.Context, pc *prContext, checkRuns [
 		}
 
 		task := w.newPRQueueTask(PRTaskOptions{
-			Type:             "pr-review",
+			Type:             api.TypePRReview,
 			PR:               pc.pr,
 			PRIssue:          pc.prIssue,
-			Phase:            2,
+			Phase:            api.PhaseComments,
 			CommitSHA:        pc.headSHA,
 			TriggerEventTime: eventTime,
-			TriggerReason:    TriggerReasonPRReadyForReview,
+			TriggerReason:    api.TriggerReasonPRReadyForReview,
 			TriggerNotes:     notes,
 			Instructions:     instructions,
 		})

--- a/factory/pkg/commands/watch/server.go
+++ b/factory/pkg/commands/watch/server.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/watch/api"
 	"gopkg.in/yaml.v3"
 	"k8s.io/klog/v2"
 )
@@ -106,14 +107,14 @@ func startQueueHTTPServer(ctx context.Context, queueDir string, addr string) {
 	_ = server.Close()
 }
 
-func buildQueueResponse(queueDir string) QueueResponse {
-	readQueueDir := func(sub string) []taskItem {
+func buildQueueResponse(queueDir string) api.QueueResponse {
+	readQueueDir := func(sub string) []api.TaskItem {
 		d := filepath.Join(queueDir, sub)
 		entries, err := os.ReadDir(d)
 		if err != nil {
 			return nil
 		}
-		var items []taskItem
+		var items []api.TaskItem
 		for _, e := range entries {
 			if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
 				continue
@@ -122,12 +123,12 @@ func buildQueueResponse(queueDir string) QueueResponse {
 			if err != nil {
 				continue
 			}
-			var t QueueTask
+			var t api.QueueTask
 			if err := yaml.Unmarshal(data, &t); err != nil {
 				continue
 			}
 			if t.Priority == "" {
-				t.Priority = "medium"
+				t.Priority = api.PriorityMedium
 			}
 			if t.EnqueuedAt.IsZero() {
 				var modTime time.Time
@@ -136,19 +137,19 @@ func buildQueueResponse(queueDir string) QueueResponse {
 				}
 				t.EnqueuedAt = getEnqueueTime(&t, modTime)
 			}
-			items = append(items, taskItem{
-				filename: e.Name(),
-				task:     &t,
+			items = append(items, api.TaskItem{
+				Filename: e.Name(),
+				Task:     &t,
 			})
 		}
 		return items
 	}
 
-	taskToItem := func(item taskItem, sub string) QueueTaskItem {
-		t := item.task
-		tPrio := strings.ToLower(t.Priority)
+	taskToItem := func(item api.TaskItem, sub string) api.QueueTaskItem {
+		t := item.Task
+		tPrio := t.Priority
 		if tPrio == "" {
-			tPrio = "medium"
+			tPrio = api.PriorityMedium
 		}
 		var createdStr, enqueuedStr, triggerEventStr, startedStr, completedStr string
 		if !t.CreatedAt.IsZero() {
@@ -170,8 +171,8 @@ func buildQueueResponse(queueDir string) QueueResponse {
 		if !t.StartedAt.IsZero() && !t.CompletedAt.IsZero() && t.CompletedAt.After(t.StartedAt) {
 			durationSec = t.CompletedAt.Sub(t.StartedAt).Seconds()
 		}
-		return QueueTaskItem{
-			FileName:         item.filename,
+		return api.QueueTaskItem{
+			FileName:         item.Filename,
 			QueueState:       sub,
 			Type:             t.Type,
 			URL:              t.URL,
@@ -195,7 +196,7 @@ func buildQueueResponse(queueDir string) QueueResponse {
 	incomingItems := readQueueDir("incoming")
 	sortedIncoming := sortTasksFairly(incomingItems)
 
-	var incoming []QueueTaskItem
+	var incoming []api.QueueTaskItem
 	for i, item := range sortedIncoming {
 		m := taskToItem(item, "incoming")
 		m.Rank = i + 1
@@ -203,19 +204,19 @@ func buildQueueResponse(queueDir string) QueueResponse {
 	}
 
 	processingItems := readQueueDir("processing")
-	var processing []QueueTaskItem
+	var processing []api.QueueTaskItem
 	for _, item := range processingItems {
 		processing = append(processing, taskToItem(item, "processing"))
 	}
 
 	processedItems := readQueueDir("processed")
-	var processed []QueueTaskItem
+	var processed []api.QueueTaskItem
 	for _, item := range processedItems {
 		processed = append(processed, taskToItem(item, "processed"))
 	}
 
-	byPrio := make(map[string]int)
-	byType := make(map[string]int)
+	byPrio := make(map[api.TaskPriority]int)
+	byType := make(map[api.TaskType]int)
 	for _, item := range incoming {
 		byPrio[item.Priority]++
 		byType[item.Type]++
@@ -225,8 +226,8 @@ func buildQueueResponse(queueDir string) QueueResponse {
 		processed = processed[:20]
 	}
 
-	return QueueResponse{
-		Summary: QueueSummary{
+	return api.QueueResponse{
+		Summary: api.QueueSummary{
 			TotalPending:    len(incoming),
 			TotalProcessing: len(processing),
 			TotalCompleted:  len(processed),

--- a/factory/pkg/commands/watch/server_test.go
+++ b/factory/pkg/commands/watch/server_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/watch/api"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -77,34 +78,34 @@ createdAt: "2026-08-10T11:00:00Z"
 			t.Errorf("expected non-empty fallback enqueuedAt for task 2")
 		}
 
-		expectedIncoming := []QueueTaskItem{
+		expectedIncoming := []api.QueueTaskItem{
 			{
 				FileName:   "task1.yaml",
 				QueueState: "incoming",
-				Type:       "pr-review",
+				Type:       api.TypePRReview,
 				URL:        "https://github.com/org/repo/pull/42",
 				Number:     42,
-				Priority:   "critical",
-				Phase:      2,
+				Priority:   api.PriorityCritical,
+				Phase:      api.PhaseComments,
 				CreatedAt:  "2026-08-10T10:00:00Z",
 				EnqueuedAt: "2026-08-10T10:05:00Z",
 				Assignee:   "alice",
-				Status:     "Pending",
+				Status:     api.StatusPending,
 				CommitSHA:  "abc123def",
 				Rank:       1,
 			},
 			{
 				FileName:   "task2.yaml",
 				QueueState: "incoming",
-				Type:       "issue-fix",
+				Type:       api.TypeIssueFix,
 				URL:        "https://github.com/org/repo/issues/99",
 				Number:     99,
-				Priority:   "medium",
+				Priority:   api.PriorityMedium,
 				Phase:      0,
 				CreatedAt:  "2026-08-10T11:00:00Z",
 				EnqueuedAt: resp.Incoming[1].EnqueuedAt,
 				Assignee:   "",
-				Status:     "Pending",
+				Status:     api.StatusPending,
 				CommitSHA:  "",
 				Rank:       2,
 			},
@@ -315,7 +316,7 @@ func TestStartQueueHTTPServer(t *testing.T) {
 	if getResp.StatusCode != http.StatusOK {
 		t.Errorf("expected status OK, got %v", getResp.StatusCode)
 	}
-	var qResp QueueResponse
+	var qResp api.QueueResponse
 	if err := json.NewDecoder(getResp.Body).Decode(&qResp); err != nil {
 		t.Fatalf("failed to decode JSON response: %v", err)
 	}

--- a/factory/pkg/commands/watch/trigger_metadata_test.go
+++ b/factory/pkg/commands/watch/trigger_metadata_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/clients"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/common"
+	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/commands/watch/api"
 	"github.com/gke-labs/gemini-for-kubernetes-development/factory/pkg/k8s"
 	githubv39 "github.com/google/go-github/v39/github"
 	"gopkg.in/yaml.v3"
@@ -50,8 +51,8 @@ func TestGetIssueTriggerInfo(t *testing.T) {
 		if !eventTime.Equal(t1) {
 			t.Errorf("expected eventTime %v, got %v", t1, eventTime)
 		}
-		if reason != TriggerReasonIssueCreated {
-			t.Errorf("expected reason %s, got %s", TriggerReasonIssueCreated, reason)
+		if reason != api.TriggerReasonIssueCreated {
+			t.Errorf("expected reason %s, got %s", api.TriggerReasonIssueCreated, reason)
 		}
 		if !strings.Contains(notes, "Issue #42 created at 2026-08-01T10:00:00Z with trigger label 'factory'") {
 			t.Errorf("unexpected notes: %s", notes)
@@ -79,8 +80,8 @@ func TestGetIssueTriggerInfo(t *testing.T) {
 		if !eventTime.Equal(t2) {
 			t.Errorf("expected eventTime %v, got %v", t2, eventTime)
 		}
-		if reason != TriggerReasonIssueLabeled {
-			t.Errorf("expected reason %s, got %s", TriggerReasonIssueLabeled, reason)
+		if reason != api.TriggerReasonIssueLabeled {
+			t.Errorf("expected reason %s, got %s", api.TriggerReasonIssueLabeled, reason)
 		}
 		if !strings.Contains(notes, "trigger label 'factory' added by alice at 2026-08-01T11:30:00Z") {
 			t.Errorf("unexpected notes: %s", notes)
@@ -98,8 +99,8 @@ func TestGetIssueTriggerInfo(t *testing.T) {
 		if !eventTime.Equal(t1) {
 			t.Errorf("expected eventTime %v, got %v", t1, eventTime)
 		}
-		if reason != TriggerReasonIssueCreated {
-			t.Errorf("expected reason %s, got %s", TriggerReasonIssueCreated, reason)
+		if reason != api.TriggerReasonIssueCreated {
+			t.Errorf("expected reason %s, got %s", api.TriggerReasonIssueCreated, reason)
 		}
 		if !strings.Contains(notes, "auto-applied by watcher") {
 			t.Errorf("unexpected notes: %s", notes)
@@ -215,7 +216,7 @@ func TestPRCommentsTriggerMetadata(t *testing.T) {
 		t.Fatalf("expected task-pr-10-comments.yaml to be created: %v", err)
 	}
 
-	var task QueueTask
+	var task api.QueueTask
 	if err := yaml.Unmarshal(data, &task); err != nil {
 		t.Fatalf("failed to unmarshal task: %v", err)
 	}
@@ -223,8 +224,8 @@ func TestPRCommentsTriggerMetadata(t *testing.T) {
 	if !task.TriggerEventTime.Equal(comment1Time) {
 		t.Errorf("expected triggerEventTime %v (oldest comment), got %v", comment1Time, task.TriggerEventTime)
 	}
-	if task.TriggerReason != TriggerReasonPRCommentsAdded {
-		t.Errorf("expected triggerReason %s, got %s", TriggerReasonPRCommentsAdded, task.TriggerReason)
+	if task.TriggerReason != api.TriggerReasonPRCommentsAdded {
+		t.Errorf("expected triggerReason %s, got %s", api.TriggerReasonPRCommentsAdded, task.TriggerReason)
 	}
 	if !strings.Contains(task.TriggerNotes, "reviewer-alice") || !strings.Contains(task.TriggerNotes, "1000") {
 		t.Errorf("unexpected triggerNotes: %s", task.TriggerNotes)
@@ -339,7 +340,7 @@ func TestPRInvestigateTriggerMetadata(t *testing.T) {
 		t.Fatalf("expected task-pr-10-investigate.yaml to be created: %v", err)
 	}
 
-	var task QueueTask
+	var task api.QueueTask
 	if err := yaml.Unmarshal(data, &task); err != nil {
 		t.Fatalf("failed to unmarshal task: %v", err)
 	}
@@ -347,8 +348,8 @@ func TestPRInvestigateTriggerMetadata(t *testing.T) {
 	if !task.TriggerEventTime.Equal(fail1Time) {
 		t.Errorf("expected triggerEventTime %v (earliest failure), got %v", fail1Time, task.TriggerEventTime)
 	}
-	if task.TriggerReason != TriggerReasonPRCheckFailed {
-		t.Errorf("expected triggerReason %s, got %s", TriggerReasonPRCheckFailed, task.TriggerReason)
+	if task.TriggerReason != api.TriggerReasonPRCheckFailed {
+		t.Errorf("expected triggerReason %s, got %s", api.TriggerReasonPRCheckFailed, task.TriggerReason)
 	}
 	if !strings.Contains(task.TriggerNotes, "lint-go") || !strings.Contains(task.TriggerNotes, "2 failed check(s)") {
 		t.Errorf("unexpected triggerNotes: %s", task.TriggerNotes)
@@ -442,7 +443,7 @@ func TestPRIterateTriggerMetadata(t *testing.T) {
 		t.Fatalf("expected task-pr-10-iterate.yaml to be created: %v", err)
 	}
 
-	var task QueueTask
+	var task api.QueueTask
 	if err := yaml.Unmarshal(data, &task); err != nil {
 		t.Fatalf("failed to unmarshal task: %v", err)
 	}
@@ -450,8 +451,8 @@ func TestPRIterateTriggerMetadata(t *testing.T) {
 	if !task.TriggerEventTime.Equal(commitTime) {
 		t.Errorf("expected triggerEventTime %v (commit time), got %v", commitTime, task.TriggerEventTime)
 	}
-	if task.TriggerReason != TriggerReasonPRMergeConflict {
-		t.Errorf("expected triggerReason %s, got %s", TriggerReasonPRMergeConflict, task.TriggerReason)
+	if task.TriggerReason != api.TriggerReasonPRMergeConflict {
+		t.Errorf("expected triggerReason %s, got %s", api.TriggerReasonPRMergeConflict, task.TriggerReason)
 	}
 	if !strings.Contains(task.TriggerNotes, "merge conflicts with base branch 'main'") {
 		t.Errorf("unexpected triggerNotes: %s", task.TriggerNotes)
@@ -466,18 +467,18 @@ func TestBuildQueueResponseTriggerFields(t *testing.T) {
 	eventTime := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
 	enqueuedTime := time.Date(2026, 8, 1, 10, 15, 0, 0, time.UTC)
 
-	task := &QueueTask{
-		Type:             "pr-comments",
+	task := &api.QueueTask{
+		Type:             api.TypePRComments,
 		URL:              "https://github.com/owner/repo/pull/123",
 		Number:           123,
-		Priority:         "medium",
-		Phase:            2,
+		Priority:         api.PriorityMedium,
+		Phase:            api.PhaseComments,
 		CreatedAt:        eventTime,
 		EnqueuedAt:       enqueuedTime,
 		TriggerEventTime: eventTime,
-		TriggerReason:    TriggerReasonPRCommentsAdded,
+		TriggerReason:    api.TriggerReasonPRCommentsAdded,
 		TriggerNotes:     "Oldest comment by alice added at 2026-08-01T10:00:00Z",
-		Status:           "Pending",
+		Status:           api.StatusPending,
 	}
 
 	_ = writeTaskAtomically(incomingDir, "task-pr-123-comments.yaml", task)
@@ -491,8 +492,8 @@ func TestBuildQueueResponseTriggerFields(t *testing.T) {
 	if item.TriggerEventTime != eventTime.Format(time.RFC3339) {
 		t.Errorf("expected item TriggerEventTime %s, got %s", eventTime.Format(time.RFC3339), item.TriggerEventTime)
 	}
-	if item.TriggerReason != TriggerReasonPRCommentsAdded {
-		t.Errorf("expected item TriggerReason '%s', got '%s'", TriggerReasonPRCommentsAdded, item.TriggerReason)
+	if item.TriggerReason != api.TriggerReasonPRCommentsAdded {
+		t.Errorf("expected item TriggerReason '%s', got '%s'", api.TriggerReasonPRCommentsAdded, item.TriggerReason)
 	}
 	if item.TriggerNotes != "Oldest comment by alice added at 2026-08-01T10:00:00Z" {
 		t.Errorf("expected item TriggerNotes 'Oldest comment by alice added at 2026-08-01T10:00:00Z', got '%s'", item.TriggerNotes)
@@ -509,26 +510,26 @@ func TestBuildQueueResponseStartedCompletedDuration(t *testing.T) {
 	startTime := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
 	endTime := time.Date(2026, 8, 1, 10, 5, 30, 0, time.UTC)
 
-	processingTask := &QueueTask{
-		Type:      "pr-review",
+	processingTask := &api.QueueTask{
+		Type:      api.TypePRReview,
 		URL:       "https://github.com/owner/repo/pull/1",
 		Number:    1,
-		Status:    "Running",
+		Status:    api.StatusRunning,
 		StartedAt: startTime,
-		Priority:  "high",
-		Phase:     2,
+		Priority:  api.PriorityHigh,
+		Phase:     api.PhaseComments,
 	}
 	_ = writeTaskAtomically(processingDir, "task-pr-1-review.yaml", processingTask)
 
-	completedTask := &QueueTask{
-		Type:        "issue-fix",
+	completedTask := &api.QueueTask{
+		Type:        api.TypeIssueFix,
 		URL:         "https://github.com/owner/repo/issues/2",
 		Number:      2,
-		Status:      "Completed",
+		Status:      api.StatusCompleted,
 		StartedAt:   startTime,
 		CompletedAt: endTime,
-		Priority:    "medium",
-		Phase:       3,
+		Priority:    api.PriorityMedium,
+		Phase:       api.PhaseInvestigate,
 	}
 	_ = writeTaskAtomically(processedDir, "task-issue-2-fix.yaml", completedTask)
 

--- a/factory/pkg/commands/watch/types.go
+++ b/factory/pkg/commands/watch/types.go
@@ -91,88 +91,8 @@ func NewWatcher(rootFlags common.RootFlags, flags Flags) *Watcher {
 	}
 }
 
-// TriggerReason represents a machine-readable, PascalCase reason for why a queue task was triggered,
-// following Kubernetes API conventions.
-type TriggerReason string
-
-const (
-	// TriggerReasonIssueCreated indicates the task was triggered because an issue was newly created
-	// (either already labeled with the trigger label or auto-labeled by the watcher).
-	TriggerReasonIssueCreated TriggerReason = "IssueCreated"
-
-	// TriggerReasonIssueLabeled indicates the task was triggered because the trigger label was
-	// added to an existing issue after its creation.
-	TriggerReasonIssueLabeled TriggerReason = "IssueLabeled"
-
-	// TriggerReasonPRCommentsAdded indicates the task was triggered by new unaddressed comments or reviews on a PR.
-	TriggerReasonPRCommentsAdded TriggerReason = "PRCommentsAdded"
-
-	// TriggerReasonPRCheckFailed indicates the task was triggered by a failed CI check run or commit status.
-	TriggerReasonPRCheckFailed TriggerReason = "PRCheckFailed"
-
-	// TriggerReasonPRMergeConflict indicates the task was triggered by merge conflicts with the base branch.
-	TriggerReasonPRMergeConflict TriggerReason = "PRMergeConflict"
-
-	// TriggerReasonPRReadyForReview indicates the task was triggered because all CI checks passed and the PR is ready for automated review.
-	TriggerReasonPRReadyForReview TriggerReason = "PRReadyForReview"
-
-	// TriggerReasonChoreScheduled indicates the task was triggered by a scheduled cron chore.
-	TriggerReasonChoreScheduled TriggerReason = "ChoreScheduled"
-)
-
-type QueueTask struct {
-	Type       string    `yaml:"type"` // "issue-fix", "pr-investigate", "pr-comments", "pr-iterate", "pr-review", "agent-chore"
-	URL        string    `yaml:"url"`
-	Number     int       `yaml:"number"`
-	Priority   string    `yaml:"priority"` // "critical", "urgent", "important", "high", "medium", "low"
-	Phase      int       `yaml:"phase"`    // 1: Rebase/iterate, 2: Comments, 3: Investigate/Fix, 4: Chores
-	CreatedAt  time.Time `yaml:"createdAt"`
-	EnqueuedAt time.Time `yaml:"enqueuedAt,omitempty"`
-	// TriggerEventTime is the timestamp when the original event that triggered this task occurred
-	// (e.g. oldest comment time, earliest CI check failure, or issue creation/labeling time).
-	TriggerEventTime time.Time `yaml:"triggerEventTime,omitempty"`
-	// TriggerReason is a machine-readable enum indicating the type of triggering event (e.g. IssueCreated, PRCommentsAdded).
-	TriggerReason TriggerReason `yaml:"triggerReason,omitempty"`
-	// TriggerNotes contains human-readable details about the triggering event (e.g. specific check that failed, comment author).
-	TriggerNotes string `yaml:"triggerNotes,omitempty"`
-	// StartedAt is the timestamp when the task began execution in processing.
-	StartedAt time.Time `yaml:"startedAt,omitempty"`
-	// CompletedAt is the timestamp when the task completed execution (either Completed or Failed).
-	CompletedAt  time.Time `yaml:"completedAt,omitempty"`
-	Assignee     string    `yaml:"assignee,omitempty"`
-	Status       string    `yaml:"status"` // "Pending", "Running", "Completed", "Failed"
-	Error        string    `yaml:"error,omitempty"`
-	AgentFile    string    `yaml:"agentFile,omitempty"` // For chore tasks
-	SessionID    string    `yaml:"sessionId,omitempty"` // For workflow sessions
-	CommitSHA    string    `yaml:"commitSHA,omitempty"`
-	Instructions []string  `yaml:"instructions,omitempty"`
-	Recovered    bool      `yaml:"recovered,omitempty"`
-}
-
-// taskItem represents a queue task bundled with its filename.
-type taskItem struct {
-	filename string
-	task     *QueueTask
-}
-
 type ChoreRunState struct {
 	LastRun time.Time `json:"lastRun"`
-}
-
-type JournalEvent struct {
-	Timestamp        time.Time     `json:"timestamp"`
-	TaskID           string        `json:"taskId"`
-	Event            string        `json:"event"`
-	Type             string        `json:"type"`
-	URL              string        `json:"url"`
-	Priority         string        `json:"priority"`
-	TriggerEventTime time.Time     `json:"triggerEventTime,omitempty"`
-	TriggerReason    TriggerReason `json:"triggerReason,omitempty"`
-	TriggerNotes     string        `json:"triggerNotes,omitempty"`
-	StartedAt        time.Time     `json:"startedAt,omitempty"`
-	CompletedAt      time.Time     `json:"completedAt,omitempty"`
-	Error            string        `json:"error,omitempty"`
-	DurationSecond   float64       `json:"durationSeconds,omitempty"`
 }
 
 // prWatchState tracks the progress and state of automated tasks for a monitored pull request.
@@ -191,43 +111,6 @@ type prWatchState struct {
 	lastIteratedSHA string
 	// lastIteratedTime is the timestamp when a rebase/conflict-resolution task was last queued or completed.
 	lastIteratedTime time.Time
-}
-
-type QueueTaskItem struct {
-	FileName         string        `json:"fileName"`
-	QueueState       string        `json:"queueState"`
-	Type             string        `json:"type"`
-	URL              string        `json:"url"`
-	Number           int           `json:"number"`
-	Priority         string        `json:"priority"`
-	Phase            int           `json:"phase"`
-	CreatedAt        string        `json:"createdAt"`
-	EnqueuedAt       string        `json:"enqueuedAt,omitempty"`
-	StartedAt        string        `json:"startedAt,omitempty"`
-	CompletedAt      string        `json:"completedAt,omitempty"`
-	DurationSeconds  float64       `json:"durationSeconds,omitempty"`
-	TriggerEventTime string        `json:"triggerEventTime,omitempty"`
-	TriggerReason    TriggerReason `json:"triggerReason,omitempty"`
-	TriggerNotes     string        `json:"triggerNotes,omitempty"`
-	Assignee         string        `json:"assignee"`
-	Status           string        `json:"status"`
-	CommitSHA        string        `json:"commitSHA"`
-	Rank             int           `json:"rank,omitempty"`
-}
-
-type QueueSummary struct {
-	TotalPending    int            `json:"totalPending"`
-	TotalProcessing int            `json:"totalProcessing"`
-	TotalCompleted  int            `json:"totalCompleted"`
-	ByPriority      map[string]int `json:"byPriority"`
-	ByType          map[string]int `json:"byType"`
-}
-
-type QueueResponse struct {
-	Summary    QueueSummary    `json:"summary"`
-	Incoming   []QueueTaskItem `json:"incoming"`
-	Processing []QueueTaskItem `json:"processing"`
-	Processed  []QueueTaskItem `json:"processed"`
 }
 
 type watchState struct {


### PR DESCRIPTION
Extract task queue data structures and HTTP server API schemas into a dedicated watch/api package. Split the types cleanly between queue.go and server.go, define enumerated types for Type, Priority, Phase, and Status, and move TriggerReason into the api package. Update watch callers and tests to reference the new package.