### PR TITLE
fix(watch): stop re-triggering issues that already have an open PR

### DIFF
--- a/factory/pkg/commands/watch/github_helpers.go
+++ b/factory/pkg/commands/watch/github_helpers.go
@@ -105,24 +105,63 @@ func getMissingLabelsForPR(prLabels []*githubv39.Label, refIssues []*githubv39.I
 	return allMissingLabels
 }
 
-func hasLinkedPR(ctx context.Context, client *githubv39.Client, owner, repo string, issueNum int) (bool, error) {
-	// 1. Try timeline check (quick and standard)
-	timeline, _, err := client.Issues.ListIssueTimeline(ctx, owner, repo, issueNum, nil)
-	if err == nil {
-		for _, event := range timeline {
-			if event.GetEvent() == "cross-referenced" && event.Source != nil {
-				if event.Source.Issue != nil && event.Source.Issue.PullRequestLinks != nil {
-					if event.Source.Issue.GetState() == "open" {
-						return true, nil
-					}
+// timelinePageSize is the maximum page size the GitHub timeline API accepts.
+const timelinePageSize = 100
+
+// maxTimelinePages caps timeline pagination so a pathologically noisy issue
+// cannot stall a scan cycle or burn the whole API rate limit budget.
+const maxTimelinePages = 20
+
+// listAllIssueTimeline retrieves the timeline events for an issue, following
+// pagination.
+//
+// The GitHub API returns only 30 events per page by default, so an unpaginated
+// call silently truncates the history of long-lived issues. Cross-reference
+// events are ordered oldest-first, which means the most recent (and therefore
+// most relevant) linked PR is the one most likely to be dropped.
+//
+// The boolean return reports whether the full timeline was read. It is false
+// when pagination was cut short by maxTimelinePages, in which case callers must
+// not treat the absence of an event as proof that it does not exist.
+func listAllIssueTimeline(ctx context.Context, client *githubv39.Client, owner, repo string, issueNum int) ([]*githubv39.Timeline, bool, error) {
+	// Start non-nil so that a successful call never returns nil: callers use a
+	// nil timeline to mean "could not be determined".
+	all := []*githubv39.Timeline{}
+	opts := &githubv39.ListOptions{PerPage: timelinePageSize}
+	for page := 0; page < maxTimelinePages; page++ {
+		events, resp, err := client.Issues.ListIssueTimeline(ctx, owner, repo, issueNum, opts)
+		if err != nil {
+			return nil, false, err
+		}
+		all = append(all, events...)
+		if resp == nil || resp.NextPage == 0 {
+			return all, true, nil
+		}
+		opts.Page = resp.NextPage
+	}
+	klog.Warningf("Issue #%d has more than %d pages of timeline events; results are truncated", issueNum, maxTimelinePages)
+	return all, false, nil
+}
+
+// timelineHasOpenLinkedPR reports whether the timeline contains a cross-reference
+// from a pull request that is still open.
+func timelineHasOpenLinkedPR(timeline []*githubv39.Timeline) bool {
+	for _, event := range timeline {
+		if event.GetEvent() == "cross-referenced" && event.Source != nil {
+			if event.Source.Issue != nil && event.Source.Issue.PullRequestLinks != nil {
+				if event.Source.Issue.GetState() == "open" {
+					return true
 				}
 			}
 		}
-	} else {
-		klog.Warningf("Failed to list issue timeline for #%d: %v. Falling back to search API.", issueNum, err)
 	}
+	return false
+}
 
-	// 2. Fallback to Search API: search for open PRs referencing the issue number
+// searchForOpenLinkedPR asks the Search API whether any open PR mentions the
+// issue number. It is the fallback for when the timeline is unavailable or
+// incomplete.
+func searchForOpenLinkedPR(ctx context.Context, client *githubv39.Client, owner, repo string, issueNum int) (bool, error) {
 	query := fmt.Sprintf("repo:%s/%s type:pr state:open \"%d\"", owner, repo, issueNum)
 	opts := &githubv39.SearchOptions{
 		ListOptions: githubv39.ListOptions{PerPage: 10},
@@ -131,26 +170,34 @@ func hasLinkedPR(ctx context.Context, client *githubv39.Client, owner, repo stri
 	if err != nil {
 		return false, fmt.Errorf("failed to search PRs for issue #%d: %w", issueNum, err)
 	}
-
-	if result.GetTotal() > 0 {
-		return true, nil
-	}
-
-	return false, nil
+	return result.GetTotal() > 0, nil
 }
 
+func hasLinkedPR(ctx context.Context, client *githubv39.Client, owner, repo string, issueNum int) (bool, error) {
+	// 1. Try timeline check (quick and standard)
+	timeline, complete, err := listAllIssueTimeline(ctx, client, owner, repo, issueNum)
+	if err == nil {
+		if timelineHasOpenLinkedPR(timeline) {
+			return true, nil
+		}
+		if complete {
+			return false, nil
+		}
+		klog.Warningf("Timeline for issue #%d was truncated. Falling back to search API.", issueNum)
+	} else {
+		klog.Warningf("Failed to list issue timeline for #%d: %v. Falling back to search API.", issueNum, err)
+	}
+
+	// 2. Fallback to Search API: search for open PRs referencing the issue number
+	return searchForOpenLinkedPR(ctx, client, owner, repo, issueNum)
+}
+
+// hasLinkedPRWithTimeline reuses a timeline the caller already fetched to avoid a
+// redundant API round trip. A nil timeline means the caller could not fetch one,
+// so we fall back to fetching it (and the Search API) ourselves.
 func hasLinkedPRWithTimeline(ctx context.Context, client *githubv39.Client, owner, repo string, issueNum int, timeline []*githubv39.Timeline) (bool, error) {
 	if timeline != nil {
-		for _, event := range timeline {
-			if event.GetEvent() == "cross-referenced" && event.Source != nil {
-				if event.Source.Issue != nil && event.Source.Issue.PullRequestLinks != nil {
-					if event.Source.Issue.GetState() == "open" {
-						return true, nil
-					}
-				}
-			}
-		}
-		return false, nil
+		return timelineHasOpenLinkedPR(timeline), nil
 	}
 	return hasLinkedPR(ctx, client, owner, repo, issueNum)
 }

--- a/factory/pkg/commands/watch/scan_issue.go
+++ b/factory/pkg/commands/watch/scan_issue.go
@@ -75,16 +75,28 @@ func (w *Watcher) queueIssueTasks(ctx context.Context, issues []*githubv39.Issue
 		lastProcessed, ok := w.processedIssues[num]
 		if !ok || issue.GetUpdatedAt().After(lastProcessed) || workflowName != "" {
 			var timeline []*githubv39.Timeline
+			timelineComplete := false
 			if w.ghClient != nil {
-				tl, _, err := w.ghClient.Issues.ListIssueTimeline(ctx, w.Repo.Owner, w.Repo.Repo, num, nil)
-				if err == nil {
+				tl, complete, err := listAllIssueTimeline(ctx, w.ghClient, w.Repo.Owner, w.Repo.Repo, num)
+				if err != nil {
+					klog.Warningf("Failed to list timeline for issue #%d: %v", num, err)
+				} else {
 					timeline = tl
+					timelineComplete = complete
 				}
 			}
 
 			// Skip KRM check for workflow triggers since they don't necessarily have linked code PRs
 			if workflowName == "" {
-				linked, err := hasLinkedPRWithTimeline(ctx, w.ghClient, w.Repo.Owner, w.Repo.Repo, num, timeline)
+				// Only let the linked-PR check trust the timeline we already
+				// fetched if it is complete. A missing or truncated timeline
+				// cannot prove the absence of a linked PR, so pass nil and let
+				// hasLinkedPRWithTimeline fall back to the Search API.
+				var verifiedTimeline []*githubv39.Timeline
+				if timelineComplete {
+					verifiedTimeline = timeline
+				}
+				linked, err := hasLinkedPRWithTimeline(ctx, w.ghClient, w.Repo.Owner, w.Repo.Repo, num, verifiedTimeline)
 				if err != nil {
 					klog.Errorf("Failed to check linked PR for issue #%d: %v", num, err)
 					continue

--- a/factory/pkg/commands/watch/timeline_test.go
+++ b/factory/pkg/commands/watch/timeline_test.go
@@ -1,0 +1,252 @@
+package watch
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+
+	githubv39 "github.com/google/go-github/v39/github"
+)
+
+// timelineServerOpts configures the fake GitHub timeline endpoint.
+type timelineServerOpts struct {
+	// pages holds the raw JSON body for each page, in order.
+	pages []string
+	// searchTotal is the total_count returned by the search API.
+	searchTotal int
+	// failSearch makes the search endpoint return a 403.
+	failSearch bool
+	// failTimeline makes the timeline endpoint return a 403.
+	failTimeline bool
+}
+
+// newTimelineTestClient spins up a fake GitHub API that paginates the timeline
+// endpoint via the Link header, exactly like the real API does.
+func newTimelineTestClient(t *testing.T, opts timelineServerOpts) (*githubv39.Client, func(), *int) {
+	t.Helper()
+
+	timelineRequests := 0
+	var serverURL string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/search/issues":
+			if opts.failSearch {
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(`{"message":"API rate limit exceeded"}`))
+				return
+			}
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"total_count":%d,"items":[]}`, opts.searchTotal)))
+
+		case "/repos/test-owner/test-repo/issues/9259/timeline":
+			timelineRequests++
+			if opts.failTimeline {
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(`{"message":"API rate limit exceeded"}`))
+				return
+			}
+			page := 1
+			if p := r.URL.Query().Get("page"); p != "" {
+				page, _ = strconv.Atoi(p)
+			}
+			if page < 1 || page > len(opts.pages) {
+				_, _ = w.Write([]byte(`[]`))
+				return
+			}
+			if page < len(opts.pages) {
+				w.Header().Set("Link", fmt.Sprintf(`<%s/repos/test-owner/test-repo/issues/9259/timeline?page=%d>; rel="next"`, serverURL, page+1))
+			}
+			_, _ = w.Write([]byte(opts.pages[page-1]))
+
+		default:
+			t.Errorf("unexpected request to %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	serverURL = server.URL
+
+	client := githubv39.NewClient(nil)
+	client.BaseURL, _ = url.Parse(server.URL + "/")
+
+	return client, server.Close, &timelineRequests
+}
+
+// crossRefIssue is a cross-reference from a plain issue (not a PR).
+const crossRefIssue = `{"event":"cross-referenced","source":{"issue":{"number":8439,"state":"open"}}}`
+
+// crossRefClosedPR is a cross-reference from a PR that has since been closed.
+const crossRefClosedPR = `{"event":"cross-referenced","source":{"issue":{"number":11169,"state":"closed","pull_request":{"url":"https://api.github.com/repos/test-owner/test-repo/pulls/11169"}}}}`
+
+// crossRefOpenPR is a cross-reference from the open PR that fixes the issue.
+const crossRefOpenPR = `{"event":"cross-referenced","source":{"issue":{"number":12689,"state":"open","pull_request":{"url":"https://api.github.com/repos/test-owner/test-repo/pulls/12689"}}}}`
+
+func TestListAllIssueTimeline_FollowsPagination(t *testing.T) {
+	client, closeFn, requests := newTimelineTestClient(t, timelineServerOpts{
+		pages: []string{
+			"[" + crossRefIssue + "," + crossRefClosedPR + "]",
+			"[" + crossRefOpenPR + "]",
+		},
+	})
+	defer closeFn()
+
+	timeline, complete, err := listAllIssueTimeline(context.Background(), client, "test-owner", "test-repo", 9259)
+	if err != nil {
+		t.Fatalf("listAllIssueTimeline() returned error: %v", err)
+	}
+	if !complete {
+		t.Errorf("complete = false; want true")
+	}
+	if *requests != 2 {
+		t.Errorf("made %d timeline requests; want 2 (pagination not followed)", *requests)
+	}
+	if len(timeline) != 3 {
+		t.Fatalf("got %d timeline events; want 3", len(timeline))
+	}
+}
+
+func TestListAllIssueTimeline_ErrorReturnsNilTimeline(t *testing.T) {
+	client, closeFn, _ := newTimelineTestClient(t, timelineServerOpts{failTimeline: true})
+	defer closeFn()
+
+	timeline, complete, err := listAllIssueTimeline(context.Background(), client, "test-owner", "test-repo", 9259)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if complete {
+		t.Errorf("complete = true; want false on error")
+	}
+	// Callers rely on a nil timeline meaning "unknown"; a partial slice would
+	// be mistaken for an authoritative answer.
+	if timeline != nil {
+		t.Errorf("timeline = %v; want nil on error", timeline)
+	}
+}
+
+// TestHasLinkedPR_DetectsPROnLaterPage is the regression test for
+// GoogleCloudPlatform/k8s-config-connector#9259: the only open linked PR was
+// event 45 of 46, so the unpaginated (30 event) timeline check missed it and
+// the watcher re-triggered a fix for an issue that already had an open PR.
+func TestHasLinkedPR_DetectsPROnLaterPage(t *testing.T) {
+	client, closeFn, _ := newTimelineTestClient(t, timelineServerOpts{
+		pages: []string{
+			// Page 1 mirrors the real issue: a cross-referenced issue (not a
+			// PR) and a cross-referenced PR that is already closed.
+			"[" + crossRefIssue + "," + crossRefClosedPR + "]",
+			"[" + crossRefOpenPR + "]",
+		},
+		// The search fallback would mask the bug, so make it return nothing.
+		searchTotal: 0,
+	})
+	defer closeFn()
+
+	linked, err := hasLinkedPR(context.Background(), client, "test-owner", "test-repo", 9259)
+	if err != nil {
+		t.Fatalf("hasLinkedPR() returned error: %v", err)
+	}
+	if !linked {
+		t.Error("hasLinkedPR() = false; want true (open PR #12689 is on timeline page 2)")
+	}
+}
+
+func TestHasLinkedPR_NoOpenPR(t *testing.T) {
+	client, closeFn, _ := newTimelineTestClient(t, timelineServerOpts{
+		pages:       []string{"[" + crossRefIssue + "," + crossRefClosedPR + "]"},
+		searchTotal: 0,
+	})
+	defer closeFn()
+
+	linked, err := hasLinkedPR(context.Background(), client, "test-owner", "test-repo", 9259)
+	if err != nil {
+		t.Fatalf("hasLinkedPR() returned error: %v", err)
+	}
+	if linked {
+		t.Error("hasLinkedPR() = true; want false (only a closed PR and a plain issue reference it)")
+	}
+}
+
+func TestHasLinkedPR_FallsBackToSearchWhenTimelineFails(t *testing.T) {
+	client, closeFn, _ := newTimelineTestClient(t, timelineServerOpts{
+		failTimeline: true,
+		searchTotal:  1,
+	})
+	defer closeFn()
+
+	linked, err := hasLinkedPR(context.Background(), client, "test-owner", "test-repo", 9259)
+	if err != nil {
+		t.Fatalf("hasLinkedPR() returned error: %v", err)
+	}
+	if !linked {
+		t.Error("hasLinkedPR() = false; want true from the search fallback")
+	}
+}
+
+// TestHasLinkedPR_ErrorsWhenBothChecksFail asserts we fail closed: the caller
+// skips the issue on error rather than assuming there is no linked PR.
+func TestHasLinkedPR_ErrorsWhenBothChecksFail(t *testing.T) {
+	client, closeFn, _ := newTimelineTestClient(t, timelineServerOpts{
+		failTimeline: true,
+		failSearch:   true,
+	})
+	defer closeFn()
+
+	if _, err := hasLinkedPR(context.Background(), client, "test-owner", "test-repo", 9259); err == nil {
+		t.Error("hasLinkedPR() returned nil error; want an error so the caller skips the issue")
+	}
+}
+
+func TestHasLinkedPRWithTimeline_NilTimelineFallsBack(t *testing.T) {
+	client, closeFn, requests := newTimelineTestClient(t, timelineServerOpts{
+		pages: []string{"[" + crossRefOpenPR + "]"},
+	})
+	defer closeFn()
+
+	// A nil timeline means the caller could not determine the answer, so the
+	// helper must fetch it itself instead of reporting "no linked PR".
+	linked, err := hasLinkedPRWithTimeline(context.Background(), client, "test-owner", "test-repo", 9259, nil)
+	if err != nil {
+		t.Fatalf("hasLinkedPRWithTimeline() returned error: %v", err)
+	}
+	if !linked {
+		t.Error("hasLinkedPRWithTimeline() = false; want true")
+	}
+	if *requests == 0 {
+		t.Error("expected a timeline fetch when the supplied timeline is nil")
+	}
+}
+
+func TestHasLinkedPRWithTimeline_ReusesSuppliedTimeline(t *testing.T) {
+	client, closeFn, requests := newTimelineTestClient(t, timelineServerOpts{})
+	defer closeFn()
+
+	num := 12689
+	state := "open"
+	timeline := []*githubv39.Timeline{
+		{
+			Event: githubv39.String("cross-referenced"),
+			Source: &githubv39.Source{
+				Issue: &githubv39.Issue{
+					Number:           &num,
+					State:            &state,
+					PullRequestLinks: &githubv39.PullRequestLinks{URL: githubv39.String("https://example.com/pulls/12689")},
+				},
+			},
+		},
+	}
+
+	linked, err := hasLinkedPRWithTimeline(context.Background(), client, "test-owner", "test-repo", 9259, timeline)
+	if err != nil {
+		t.Fatalf("hasLinkedPRWithTimeline() returned error: %v", err)
+	}
+	if !linked {
+		t.Error("hasLinkedPRWithTimeline() = false; want true")
+	}
+	if *requests != 0 {
+		t.Errorf("made %d timeline requests; want 0 (supplied timeline should be reused)", *requests)
+	}
+}

--- a/factory/pkg/commands/watch/watch.go
+++ b/factory/pkg/commands/watch/watch.go
@@ -188,6 +188,26 @@ func (w *Watcher) init(ctx context.Context) error {
 	return nil
 }
 
+// canQueueIssueTasks reports whether the watcher has enough state to safely
+// decide which issues still need work.
+//
+// The open PR cache is the primary duplicate-suppression signal for issue
+// scans. An empty cache is indistinguishable from "no open PR references this
+// issue", so scanning with an unpopulated cache makes the watcher re-trigger
+// fixes for issues that already have an open PR. This happens in practice when
+// the process restarts into a GitHub rate limit window and every attempt to
+// list open PRs fails. Fail closed and wait for a successful PR scan instead.
+func (w *Watcher) canQueueIssueTasks(prCachePopulated bool) bool {
+	if w.IssueMode == "disabled" {
+		return false
+	}
+	if !prCachePopulated {
+		klog.Warningf("Skipping issue task queueing: the open PR cache is not populated, so issues with an open fix PR cannot be identified. Waiting for a successful PR scan.")
+		return false
+	}
+	return true
+}
+
 func (w *Watcher) checkRepo(ctx context.Context) {
 	w.state.mu.Lock()
 	if w.state.shuttingDown {
@@ -276,6 +296,7 @@ func (w *Watcher) checkRepo(ctx context.Context) {
 				}
 			}
 			w.state.mu.Unlock()
+			hasPRs = true
 		} else {
 			klog.Errorf("Failed to populate open PRs cache: %v", err)
 		}
@@ -297,6 +318,7 @@ func (w *Watcher) checkRepo(ctx context.Context) {
 			}
 			w.state.lastPRScan = now
 			w.state.mu.Unlock()
+			hasPRs = true
 		} else {
 			klog.Errorf("Failed to list open PRs: %v", err)
 		}
@@ -308,7 +330,7 @@ func (w *Watcher) checkRepo(ctx context.Context) {
 		}
 
 		// Process slow issues
-		if w.IssueMode != "disabled" {
+		if w.canQueueIssueTasks(hasPRs) {
 			w.queueIssueTasks(ctx, slowIssues, refIssues)
 		}
 
@@ -368,7 +390,7 @@ func (w *Watcher) checkRepo(ctx context.Context) {
 			klog.Errorf("Failed to scan fast issues: %v", err)
 		}
 
-		if w.IssueMode != "disabled" {
+		if w.canQueueIssueTasks(hasPRs) {
 			w.queueIssueTasks(ctx, issues, refIssues)
 		}
 

--- a/factory/pkg/commands/watch/watch_test.go
+++ b/factory/pkg/commands/watch/watch_test.go
@@ -1,0 +1,60 @@
+package watch
+
+import (
+	"testing"
+)
+
+func TestCanQueueIssueTasks(t *testing.T) {
+	tests := []struct {
+		name             string
+		issueMode        string
+		prCachePopulated bool
+		want             bool
+	}{
+		{
+			name:             "queues when issue mode enabled and PR cache populated",
+			issueMode:        "",
+			prCachePopulated: true,
+			want:             true,
+		},
+		{
+			// Regression for k8s-config-connector#9259: after a restart into a
+			// rate limit window the PR cache was empty, which made every issue
+			// look like it had no linked PR.
+			name:             "fails closed when PR cache is not populated",
+			issueMode:        "",
+			prCachePopulated: false,
+			want:             false,
+		},
+		{
+			name:             "never queues when issue mode is disabled",
+			issueMode:        "disabled",
+			prCachePopulated: true,
+			want:             false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := &Watcher{Flags: Flags{IssueMode: tc.issueMode}}
+			if got := w.canQueueIssueTasks(tc.prCachePopulated); got != tc.want {
+				t.Errorf("canQueueIssueTasks(%v) = %v; want %v", tc.prCachePopulated, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCheckRepoHasPRsSignal documents the state that drives canQueueIssueTasks:
+// a fresh watcher has never listed open PRs, so it must not be treated as
+// "no issue has a linked PR".
+func TestCheckRepoHasPRsSignal(t *testing.T) {
+	w := &Watcher{state: &watchState{referencedIssues: make(map[int]bool)}}
+
+	hasPRs := len(w.state.openPRs) > 0 || !w.state.lastPRScan.IsZero()
+	if hasPRs {
+		t.Error("hasPRs = true for a watcher that has never scanned; want false")
+	}
+	if w.canQueueIssueTasks(hasPRs) {
+		t.Error("canQueueIssueTasks() = true before any successful PR scan; want false")
+	}
+}


### PR DESCRIPTION
The watcher commented "AI Factory started fixing this issue in a sandbox" on k8s-config-connector#9259 and spawned a duplicate sandbox even though PR #12689 ("Fixes #9259") had been open for nine days. Two independent duplicate-suppression mechanisms failed at the same time.

1. Timeline check was unpaginated. ListIssueTimeline was called with nil options, so only the first 30 events were inspected. Issue #9259 has 46 events and the cross-reference to the open PR is event 45, so the check only ever saw an older closed PR and a plain issue reference.

   listAllIssueTimeline now follows pagination at per_page=100 (capped at 20 pages) and reports whether the read completed. Callers only trust a negative answer from a complete timeline; otherwise they fall back to the Search API, which previously only ran when the timeline errored.

2. The open PR cache was empty. The process restarted into a GitHub rate limit window, both attempts to list open PRs returned 403, and the scan proceeded with an empty referencedIssues map, which is indistinguishable from "no PR references this issue".

   canQueueIssueTasks now fails closed: hasPRs is only set after a successful listing, and no issue work is queued until then.